### PR TITLE
build: set `BUILD_DATE` instead of using `__DATE__`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5)
+# Why CMake 3.8?
+# This allows package maintainers to create reproducible builds:
+# > New in version 3.8: If the SOURCE_DATE_EPOCH environment variable is set,
+# > its value will be used instead of the current time.
+# > See https://reproducible-builds.org/specs/source-date-epoch/ for details.
+cmake_minimum_required(VERSION 3.8)
+
 project(deskflow C CXX)
 
 include(cmake/Version.cmake)
@@ -25,6 +31,7 @@ include(cmake/Packaging.cmake)
 
 set_version()
 configure_definitions()
+configure_build()
 configure_libs()
 configure_packaging()
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Enhancements:
 - #7539 Lint and add comment to PR on lint failure
 - #7544 Use system deps for `tomlplusplus` and `CLI11`
 - #7549 Script to create Python virtual environment (venv)
+- #7547 Use `SOURCE_DATE_EPOCH` for reproducible builds
 
 # 1.16.1
 

--- a/cmake/Build.cmake
+++ b/cmake/Build.cmake
@@ -13,13 +13,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-if(WIN32)
-  message(STATUS "Enabling warnings as errors (MSVC)")
-  add_compile_options(/WX)
-elseif(UNIX)
-  message(STATUS "Enabling warnings as errors (GNU/Clang)")
-  add_compile_options(-Werror)
-endif()
+macro(configure_build)
+  warnings_as_errors()
+  set_build_date()
+endmacro()
+
+macro(warnings_as_errors)
+  if(WIN32)
+    message(STATUS "Enabling warnings as errors (MSVC)")
+    add_compile_options(/WX)
+  elseif(UNIX)
+    message(STATUS "Enabling warnings as errors (GNU/Clang)")
+    add_compile_options(-Werror)
+  endif()
+endmacro()
+
+macro(set_build_date)
+  # Since CMake 3.8.0, `string(TIMESTAMP ...)` respects `SOURCE_DATE_EPOCH` env var if set,
+  # which allows package maintainers to create reproducible builds.
+  # We require CMake 3.8.0 in the root `CMakeLists.txt` for this reason.
+  string(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
+  message(STATUS "Build date: ${BUILD_DATE}")
+  add_definitions(-DBUILD_DATE="${BUILD_DATE}")
+endmacro()
 
 macro(post_config)
 

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -38,8 +38,8 @@ AboutDialog::AboutDialog(MainWindow *parent)
   QString version = QString::fromStdString(deskflow::version());
   m_pLabelDeskflowVersion->setText(version);
 
-  QString buildDateString = QString::fromLocal8Bit(__DATE__).simplified();
-  QDate buildDate = QLocale("en_US").toDate(buildDateString, "MMM d yyyy");
+  QString buildDateString = QString::fromLocal8Bit(BUILD_DATE).simplified();
+  QDate buildDate = QLocale("en_US").toDate(buildDateString, "yyyy-MM-dd");
   m_pLabelBuildDate->setText(
       buildDate.toString(QLocale::system().dateFormat(QLocale::LongFormat)));
 }

--- a/src/lib/common/copyright.h
+++ b/src/lib/common/copyright.h
@@ -29,8 +29,8 @@ const auto kCopyrightFormat = //
     "Copyright (C) 2002-2009 Chris Schoeneman";
 
 inline std::string copyright() {
-  const std::string date = __DATE__;
-  const auto year = date.substr(date.size() - 4);
+  const std::string date = BUILD_DATE;
+  const auto year = date.substr(0, 4);
   const auto kBufferLength = 256;
   std::vector<char> buffer(kBufferLength);
   std::snprintf( // NOSONAR


### PR DESCRIPTION
Fixes: #7545

We are using `__DATE__` macro which does not respect `SOURCE_DATE_EPOCH` making it difficult for downstream packagers to create reproducible builds.

Using `string(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)` in CMake respects [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/). ~~And for older versions of CMake (Debian Trixie for instance uses CMake 3.30.0) we have the less desirable way.~~

> only respects SOURCE_DATE_EPOCH since version 3.8.0 ([April 2017](https://cmake.org/pipermail/cmake-developers/2017-April/029946.html)). Note that the final argument UTC is required or the timestamp may vary between timezones.

Edit: The min version for CMake is set to 3.8 for this reason.