### PR TITLE
Trap WM_SYSCOMMAND SC_MONITORPOWER to detect monitor off even if no s…

### DIFF
--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -287,6 +287,7 @@ private:
                         m_screensaver;
     bool                m_screensaverNotify;
     bool                m_screensaverActive;
+    bool                m_screensaverPowerOff;
 
     // clipboard stuff.  our window is used mainly as a clipboard
     // owner and as a link in the clipboard viewer chain.

--- a/src/lib/synwinhk/synwinhk.cpp
+++ b/src/lib/synwinhk/synwinhk.cpp
@@ -630,11 +630,17 @@ getMessageHook(int code, WPARAM wParam, LPARAM lParam)
     if (code >= 0) {
         if (g_screenSaver) {
             MSG* msg = reinterpret_cast<MSG*>(lParam);
-            if (msg->message == WM_SYSCOMMAND &&
-                msg->wParam  == SC_SCREENSAVE) {
-                // broadcast screen saver started message
-                PostThreadMessage(g_threadID,
-                                SYNERGY_MSG_SCREEN_SAVER, TRUE, 0);
+            if (msg->message == WM_SYSCOMMAND) {
+                if (msg->wParam == SC_SCREENSAVE) {
+                    // broadcast screen saver started message
+                    PostThreadMessage(g_threadID,
+                                    SYNERGY_MSG_SCREEN_SAVER, TRUE, 0);
+                }
+                else if (msg->wParam == SC_MONITORPOWER) {
+                    // broadcast monitor power off/on message
+                    PostThreadMessage(g_threadID,
+                                    SYNERGY_MSG_SCREEN_POWER_OFF, msg->lParam, 0);
+                }
             }
         }
         if (g_mode == kHOOK_RELAY_EVENTS) {

--- a/src/lib/synwinhk/synwinhk.h
+++ b/src/lib/synwinhk/synwinhk.h
@@ -46,6 +46,7 @@
 #define SYNERGY_MSG_PRE_WARP        WM_APP + 0x0017    // x; y
 #define SYNERGY_MSG_SCREEN_SAVER    WM_APP + 0x0018    // activated; <unused>
 #define SYNERGY_MSG_DEBUG            WM_APP + 0x0019    // data, data
+#define SYNERGY_MSG_SCREEN_POWER_OFF WM_APP + 0x0020    // poweroff; <unused>
 #define SYNERGY_MSG_INPUT_FIRST        SYNERGY_MSG_KEY
 #define SYNERGY_MSG_INPUT_LAST        SYNERGY_MSG_PRE_WARP
 #define SYNERGY_HOOK_LAST_MSG        SYNERGY_MSG_DEBUG


### PR DESCRIPTION
…creen

saver running.

HACK: we never get SC_MONITORPOWER lParam = -1, so just assume monitor turned
back on if we get any event on the primary screen.