### PR TITLE
ci: use `workflow_run` to comment on PRs

### DIFF
--- a/.github/actions/lint-error/action.yml
+++ b/.github/actions/lint-error/action.yml
@@ -52,27 +52,6 @@ runs:
         retention-days: 3
         if-no-files-found: error
 
-    - name: PR comment (lint source hint)
-      if: steps.changes.outputs.diff
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: ${{ inputs.comment-header }}
-        message: |
-          ❌ `${{ inputs.format-tool }}` failed: It looks like your changes don't match our code style.
-
-          🛠️ Please either run `${{ inputs.format-command }}` or apply this patch with `git apply`:
-          ```diff
-          ${{ steps.changes.outputs.diff }}
-          ```
-          [${{ steps.changes.outputs.file }}](${{ steps.upload.outputs.artifact-url }})
-
-    - name: Delete PR comment
-      if: ${{ !steps.changes.outputs.diff }}
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: ${{ inputs.comment-header }}
-        delete: true
-
     - name: Fail if diff exists
       if: steps.changes.outputs.diff
       run: exit 1

--- a/.github/workflows/lint-clang.yml
+++ b/.github/workflows/lint-clang.yml
@@ -1,6 +1,4 @@
-# Lints CMake config and C++ source code.
-
-name: "Lint (Clang)"
+name: "Lint Clang"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/lint-cmake.yml
+++ b/.github/workflows/lint-cmake.yml
@@ -1,6 +1,4 @@
-# Lints CMake config and C++ source code.
-
-name: "Lint (CMake)"
+name: "Lint CMake"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/lint-comment.yml
+++ b/.github/workflows/lint-comment.yml
@@ -1,0 +1,61 @@
+# We use `workflow_run` to securely add a comment to the PR.
+# PRs opened by external forks do not have write access to their PR, so can't add comments.
+name: PR lint comment
+
+on:
+  workflow_run:
+    workflows: ["Lint Clang", "Lint CMake"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download artifact
+        if: github.event.workflow_run.conclusion == 'failure'
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Debug
+        run: ls -R
+
+      - name: Read diff file
+        id: changes
+        run: |
+          file=$(find . -name '*.diff')
+          if [ -z "$file" ]; then
+            echo "No changes detected"
+            exit 0
+          fi
+
+          echo "file=$file" >> $GITHUB_OUTPUT
+          {
+            echo "diff<<EOF"
+            cat $file
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: PR comment (lint source hint)
+        if: steps.changes.outputs.diff
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ${{ github.event.workflow_run.name }}
+          message: |
+            ❌ Lint failed: It looks like your changes don't match our code style.
+
+            🛠️ Please apply this patch with `git apply`:
+            ```diff
+            ${{ steps.changes.outputs.diff }}
+            ```
+
+      - name: Delete PR comment
+        if: ${{ !steps.changes.outputs.diff }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ${{ github.event.workflow_run.name }}
+          delete: true


### PR DESCRIPTION
Related to: #7558

:warning: This PR probably doesn't work (unless I got lucky), but we have to merge this before we can test it; to quote the [`workflow_run` docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run):
> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

This is likely to be a security feature.