### PR TITLE
Interpret `synergyc --tls-cert` as a "trusted" cert to verify the server

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -682,11 +682,9 @@ SecureSocket::verifyCertFingerprint()
 {
     // calculate received certificate fingerprint
     X509 *cert = cert = SSL_get_peer_certificate(m_ssl->m_ssl);
-    EVP_MD* tempDigest;
     unsigned char tempFingerprint[EVP_MAX_MD_SIZE];
     unsigned int tempFingerprintLen;
-    tempDigest = (EVP_MD*)EVP_sha256();
-    int digestResult = X509_digest(cert, tempDigest, tempFingerprint, &tempFingerprintLen);
+    int digestResult = X509_digest(cert, EVP_sha256(), tempFingerprint, &tempFingerprintLen);
 
     if (digestResult <= 0) {
         LOG((CLOG_ERR "failed to calculate fingerprint, digest result: %d", digestResult));
@@ -697,8 +695,6 @@ SecureSocket::verifyCertFingerprint()
     String fingerprint(static_cast<char*>(static_cast<void*>(tempFingerprint)), tempFingerprintLen);
     formatFingerprint(fingerprint);
     LOG((CLOG_NOTE "server fingerprint: %s", fingerprint.c_str()));
-
-    std::ifstream file;
 
     // if the --tls-cert option is set, check the fingerprint against that first
     if (!ArgParser::argsBase().m_tlsCertFile.empty()) {
@@ -742,6 +738,7 @@ SecureSocket::verifyCertFingerprint()
 
     // check if this fingerprint exist
     String fileLine;
+    std::ifstream file;
     file.open(trustedServersFilename.c_str());
 
     bool isValid = false;

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -713,7 +713,7 @@ SecureSocket::verifyCertFingerprint()
             return false;
         }
 
-        digestResult = X509_digest(cert, EVP_sha256(), tempFingerprint, &tempFingerprintLen);
+        digestResult = X509_digest(trustedCert, EVP_sha256(), tempFingerprint, &tempFingerprintLen);
         if (digestResult <= 0) {
             LOG((CLOG_ERR "failed to calculate trusted fingerprint, digest result: %d", digestResult));
             return false;
@@ -722,7 +722,7 @@ SecureSocket::verifyCertFingerprint()
         // format fingerprint into hexdecimal format with colon separator
         String trustedFingerprint(static_cast<char*>(static_cast<void*>(tempFingerprint)), tempFingerprintLen);
         formatFingerprint(trustedFingerprint);
-        LOG((CLOG_NOTE "trusted fingerprint: %s", fingerprint.c_str()));
+        LOG((CLOG_NOTE "trusted fingerprint: %s", trustedFingerprint.c_str()));
 
         if (trustedFingerprint == fingerprint) {
             return true;


### PR DESCRIPTION
I was experiencing the issue mentioned in #4626 ("failed to verify 
server certificate fingerprint"). `synergyc --help` reports that it
accepts the --tls-cert option with very little information. So my 
initial assumption was that I could copy the .pem file from my server 
and pass that to this argument in order to configure the client to 
consider this certificate "trusted" and verify the server against that 
during the handshake. 

But the verify problem remained. Looking at the code, I don't see where
synergyc actually does anything with the `--tls-cert` argument. So this
branch implements what I expected:

* in verifyCertFingerprint(), if the user passed `--tls-cert` to
  synergyc, we parse that file as a PEM certificate and extract *that* 
  certificate's fingerprint and compare against the fingerprint of the 
  certificate sent by the server.
* If the fingerprint matches, the connection is marked as trusted 
* Otherwise, fallback to the previous behavior of checking the
  fingerprints in SSL/FingerPrints/TrustedServers.txt

Maybe there was/is a plan to utilize `--tls-cert` in `synergyc` for some
other purpose (specify a client certificate for mutual auth?). If so, I can
rename this new behavior to use a new command line flag like
`--trusted-cert` or even `--trusted-certs` if we need the ability to
specify multiple trusted certs.