### PR TITLE
fix: protocol compatibility with Synergy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 # 1.17.0
 
+Bug fixes:
+
+- #7524 Restore protocol compatibility with Synergy
+
+Enhancements:
+
 - #7519 Rename project to Deskflow (was Synergy Community Edition)
 - #7522 Fix broken CI caused by renaming project to Deskflow
 

--- a/src/lib/deskflow/protocol_types.cpp
+++ b/src/lib/deskflow/protocol_types.cpp
@@ -17,9 +17,9 @@
  */
 
 #include "deskflow/protocol_types.h"
-
-const char *const kMsgHello = "Deskflow%2i%2i";
-const char *const kMsgHelloBack = "Deskflow%2i%2i%s";
+//Keep the Synergy name for hello to preserve compatibility with synergy
+const char *const kMsgHello = "Synergy%2i%2i";
+const char *const kMsgHelloBack = "Synergy%2i%2i%s";
 const char *const kMsgCNoop = "CNOP";
 const char *const kMsgCClose = "CBYE";
 const char *const kMsgCEnter = "CINN%2i%2i%4i%2i";

--- a/src/lib/deskflow/protocol_types.cpp
+++ b/src/lib/deskflow/protocol_types.cpp
@@ -17,7 +17,8 @@
  */
 
 #include "deskflow/protocol_types.h"
-//Keep the Synergy name for hello to preserve compatibility with synergy
+
+// Keep the "Synergy" name for hello to preserve compatibility with Synergy
 const char *const kMsgHello = "Synergy%2i%2i";
 const char *const kMsgHelloBack = "Synergy%2i%2i%s";
 const char *const kMsgCNoop = "CNOP";


### PR DESCRIPTION
Fixes: #7523 
revert protocol hello to `Synergy`

 NOTE: For compatibility with Barrier / InputLeap we need to use `Barrier` 
TODO: Check for and Send the correct one based on what we are connecting to 

