### PR TITLE
fix: align --display explanation in help message

### DIFF
--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -145,7 +145,7 @@ void ClientApp::help() {
       << "                             and listen instead of connecting.\n"
 #if WINAPI_XWINDOWS
       << "      --display <display>  when in X mode, connect to the X server\n"
-      << "                             at <display>\n."
+      << "                             at <display>.\n"
       << "      --no-xinitthreads    do not call XInitThreads()\n"
 #endif
       << HELP_COMMON_INFO_2 << "\n"

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -148,7 +148,7 @@ void ServerApp::help() {
 
 #if WINAPI_XWINDOWS
       << "      --display <display>  when in X mode, connect to the X server\n"
-      << "                             at <display>\n."
+      << "                             at <display>.\n"
       << "      --no-xinitthreads    do not call XInitThreads()\n"
 #endif
 


### PR DESCRIPTION
Broken "." position was fixed like this.

Before:

```
        --display <display>  when in X mode, connect to the X server
                               at <display>
  .      --no-xinitthreads    do not call XInitThreads()
```

After:

```
        --display <display>  when in X mode, connect to the X server
                               at <display>.
        --no-xinitthreads    do not call XInitThreads()
```