### PR TITLE
ci: remove `restore-keys` for `vcpkg` and use local bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            vcpkg
             vcpkg_installed
-            ${{ env.LOCALAPPDATA }}/vcpkg
           key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
-          restore-keys: vcpkg-${{ runner.os }}
 
       # Should only restore the .venv directory from cache.
       - name: Init Python venv
@@ -98,6 +97,8 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Install dependencies
+        env:
+          VCPKG_ROOT: "" # Unset deliberately to suppress 'already installed' warning.
         run: python ./scripts/install_deps.py
 
       - name: Configure

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -175,7 +175,7 @@ def install(args):
     if env.is_windows() and not args.skip_vcpkg:
         import lib.vcpkg as vcpkg
 
-        vcpkg.install()
+        vcpkg.install(args.ci_env)
 
     if not args.skip_meson:
         if args.subprojects:

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -21,14 +21,15 @@ import lib.cmd_utils as cmd_utils
 GIT_REPO = "https://github.com/microsoft/vcpkg.git"
 
 
-def install():
-    vcpkg_bin = ensure_vcpkg()
+def install(ci_env):
+    vcpkg_bin = ensure_vcpkg(ci_env)
 
     cmd_utils.run([vcpkg_bin, "install"], print_cmd=True)
 
 
-def ensure_vcpkg():
-    if cmd_utils.has_command("vcpkg"):
+def ensure_vcpkg(ci_env):
+    # Don't use the local vcpkg if we're in CI, since this makes caching complicated.
+    if not ci_env and cmd_utils.has_command("vcpkg"):
         print("Using system vcpkg")
         return "vcpkg"
 


### PR DESCRIPTION
Fixes: #7540

Using the GitHub system-installed `vcpkg` seems to cause issues with caching. Instead, we will ignore the system-installed `vcpkg` and use our own local bootstrapped one; this seems to allow us greater control over caching. Using `restore-keys` seems to have no benefit, so this was removed.