### PR TITLE
ci: lint and add comment to PR on fail

### DIFF
--- a/.github/actions/lint-error/action.yml
+++ b/.github/actions/lint-error/action.yml
@@ -1,0 +1,79 @@
+name: "Lint error"
+description: "Checks for lint errors and posts a helpful comment"
+
+inputs:
+  comment-header:
+    description: "The header ID for the comment"
+    required: true
+
+  format-command:
+    description: "The command to run to fix lint errors"
+    required: true
+
+  format-tool:
+    description: "The name of the linting tool"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run format command
+      run: ${{ inputs.format-command }}
+      shell: bash
+
+    - name: Find changes
+      id: changes
+      run: |
+        file=${{ inputs.format-tool }}.diff
+        diff=$(git diff | tee $file)
+
+        if [ -z "$diff" ]; then
+          echo "No changes detected"
+          exit 0
+        fi
+
+        echo "file=$file" >> $GITHUB_OUTPUT
+
+        {
+          echo "diff<<EOF"
+          cat $file
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
+
+      shell: bash
+
+    - name: Upload to GitHub
+      id: upload
+      if: steps.changes.outputs.diff
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.changes.outputs.file }}
+        path: ${{ steps.changes.outputs.file }}
+        retention-days: 3
+        if-no-files-found: error
+
+    - name: PR comment (lint source hint)
+      if: steps.changes.outputs.diff
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: ${{ inputs.comment-header }}
+        message: |
+          ❌ `${{ inputs.format-tool }}` failed: It looks like your changes don't match our code style.
+
+          🛠️ Please either run `${{ inputs.format-command }}` or apply this patch with `git apply`:
+          ```diff
+          ${{ steps.changes.outputs.diff }}
+          ```
+          [${{ steps.changes.outputs.file }}](${{ steps.upload.outputs.artifact-url }})
+
+    - name: Delete PR comment
+      if: ${{ !steps.changes.outputs.diff }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: ${{ inputs.comment-header }}
+        delete: true
+
+    - name: Fail if diff exists
+      if: steps.changes.outputs.diff
+      run: exit 1
+      shell: bash

--- a/.github/workflows/lint-clang.yml
+++ b/.github/workflows/lint-clang.yml
@@ -1,6 +1,6 @@
 # Lints CMake config and C++ source code.
 
-name: "Lint source code"
+name: "Lint (Clang)"
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
       - ready_for_review
 
 jobs:
-  lint-source-code:
+  lint-clang:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -23,15 +23,17 @@ jobs:
       - name: Setup Python venv
         uses: ./.github/actions/init-python
         with:
-          cache-key: "lint-source-code"
+          cache-key: "lint-clang"
 
       - name: Install dependencies
         run: |
           source .venv/bin/activate
-          pip install pyyaml cmake_format clang_format
-
-      - name: Linting with CMake formatter
-        run: ./scripts/lint_cmake.py
+          pip install pyyaml clang_format
 
       - name: Linting with Clang format
-        run: ./scripts/lint_clang.py
+        id: lint-clang
+        uses: ./.github/actions/lint-error
+        with:
+          format-command: ./scripts/lint_clang.py -f
+          format-tool: "clang-format"
+          comment-header: "lint-clang"

--- a/.github/workflows/lint-cmake.yml
+++ b/.github/workflows/lint-cmake.yml
@@ -1,0 +1,39 @@
+# Lints CMake config and C++ source code.
+
+name: "Lint (CMake)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  lint-cmake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python venv
+        uses: ./.github/actions/init-python
+        with:
+          cache-key: "lint-cmake"
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          pip install pyyaml cmake_format
+
+      - name: Linting with CMake formatter
+        id: lint-cmake
+        uses: ./.github/actions/lint-error
+        with:
+          format-command: ./scripts/lint_cmake.py -f
+          format-tool: "cmake-format"
+          comment-header: "lint-cmake"

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Enhancements:
 
 - #7519 Rename project to Deskflow (was Synergy Community Edition)
 - #7533 Always upgrade packages on Arch Linux in deps script
+- #7539 Lint and add comment to PR on lint failure
 
 # 1.16.1
 


### PR DESCRIPTION
Fixes: #7527

:warning: Code style errors are intentional and are for testing (to trigger the lint errors). Before merging, apply the suggested fixes. The lint error comments should go away automatically once the lint errors are fixed.
