### PR TITLE
build: script to create Python virtual env

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Enhancements:
 - #7533 Always upgrade packages on Arch Linux in deps script
 - #7539 Lint and add comment to PR on lint failure
 - #7544 Use system deps for `tomlplusplus` and `CLI11`
+- #7549 Script to create Python virtual environment (venv)
 
 # 1.16.1
 

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -131,8 +131,12 @@ def ensure_in_venv(script_file, auto_create=False):
     if not in_venv():
         if not os.path.exists(VENV_DIR):
             if not auto_create:
-                print("Hint: Run the `install_deps.py` script first.")
-                raise RuntimeError(f"Virtual environment not found at: {VENV_DIR}")
+                print(
+                    "The Python virtual environment (.venv) needs to be created before you can "
+                    "run this script.\n"
+                    "Please run: scripts/setup_venv.py"
+                )
+                sys.exit(1)
 
             print(f"Creating virtual environment at {VENV_DIR}")
             venv.create(VENV_DIR, with_pip=True)

--- a/scripts/setup_venv.py
+++ b/scripts/setup_venv.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Deskflow -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import lib.env as env
+
+env.ensure_in_venv(__file__, auto_create=True)
+env.install_requirements()
+
+import lib.colors as colors
+
+print(colors.SUCCESS_TEXT, "Python virtual environment is ready.")


### PR DESCRIPTION
Related discussion: https://github.com/deskflow/deskflow/discussions/7550

When running any of the Python scripts in `scripts` dir, if you don't first run `install_deps.py` then you'll see an error:
```
$ ./scripts/lint_cmake.py 
Hint: Run the `install_deps.py` script first.
Traceback (most recent call last):
  File "/home/nick/Projects/deskflow/./scripts/lint_cmake.py", line 20, in <module>
    env.ensure_in_venv(__file__)
  File "/home/nick/Projects/deskflow/scripts/lib/env.py", line 135, in ensure_in_venv
    raise RuntimeError(f"Virtual environment not found at: {VENV_DIR}")
RuntimeError: Virtual environment not found at: .venv
```

This can create an obstacle to first time contributors or those who don't want to run `install_deps.py` (i.e. would rather install deps manually). 

This PR makes the error more approachable and provides an easier way to setup the Python virtual environment:
```
$ ./scripts/lint_cmake.py 
The Python virtual environment (.venv) needs to be created before you can run this script.
Please run: scripts/setup_venv.py
```

Running the new `scripts/setup_venv.py` script will setup the local `.venv` dir with all the deps needed to run all Python scripts in the `scripts` dir.