### PR TITLE
build: Don't force CMAKE_INSTALL_PREFIX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
 
       - name: Configure
-        run: cmake -B build --preset=linux-release ${{ matrix.distro.extra-cmake-args }}
+        run: cmake -B build --preset=linux-release ${{ matrix.distro.extra-cmake-args }} -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: Build
         run: cmake --build build -j8

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -114,13 +114,6 @@ macro(configure_linux_packaging)
   # 12), so we must add it manually.
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "qt6-qpa-plugins")
 
-  # The default for CMake seems to be /usr/local, which seems uncommon. While
-  # the default /usr/local prefix causes the app to appear on Debian and Fedora,
-  # it doesn't seem to appear on Arch Linux. Setting the prefix to /usr seems to
-  # work on a wider variety of distros, and that also seems to be where most
-  # apps install to.
-  set(CMAKE_INSTALL_PREFIX /usr)
-
   set(source_desktop_file ${DESKFLOW_PROJECT_RES_DIR}/dist/linux/app.desktop.in)
   set(configured_desktop_file ${PROJECT_BINARY_DIR}/app.desktop)
   set(install_desktop_file ${DESKFLOW_APP_ID}.desktop)


### PR DESCRIPTION
This should only ever be set from the outside, not the project itself

Distribution build systems will set it to the right value

This breaks installing it to a custom if desired