### PR TITLE
docs: fixed link to `config.yaml` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are a few ways to join in with the project and get involved:
 
 **1. Dependencies:**
 
-You can either copy/paste the command from [config.yaml] or use the script.
+You can either copy/paste the commands for your OS from [`config.yaml`](config.yaml) or use the deps script.
 
 *Linux, macOS, or BSD-derived:*
 ```


### PR DESCRIPTION
Blocked by: #7533, #7535

The link to `config.yaml` is not working in `README.md`.

{no-changelog-lint}