### PR TITLE
Use `sonarsource/sonarcloud-github-c-cpp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,12 @@ jobs:
 
       - name: Check PR comment for flags
         id: check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          pr_body="${{ github.event.pull_request.body }}"
           no_sonar="{no-sonar}"
 
-          if echo $pr_body | grep -q "$no_sonar"; then
+          if echo $PR_BODY | grep -q "$no_sonar"; then
             echo "Flag $no_sonar found in PR body."
             echo "no-sonar=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -49,26 +49,14 @@ jobs:
           # Prevent apt prompting for input.
           DEBIAN_FRONTEND: noninteractive
 
-      - name: Install SonarScanner
-        run: |
-          export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux-x64
-          curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip \
-            $SONAR_SCANNER_URL_BASE/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux-x64.zip
-          unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
-
-      - name: Install build-wrapper
-        run: |
-          file="build-wrapper-linux-x86.zip"
-          url="https://sonarcloud.io/static/cpp/$file"
-          curl --create-dirs -sSLo $HOME/.sonar/$file $url
-          unzip -o $HOME/.sonar/$file -d $HOME/.sonar/
+      - name: Install sonar-scanner and build-wrapper
+        uses: sonarsource/sonarcloud-github-c-cpp@v3
 
       - name: Configure
         run: cmake -B build --preset=linux-debug -DENABLE_COVERAGE=ON
 
       - name: Build
         run: |
-          export PATH=$HOME/.sonar/build-wrapper-linux-x86:$PATH
           build-wrapper-linux-x86-64 --out-dir bw-output cmake --build build -j${CPU_CORE_COUNT}
 
       - name: Unit tests coverage


### PR DESCRIPTION
We are using the old way to install `sonar-scanner` and `build-wrapper`, but there has been a GitHub action for a while now which simplifies the process.

This PR uses the [`sonarsource/sonarcloud-github-c-cpp`](https://github.com/SonarSource/sonarcloud-github-c-cpp) action to install `sonar-scanner` and `build-wrapper` instead of doing it manually as before. This PR should not change the behavior, but does decrease our maintenance burden.