### PR TITLE
ci: give write permission for PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ env:
   PACKAGE_BUILD: ${{ !github.event.pull_request.draft }}
   PACKAGE_UPLOAD: ${{ !github.event.pull_request.draft }}
 
+permissions:
+  pull-requests: write
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -16,6 +16,9 @@ on:
       - ready_for_review
       - edited
 
+permissions:
+  pull-requests: write
+
 jobs:
   lint-changelog:
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/lint-clang.yml
+++ b/.github/workflows/lint-clang.yml
@@ -11,6 +11,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  pull-requests: write
+
 jobs:
   lint-clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-cmake.yml
+++ b/.github/workflows/lint-cmake.yml
@@ -11,6 +11,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  pull-requests: write
+
 jobs:
   lint-cmake:
     runs-on: ubuntu-latest

--- a/.github/workflows/valgrind-analysis.yml
+++ b/.github/workflows/valgrind-analysis.yml
@@ -9,14 +9,14 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  pull-requests: write
+
 jobs:
   valgrind-analysis:
     runs-on: ubuntu-latest
     container: deskflow/deskflow:ubuntu-22.04-amd64
     timeout-minutes: 10
-
-    permissions:
-      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
When the comment action is triggered by a PR originating from an external fork (i.e. a contributor) the error, `Resource not accessible by integration` shows because the worklow doesn't automatically have write permission to the PR.

Example: https://github.com/deskflow/deskflow/actions/runs/10964481892?pr=7511

We need to explicitly grant this permission with:
```
permissions:
  pull-requests: write
```

{no-changelog-lint}