### PR TITLE
Add leading edge philosophy to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ install `deskflow` (see: [installing packages](#how-to-install-packages)).
 - Motivated by the community interests (not business-driven)
 - Privacy by default (e.g. update check is off by default)
 - Nothing customer-related (this is all moved downstream to Synergy)
+- Leading edge releases (we don't focus on supporting older systems)
 - Decisions are discussed and documented publicly with majority rule
 - Have fun; we don't need to worry about impressing anyone
 


### PR DESCRIPTION
I think it's important to help people understand the difference between Deskflow and Input Leap. e.g. We don't support Qt5, but IL seem to want to support Qt5.