### PR TITLE
ci: option to skip changelog lint in PR

### DIFF
--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -14,6 +14,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - edited
 
 jobs:
   lint-changelog:
@@ -23,20 +24,48 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Skip ChangeLog lint
+        id: skip
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.body, '{no-changelog-lint}') }}
+        run: echo "skip=1" >> $GITHUB_OUTPUT
+
       - name: Get changes
+        if: ${{ !steps.skip.outputs.skip }}
         id: file_changes
         uses: trilom/file-changes-action@v1.2.4
         with:
           output: ","
 
       - name: Show modified
+        if: ${{ !steps.skip.outputs.skip }}
         run: echo '${{ steps.file_changes.outputs.files_modified}}'
 
       - name: Check
+        if: ${{ !steps.skip.outputs.skip }}
+        id: check
+        continue-on-error: true
         run: |
-          if [[ "${{ steps.file_changes.outputs.files_modified}}" == *"ChangeLog"* ]]; then
-            echo "ChangeLog has been updated"
-          else
-            echo "::error file=app.js,line=10,col=15::Changelog hasn't been updated"
+          if [[ "${{ steps.file_changes.outputs.files_modified}}" != *"ChangeLog"* ]]; then
             exit 1
           fi
+
+      - name: PR comment (no lint hint)
+        if: ${{ steps.check.outcome == 'failure' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lint-changelog-tip
+          message: |
+            ❌ `ChangeLog` lint failed: It looks like you didn't add to the `ChangeLog` file.
+
+            🛠️ Please either add to `ChangeLog` or add `{no-changelog-lint}` to the PR description to skip this check.
+
+      - name: Delete PR comment
+        if: ${{ steps.skip.outputs.skip || steps.check.outcome == 'success' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lint-changelog-tip
+          delete: true
+
+      - name: Fail if no ChangeLog
+        if: ${{ steps.check.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
Blocked by: #7533 

We don't always need to add to the `ChangeLog`, for instance when it's a minor edit to the docs.

This PR allows a PR author to add `{no-changelog-lint}` to their PR in order to skip the `ChangeLog` lint.