### PR TITLE
Remove Google Drive upload and always upload to GitHub

### DIFF
--- a/.github/actions/dist-upload/action.yml
+++ b/.github/actions/dist-upload/action.yml
@@ -1,7 +1,7 @@
 name: "Distribute upload"
 description: "Uploads the package from the dist dir to GitHub artifacts or Google Drive"
 inputs:
-  use_github:
+  use-github:
     description: "Whether to upload to GitHub artifacts"
     required: true
 
@@ -33,9 +33,9 @@ runs:
   using: "composite"
 
   steps:
-    - if: ${{ inputs.use_gdrive == inputs.use_github }}
+    - if: ${{ inputs.use_gdrive == inputs.use-github }}
       run: |
-        echo "Either 'use_github' or 'use_gdrive' must be true (and not both)"
+        echo "Either 'use-github' or 'use_gdrive' must be true (and not both)"
         exit 1
       shell: bash
 
@@ -52,7 +52,7 @@ runs:
       shell: bash
 
     - name: Upload to GitHub
-      if: ${{ inputs.use_github == 'true' }}
+      if: ${{ inputs.use-github == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.github-target-filename }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ env:
   DESKFLOW_PRODUCT_NAME: ${{ vars.DESKFLOW_PRODUCT_NAME }}
   DESKFLOW_PACKAGE_PREFIX: ${{ vars.DESKFLOW_PACKAGE_PREFIX || 'deskflow' }}
   PACKAGE_BUILD: ${{ !github.event.pull_request.draft }}
-  PACKAGE_UPLOAD: ${{ !github.event.pull_request.draft && github.ref_name != 'master' }}
-  UPLOAD_TO_GITHUB: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
-  UPLOAD_TO_GDRIVE: ${{ github.event_name != 'pull_request' }}
+  PACKAGE_UPLOAD: ${{ !github.event.pull_request.draft }}
 
 jobs:
   setup:
@@ -122,12 +120,8 @@ jobs:
         if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
-          use_github: ${{ env.UPLOAD_TO_GITHUB }}
-          use_gdrive: ${{ env.UPLOAD_TO_GDRIVE }}
+          use-github: true
           github-target-filename: "${{ env.DESKFLOW_PACKAGE_PREFIX }}-${{ matrix.target.name }}"
-          gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
-          gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
-          gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
           package-version: ${{ env.DESKFLOW_VERSION }}
 
   macos:
@@ -209,12 +203,8 @@ jobs:
         if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
-          use_github: ${{ env.UPLOAD_TO_GITHUB }}
-          use_gdrive: ${{ env.UPLOAD_TO_GDRIVE }}
+          use-github: true
           github-target-filename: "${{ env.DESKFLOW_PACKAGE_PREFIX }}-${{ matrix.target.name }}"
-          gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
-          gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
-          gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
           package-version: ${{ env.DESKFLOW_VERSION }}
 
   linux-matrix:
@@ -294,12 +284,8 @@ jobs:
         if: ${{ vars.CI_ENABLE_PACKAGING && env.PACKAGE_UPLOAD == 'true' }}
         uses: ./.github/actions/dist-upload
         with:
-          use_github: ${{ env.UPLOAD_TO_GITHUB }}
-          use_gdrive: ${{ env.UPLOAD_TO_GDRIVE }}
+          use-github: true
           github-target-filename: "${{ env.DESKFLOW_PACKAGE_PREFIX }}-${{ matrix.distro.name }}"
-          gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
-          gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
-          gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
           package-version: ${{ env.DESKFLOW_VERSION }}
 
   # Technically, "unix" is a misnomer, but we use it here to mean "Unix-like BSD-derived".

--- a/.github/workflows/test-dist-upload.yml
+++ b/.github/workflows/test-dist-upload.yml
@@ -24,7 +24,7 @@ jobs:
         if:
         uses: ./.github/actions/dist-upload
         with:
-          use_github: true
+          use-github: true
           github-target-filename: "test"
 
       - name: Upload to Google Drive

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,12 +2,13 @@
 
 Bug fixes:
 
+- #7522 Fix broken CI caused by renaming project to Deskflow
 - #7524 Restore protocol compatibility with Synergy
+- #7525 Remove Google Drive upload from CI
 
 Enhancements:
 
 - #7519 Rename project to Deskflow (was Synergy Community Edition)
-- #7522 Fix broken CI caused by renaming project to Deskflow
 
 # 1.16.1
 


### PR DESCRIPTION
Problem: Google Drive upload breaks CI on `master` and is also a downstream requirement which we probably don't need it for Deskflow.

Solution: Remove Google Drive use in CI, and let downstream worry about that.