### PR TITLE
feat: change most domains to Deskflow

### DIFF
--- a/cmake/Definitions.cmake
+++ b/cmake/Definitions.cmake
@@ -34,7 +34,7 @@ macro(configure_definitions)
   set(UNIT_TESTS_BIN unittests)
 
   if("${VERSION_URL}" STREQUAL "")
-    set(VERSION_URL "https://api.symless.com/version?version=v1")
+    set(VERSION_URL "https://api.deskflow.org/version")
   endif()
   add_definitions(-DDESKFLOW_VERSION_URL="${VERSION_URL}")
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -21,7 +21,7 @@ macro(configure_packaging)
 
   if(${BUILD_INSTALLER})
     set(CPACK_PACKAGE_NAME "deskflow")
-    set(CPACK_PACKAGE_CONTACT "Deskflow <support@symless.com>")
+    set(CPACK_PACKAGE_CONTACT "Deskflow <maintainers@deskflow.org>")
     set(CPACK_PACKAGE_DESCRIPTION "Mouse and keyboard sharing utility")
     set(CPACK_PACKAGE_VENDOR "Symless")
     set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
@@ -89,7 +89,7 @@ macro(configure_linux_packaging)
   set(CPACK_PACKAGE_VERSION ${DESKFLOW_VERSION_LINUX})
   set(CPACK_GENERATOR "DEB;RPM;TGZ")
 
-  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Deskflow <developers@symless.com>")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Deskflow <maintainers@deskflow.org>")
   set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
   set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 

--- a/res/dist/arch/PKGBUILD.in
+++ b/res/dist/arch/PKGBUILD.in
@@ -1,10 +1,10 @@
-# Maintainer: Deskflow team <developers@symless.com>
+# Maintainer: Deskflow <maintainers@deskflow.org>
 
 pkgname=deskflow
 pkgver=@DESKFLOW_VERSION_FOUR_PART@
 pkgrel=1
 pkgdesc="Mouse and keyboard sharing utility"
-url='https://symless.com/deskflow/'
+url='https://deskflow.org/'
 arch=('x86_64')
 license=('GPL-2.0-only')
 depends=(

--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -873,9 +873,7 @@
        <item>
         <widget class="QLabel" name="label_6">
          <property name="text">
-          <string>Use a Core server config file to create complex screen layouts that are not possible with the simple grid-based screen layout editor.
-
-[How to write a config file](https://symless.com/synergy/help/creating-text-config-files)
+          <string>Use a server config file to create complex screen layouts that are not possible with the simple grid-based screen layout editor.
 
 Enabling this setting will disable the server config GUI.</string>
          </property>

--- a/src/lib/gui/constants.h
+++ b/src/lib/gui/constants.h
@@ -24,7 +24,7 @@ namespace deskflow::gui {
 // important: this is used for settings paths on some platforms,
 // and must not be a url. qt automatically converts this to reverse domain
 // notation (rdn), e.g. com.symless
-const auto kOrgDomain = "symless.com";
+const auto kOrgDomain = "deskflow.org";
 
 const auto kLinkBuy = R"(<a href="%1" style="color: %2">Buy now</a>)";
 const auto kLinkRenew = R"(<a href="%1" style="color: %2">Renew now</a>)";
@@ -32,7 +32,7 @@ const auto kLinkDownload = R"(<a href="%1" style="color: %2">Download now</a>)";
 
 const auto kUrlWebsite = "https://symless.com";
 const auto kUrlSourceQuery = "source=gui";
-const auto kUrlGitHub = "https://github.com/symless/synergy";
+const auto kUrlGitHub = "https://github.com/deskflow/deskflow";
 const auto kUrlGnomeTrayFix =
     "https://extensions.gnome.org/extension/2890/tray-icons-reloaded/";
 const auto kUrlProduct = QString("%1/synergy").arg(kUrlWebsite);

--- a/src/lib/gui/proxy/QSettingsProxy.cpp
+++ b/src/lib/gui/proxy/QSettingsProxy.cpp
@@ -131,7 +131,7 @@ void QSettingsProxy::loadUser() {
 #if defined(Q_OS_MAC)
   // on mac, we used to save settings to "com.http-symless-com.Deskflow.plist"
   // because `setOrganizationName` was historically called using a url instead
-  // of an actual domain (e.g. symless.com).
+  // of an actual domain (e.g. deskflow.org).
   migrateLegacyUserSettings(*m_pSettings);
 #endif // Q_OS_MAC
 }

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -121,10 +121,6 @@ bool MSWindowsClipboard::open(Time time) const {
   LOG((CLOG_DEBUG "open clipboard"));
 
   if (!OpenClipboard(m_window)) {
-    // unable to cause this in integ tests; but this can happen!
-    // * http://symless.com/pm/issues/86
-    // * http://symless.com/pm/issues/1256
-    // logging improved to see if we can catch more info next time.
     LOG((CLOG_WARN "failed to open clipboard: %d", GetLastError()));
     return false;
   }

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -863,9 +863,7 @@ OSXScreen::enter()
 		// reset buttons
 		m_buttonState.reset();
 
-		// patch by Yutaka Tsutano
 		// wakes the client screen
-		// http://symless.com/spit/issues/details/3287#c12
 		io_registry_entry_t entry = IORegistryEntryFromPath(
 			kIOMasterPortDefault,
 			"IOService:/IOResources/IODisplayWrangler");


### PR DESCRIPTION
The 'symless.com' domain is used in various places.

Replace it with 'deskflow.org'

Note: Remaining 'symless.com' URLs will be removed when licensing is moved downstream to Synergy.