### PR TITLE
feat: Use native style on KDE Plasma

### DIFF
--- a/src/gui/src/DeskflowApplication.cpp
+++ b/src/gui/src/DeskflowApplication.cpp
@@ -26,6 +26,8 @@
 DeskflowApplication::DeskflowApplication(int &argc, char **argv)
     : QApplication(argc, argv) {
 
-  // causes dark mode to be used on some OS (e.g. Windows)
-  setStyle("fusion");
+  if (qEnvironmentVariable("XDG_CURRENT_DESKTOP") != QLatin1String("KDE")) {
+    // causes dark mode to be used on some OS (e.g. Windows)
+    setStyle("fusion");
+  }
 }


### PR DESCRIPTION
On Plasma it is preferred to use the default Breeze style instead of Fusion

Breeze also has dark mode support out of the box, so no need to work around that