### PR TITLE
ci: fixed syntax error in ci comment workflow

### DIFF
--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -52,7 +52,7 @@ jobs:
           run_url="$repo_url/actions/runs/${{ github.event.workflow_run.id }}"
 
           echo > $GITHUB_OUTPUT
-          echo "[Full summary]($run_url)" (scroll down) >> $GITHUB_OUTPUT
+          echo "[Full summary]($run_url) (scroll down)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Set PR comment


### PR DESCRIPTION
Relates to: https://github.com/deskflow/deskflow/issues/7568 and https://github.com/deskflow/deskflow/issues/7558

:warning: As this is a `workflow_run`, it must be landed in master to test.