### PR TITLE
Use modern Qt connections in GUI

### DIFF
--- a/src/gui/src/AddClientDialog.cpp
+++ b/src/gui/src/AddClientDialog.cpp
@@ -39,25 +39,33 @@ AddClientDialog::AddClientDialog(const QString &clientName, QWidget *parent)
   m_pButtonLeft->setIcon(icon);
   m_pButtonLeft->setIconSize(IconSize);
   gridLayout->addWidget(m_pButtonLeft, 2, 0, 1, 1, Qt::AlignCenter);
-  connect(m_pButtonLeft, SIGNAL(clicked()), this, SLOT(handleButtonLeft()));
+  connect(
+      m_pButtonLeft, &QPushButton::clicked, this,
+      &AddClientDialog::handleButtonLeft);
 
   m_pButtonUp = new QPushButton(this);
   m_pButtonUp->setIcon(icon);
   m_pButtonUp->setIconSize(IconSize);
   gridLayout->addWidget(m_pButtonUp, 1, 1, 1, 1, Qt::AlignCenter);
-  connect(m_pButtonUp, SIGNAL(clicked()), this, SLOT(handleButtonUp()));
+  connect(
+      m_pButtonUp, &QPushButton::clicked, this,
+      &AddClientDialog::handleButtonUp);
 
   m_pButtonRight = new QPushButton(this);
   m_pButtonRight->setIcon(icon);
   m_pButtonRight->setIconSize(IconSize);
   gridLayout->addWidget(m_pButtonRight, 2, 2, 1, 1, Qt::AlignCenter);
-  connect(m_pButtonRight, SIGNAL(clicked()), this, SLOT(handleButtonRight()));
+  connect(
+      m_pButtonRight, &QPushButton::clicked, this,
+      &AddClientDialog::handleButtonRight);
 
   m_pButtonDown = new QPushButton(this);
   m_pButtonDown->setIcon(icon);
   m_pButtonDown->setIconSize(IconSize);
   gridLayout->addWidget(m_pButtonDown, 3, 1, 1, 1, Qt::AlignCenter);
-  connect(m_pButtonDown, SIGNAL(clicked()), this, SLOT(handleButtonDown()));
+  connect(
+      m_pButtonDown, &QPushButton::clicked, this,
+      &AddClientDialog::handleButtonDown);
 
   m_pLabelCenter = new QLabel(this);
   m_pLabelCenter->setPixmap(QPixmap(":res/icons/64x64/video-display.png"));
@@ -69,7 +77,9 @@ AddClientDialog::AddClientDialog(const QString &clientName, QWidget *parent)
 
   QPushButton *advanced =
       m_pDialogButtonBox->addButton("Advanced", QDialogButtonBox::HelpRole);
-  connect(advanced, SIGNAL(clicked()), this, SLOT(handleButtonAdvanced()));
+  connect(
+      advanced, &QPushButton::clicked, this,
+      &AddClientDialog::handleButtonAdvanced);
 }
 
 AddClientDialog::~AddClientDialog() {

--- a/src/gui/src/DataDownloader.cpp
+++ b/src/gui/src/DataDownloader.cpp
@@ -22,8 +22,8 @@ DataDownloader::DataDownloader(QObject *parent)
       m_pReply(nullptr),
       m_IsFinished(false) {
   connect(
-      &m_NetworkManager, SIGNAL(finished(QNetworkReply *)),
-      SLOT(complete(QNetworkReply *)));
+      &m_NetworkManager, &QNetworkAccessManager::finished, this,
+      &DataDownloader::complete);
 }
 
 DataDownloader::~DataDownloader() {}

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -107,8 +107,8 @@ ServerConfigDialog::ServerConfigDialog(
 
   m_pButtonAddComputer->setEnabled(!model().isFull());
   connect(
-      m_pTrashScreenWidget, SIGNAL(screenRemoved()), this,
-      SLOT(onScreenRemoved()));
+      m_pTrashScreenWidget, &TrashScreenWidget::screenRemoved, this,
+      &ServerConfigDialog::onScreenRemoved);
 
   onChange();
 


### PR DESCRIPTION
Requires: #7624 Landed first To Pass Lint
Update the Qt Connections to use the "Qt5" Style. 