### PR TITLE
ci: test results gathering job must always pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
   test-results:
     needs: [windows, macos, linux]
     if: always()
+    continue-on-error: true
 
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
- Since the test results job is set to `always` we have to also now tell it continue-on-error so if we skip ci (due to path ignore ) we dont' "fail" ci