### PR TITLE
fix: Set correct QGuiApplication::desktopFileName

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -75,6 +75,7 @@ int main(int argc, char *argv[]) {
 
   QCoreApplication::setApplicationName(kAppName);
   QCoreApplication::setOrganizationName(kAppName);
+  QGuiApplication::setDesktopFileName(DESKFLOW_APP_ID);
 
   // used as a prefix for settings paths, and must not be a url.
   QCoreApplication::setOrganizationDomain(kOrgDomain);


### PR DESCRIPTION
The implicity default doesn't match the actual name of the desktop file.

This fixes e.g. the application icon on Wayland