### PR TITLE
ci: always upgrade packages on arch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Bug fixes:
 Enhancements:
 
 - #7519 Rename project to Deskflow (was Synergy Community Edition)
+- #7533 Always upgrade packages on Arch Linux in deps script
 
 # 1.16.1
 

--- a/config.yaml
+++ b/config.yaml
@@ -132,7 +132,7 @@ config:
 
     arch: &arch
       dependencies:
-        command: sudo pacman -Sy --noconfirm \
+        command: sudo pacman -Syu --noconfirm \
           base-devel \
           cmake \
           ninja \


### PR DESCRIPTION
CI error: https://github.com/deskflow/deskflow/actions/runs/10953461679/job/30413790856

This PR resolves transient issues on CI:
```
sudo pacman -Sy --noconfirm base-devel cmake ninja gcc openssl glib2 gdk-pixbuf2 libxtst libnotify libxkbfile gtest pugixml libei libportal qt6-base qt6-tools gtk3
:: Synchronizing package databases...
 core downloading...
 extra downloading...
warning: base-devel-1-2 is up to date -- reinstalling
warning: cmake-3.30.3-2 is up to date -- reinstalling
resolving dependencies...
warning: ninja-1.12.1-1 is up to date -- reinstalling
warning: gcc-14.2.1+r134+gab884fffe3fc-1 is up to date -- reinstalling
warning: openssl-3.3.2-1 is up to date -- reinstalling
warning: gdk-pixbuf2-2.42.12-1 is up to date -- reinstalling
warning: libxtst-1.2.5-1 is up to date -- reinstalling
warning: libnotify-0.8.3-1 is up to date -- reinstalling
warning: libxkbfile-1.1.3-1 is up to date -- reinstalling
warning: gtest-1.15.2-1 is up to date -- reinstalling
warning: pugixml-1.14-1 is up to date -- reinstalling
warning: libei-1.3.0-1 is up to date -- reinstalling
warning: libportal-0.8.1-1 is up to date -- reinstalling
warning: qt6-base-6.7.2-2 is up to date -- reinstalling
warning: qt6-tools-6.7.2-2 is up to date -- reinstalling
looking for conflicting packages...
error: unresolvable package conflicts detected
:: tinysparql-3.8.0-1 and tracker3-3.7.3-2 are in conflict. Remove tracker3? [y/N] 
error: failed to prepare transaction (conflicting dependencies)
:: tinysparql-3.8.0-1 and tracker3-3.7.3-2 are in conflict (tracker3<=3.7.3-2)
```

Note: I had previously removed the `-u` opt, as I was worried it was a bit rude just upgrading packages, but the deps script is mostly for our use as Arch Linux users will most likely want to copy/paste the command and run it manually.