### PR TITLE
Remove word 'beta' from Wayland message

### DIFF
--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -287,13 +287,13 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath) {
 
 void showWaylandExperimental(QWidget *parent) {
   QMessageBox::information(
-      parent, "Experimental feature",
+      parent, "Wayland support (experimental)",
       QString(
-          "<p>Thanks for trying the beta version!</p>"
+          "<p>Heads up!</p>"
           "<p>Wayland support is experimental and contains bugs.</p>"
           R"(<p>Please <a href="%1" style="color: %2">report bugs</a> to us if you find any.</p>)"
           "<p>Happy testing!</p>")
-          .arg(kUrlHelp, kColorSecondary));
+          .arg(kAppName, kUrlHelp, kColorSecondary));
 }
 
 void showWaylandLibraryError(QWidget *parent) {


### PR DESCRIPTION
Since we're not using the word beta in the version number, saying "beta" doesn't make sense. I reworded the message to reflect this.

I believe it still makes sense to have this message, so that people are aware that our Wayland support is still a WIP.