### PR TITLE
ci: use `github.event.workflow_run.id` for CI summary comment

### DIFF
--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -35,7 +35,7 @@ jobs:
         id: workflow-url
         run: |
           repo_url="${{ github.server_url }}/${{ github.repository }}"
-          echo "url=$repo_url/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "url=$repo_url/actions/runs/${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Merge summaries


### PR DESCRIPTION
Relates to: https://github.com/deskflow/deskflow/issues/7568 and https://github.com/deskflow/deskflow/issues/7558

:warning: As this is a `workflow_run`, it must be landed in master to test.