### PR TITLE
ci: lock qt version to 6.7.2 on win/mac

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ config:
       # already installed on the Windows runner.
       command: if not defined CI (winget install ninja-build.ninja cmake)
       qt:
-        version: 6.7
+        version: 6.7.2
         mirror: https://qt.mirror.constant.com/
         base-dir: ./deps/qt
 
@@ -20,7 +20,7 @@ config:
     dependencies:
       command: brew bundle --file=Brewfile
       qt:
-        version: 6.7
+        version: 6.7.2
         mirror: https://qt.mirror.constant.com/
         base-dir: ./deps/qt
 


### PR DESCRIPTION
Fixes: #7513

For some reason `aqt` is trying to download `6.7.3` even though it doesn't exist in [`official_releases/qt/6.7`](https://qt.mirror.constant.com/official_releases/qt/6.7/) on the Qt mirror.

Note: We have discussed using `vcpkg` instead of `aqt` on Windows, but this PR fixes the problem for now so we should land it before looking at using `vcpkg`. See: [Discussion on `vcpkg` vs `aqt`](https://github.com/deskflow/deskflow/discussions/7586)