### PR TITLE
Remove Python `.venv` dir caching to reduce complexity

### DIFF
--- a/.github/actions/init-python/action.yml
+++ b/.github/actions/init-python/action.yml
@@ -1,50 +1,23 @@
+# Important: Do not be tempted to cache the .venv dir (Python virtual environment).
+# When the runner environment changes (e.g. Python is upgraded), the venv will need to be
+# re-created. Trying to upgrade a venv can be complex and it's usually more practical re-create it.
+# We don't save much time anyway by caching the venv so it's not worth the added complexity.
+
 name: "Setup Python venv"
-description: "Creates and caches a Python virtual environment"
-
-inputs:
-  cache:
-    description: "Cache Python venv"
-    default: true
-
-  setup:
-    description: "Setup Python venv"
-    default: true
-
-  python-bin:
-    description: "Python binary to use"
-    default: "python3"
-
-  cache-key:
-    description: "Cache key (note: hash is appended)"
-    required: true
+description: "Creates a Python virtual environment (venv)"
 
 runs:
   using: "composite"
 
   steps:
-    - name: Check cache key
-      if: ${{ inputs.cache }}
-      run: |
-        if [ -z "${{ inputs.cache-key }}" ]; then
-          echo "Cache key is required"
-          exit 1
-        fi
-      shell: bash
-
-    - name: Cache Python venv
-      if: ${{ inputs.cache }}
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: python-venv-${{ inputs.cache-key }}-${{ hashFiles('scripts/pyproject.toml') }}
-
-    # Use bash if to make output clearer in case of skipping.
     - name: Setup Python venv
       run: |
-        if [ "${{ inputs.setup }}" = "true" ]; then
-          echo "Setting up Python venv"
-          ${{ inputs.python-bin }} -m venv .venv
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          python=python
         else
-          echo "Skipping Python venv setup"
+          python=python3
         fi
+
+        echo "Setting up Python venv, bin=$python"
+        $python -m venv .venv
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,6 @@ jobs:
             ${{ env.LOCALAPPDATA }}/vcpkg
           key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
 
-      # Should only restore the .venv directory from cache.
-      - name: Init Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: ci-${{ matrix.target.name }}
-          setup: false
-
       - name: Cache deps dir
         uses: actions/cache@v4
         with:
@@ -218,13 +211,6 @@ jobs:
       - name: Get version
         uses: ./.github/actions/get-version
 
-      # Should only restore the .venv directory from cache.
-      - name: Setup Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: ci-${{ matrix.target.name }}
-          setup: false
-
       - name: Cache deps dir
         uses: actions/cache@v4
         with:
@@ -296,13 +282,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # Should only restore the .venv directory from cache.
-      - name: Setup Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: ci-${{ matrix.distro.name }}
-          setup: false
 
       - name: Get version
         uses: ./.github/actions/get-version

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,13 +27,6 @@ jobs:
       - name: Config Git safe dir
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      # Should only restore the .venv directory from cache.
-      - name: Init Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: "codeql"
-          setup: false
-
       - name: Install dependencies
         run: ./scripts/install_deps.py
         env:

--- a/.github/workflows/lint-clang.yml
+++ b/.github/workflows/lint-clang.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup Python venv
         uses: ./.github/actions/init-python
-        with:
-          cache-key: "lint-clang"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint-cmake.yml
+++ b/.github/workflows/lint-cmake.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup Python venv
         uses: ./.github/actions/init-python
-        with:
-          cache-key: "lint-cmake"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Config Git safe dir
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      # Should only restore the .venv directory from cache.
-      - name: Init Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: "sonarcloud"
-          setup: false
-
       - name: Install dependencies
         run: |
           ./scripts/install_deps.py &&

--- a/.github/workflows/valgrind-analysis.yml
+++ b/.github/workflows/valgrind-analysis.yml
@@ -17,13 +17,6 @@ jobs:
       - name: Config Git safe dir
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      # Should only restore the .venv directory from cache.
-      - name: Init Python venv
-        uses: ./.github/actions/init-python
-        with:
-          cache-key: "valgrind"
-          setup: false
-
       - name: Install dependencies
         run: |
           ./scripts/install_deps.py &&


### PR DESCRIPTION
Caching the `.venv` dir in CI was a bad idea, as it only saves a few seconds and causes a lot of complexity; where caching adds only negligible performance gains, we should always avoid it.

Fixes error on macOS:
```
Run ./scripts/install_deps.py
CI environment detected
Using virtual environment for: /Users/runner/work/deskflow/deskflow/scripts/install_deps.py
dyld[2337]: Library not loaded: /opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/Python
  Referenced from: <CAFBC7FD-3E97-32A7-8EE8-EF3B8E2B346A> /Users/runner/work/deskflow/deskflow/.venv/bin/python
  Reason: tried: '/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/Python' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/Python' (no such file), '/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/Python' (no such file)
Error: Process completed with exit code 250.
```