### PR TITLE
chore: add note known issues in bug_template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,6 +70,15 @@ body:
         - label: I have reviewed the Wayland known issues and my issue is new
         - label: I am not using Wayland on Linux
 
+  - type: checkboxes
+    id: mac-signcheck
+    attributes:
+      label: Signing on mac os
+      description: If you using Mac os, and the app seams to just crash try [Apple's Solution](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac) before reporting.
+      options:
+        - label: I have Authrized the application to run on my mac
+        - label: I am not using Mac os
+
   - type: textarea
     id: os-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,11 +54,21 @@ body:
       options:
         - label: Windows
         - label: macOS
-        - label: Linux
+        - label: Linux (X11)
+        - label: Linux (Wayland)
         - label: BSD-derived
         - label: Other
     validations:
       required: true
+
+  - type: checkboxes
+    id: linux-wayland
+    attributes:
+      label: Wayland on Linux
+      description: If you using Wayland on Linux, please review the [known issues](https://github.com/deskflow/deskflow/discussions/7499) before reporting.
+      options:
+        - label: I have reviewed the Wayland known issues and my issue is new
+        - label: I am not using Wayland on Linux
 
   - type: textarea
     id: os-version


### PR DESCRIPTION
In an attempt to slow the duplicate Wayland portal issues being raised. 

 - Add os option  for  Linux (X11) / Llinux (wayland)
 - Add note for linux(wayland ) bug reporters to check the known issues first.
 - Add note for mac os to check apples unknown dev guidance (i.e get unsigned app to run ) 