### PR TITLE
docs: add build type to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,6 +31,21 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: build
+    attributes:
+      label: Build type
+      description: What kind of build are you using?
+      options:
+        # Empty option to force selection
+        -
+        - Local developer build (built it yourself)
+        - Community package (apt, dnf, brew, etc.)
+        - Deskflow package (downloaded from us)
+      default: 0
+    validations:
+      required: true
+
   - type: checkboxes
     id: os
     attributes:


### PR DESCRIPTION
With issues such as #7541, it's important to know what environment the binary is being run in, since it behaves diffeently in dev env vs package. It would also be useful to know who built the package (us or an external package maintainer).

This PR adds an option to the bug report template so the reporter can specity how it was built.

{no-changelog-lint}