### PR TITLE
build: fixed option name for `SYSTEM_TOMLPLUSPLUS`

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -645,9 +645,9 @@ macro(configure_tomlplusplus)
     set(DEFAULT_SYSTEM_TOMLPLUSPLUS ON)
   endif()
 
-  option(DEFAULT_SYSTEM_TOMLPLUSPLUS "Use system tomlplusplus"
+  option(SYSTEM_TOMLPLUSPLUS "Use system tomlplusplus"
          ${DEFAULT_SYSTEM_TOMLPLUSPLUS})
-  if(DEFAULT_SYSTEM_TOMLPLUSPLUS)
+  if(SYSTEM_TOMLPLUSPLUS)
     message(VERBOSE "Using system tomlplusplus")
     find_package(tomlplusplus)
     if(tomlplusplus_FOUND)


### PR DESCRIPTION
Oops, in PR #7544 I accidentally set the option name to `DEFAULT_SYSTEM_TOMLPLUSPLUS` when it should have been `SYSTEM_TOMLPLUSPLUS`. This causes a CMake warning:

```
[cmake] CMake Warning (dev) at cmake/Libraries.cmake:648 (option):
[cmake]   Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
[cmake]   --help-policy CMP0077" for policy details.  Use the cmake_policy command to
[cmake]   set the policy and suppress this warning.
[cmake] 
[cmake]   For compatibility with older versions of CMake, option is clearing the
[cmake]   normal variable 'DEFAULT_SYSTEM_TOMLPLUSPLUS'.
[cmake] Call Stack (most recent call first):
[cmake]   cmake/Libraries.cmake:16 (configure_tomlplusplus)
[cmake]   CMakeLists.txt:32 (configure_libs)
[cmake] This warning is for project developers.  Use -Wno-dev to suppress it.
[cmake] 
[cmake] -- tomlplusplus version: 3.4.0
```

This PR fixes the minor snafu by using `SYSTEM_TOMLPLUSPLUS` as it should have been.

{no-changelog-lint}