### PR TITLE
chore: add basic .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Chris Rizzitello <sithlord48@gmail.com>
+# SPDX-License-Identifier: MIT
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.github* export-ignore


### PR DESCRIPTION
  Don't add the items below to "Source" exports
   -  `.github*`
   -  `.gitattributes`
   -  `.gitignore`


