### PR TITLE
Update onMouseMoveSecondary to allow offset adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,14 @@ jobs:
           job: ${{ matrix.target.name }}
 
       - name: Package
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_BUILD == 'true' }}
+        if: ${{ env.PACKAGE_BUILD == 'true' }}
         run: python ./scripts/package.py
         env:
           WINDOWS_PFX_CERTIFICATE: ${{ secrets.WINDOWS_PFX }}
           WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASS }}
 
       - name: Upload
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
+        if: ${{ env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
           use-github: true
@@ -223,7 +223,7 @@ jobs:
           job: ${{ matrix.target.name }}
 
       - name: Package
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_BUILD == 'true' }}
+        if: ${{ env.PACKAGE_BUILD == 'true' }}
         run: ./scripts/package.py
         env:
           APPLE_CODESIGN_ID: ${{ secrets.APPLE_CODESIGN_ID }}
@@ -234,7 +234,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
+        if: ${{ env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
           use-github: true
@@ -308,14 +308,14 @@ jobs:
           job: linux-${{ matrix.distro.name }}
 
       - name: Package
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_BUILD == 'true' }}
+        if: ${{ env.PACKAGE_BUILD == 'true' }}
         env:
           LINUX_EXTRA_PACKAGES: ${{ matrix.distro.extra-packages }}
           LINUX_PACKAGE_USER: ${{ matrix.distro.package-user }}
         run: ./scripts/package.py
 
       - name: Upload
-        if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
+        if: ${{ env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
           use-github: true


### PR DESCRIPTION
Fixes: #4245

Blocked by: #7522, #7569

---

We now have a working prototype where onMouseMoveSecondary can be adjusted via an environment variable at startup. This implementation is server-side and relates to the issue discussed at #4245 (credit to @neworld for their initial implementation).

To double the mouse speed, use the following on the server side:

```
SYNERGY_MOUSE_ADJUSTMENT=2; open /Applications/Synergy.app
```

This results in consistent mouse speed across my Mac OS X server and HiDPI Windows client, achieving the desired functional outcome.

To reduce the speed, you can modify the value like so:

```
SYNERGY_MOUSE_ADJUSTMENT=0.3; open /Applications/Synergy.app
```

In the future, this could ideally be managed through the UI, with the ability to apply different speed adjustments for specific targets, rather than having a global setting. In my case, I only have two systems, so this works fine, but others may require more granular control.

Consider this a proof of concept for reference, rather than code intended for direct inclusion in the upstream codebase.