### PR TITLE
ci: check for summaries dir before building message

### DIFF
--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -41,16 +41,22 @@ jobs:
       - name: Merge summaries
         id: summary
         run: |
-          files=$(ls summaries)
-          if [ -z "$files" ]; then
-            echo "No summaries found"
+          dir="summaries"
+          if [ ! -d "$dir" ]; then
+            echo "Skipping, no summaries, no such dir: $dir"
             exit 0
+          fi
+
+          files=$(ls $dir)
+          if [ -z "$files" ]; then
+            echo "Error: No summaries found in dir: $dir"
+            exit 1
           fi
 
           echo "message<<EOF" >> $GITHUB_OUTPUT
           echo "## CI Summary" >> $GITHUB_OUTPUT
 
-          for file in summaries/*; do
+          for file in $dir/*; do
             echo $(cat $file) >> $GITHUB_OUTPUT
           done
 


### PR DESCRIPTION
Relates to: https://github.com/deskflow/deskflow/issues/7568 and https://github.com/deskflow/deskflow/issues/7558

:warning: As this is a `workflow_run`, it must be landed in master to test.