### PR TITLE
Remove `max_pargs_hwrap` from `cmake-format.yaml`

### DIFF
--- a/cmake-format.yaml
+++ b/cmake-format.yaml
@@ -2,9 +2,6 @@ format:
   # Solves line ending issues on Windows.
   line_ending: "auto"
 
-  # Any more than 4 args, and function calls become hard to read.
-  max_pargs_hwrap: 4
-
 markup:
   # Disable formatting of comments entirely, as this is annoying.
   enable_markup: false

--- a/cmake/Build.cmake
+++ b/cmake/Build.cmake
@@ -93,12 +93,8 @@ macro(post_config_all)
       VERBATIM
       COMMENT "Copying files to bin dir")
 
-    add_dependencies(
-      run_post_build
-      ${GUI_BINARY_NAME}
-      ${CLIENT_BINARY_NAME}
-      ${SERVER_BINARY_NAME}
-      ${DAEMON_BINARY_NAME})
+    add_dependencies(run_post_build ${GUI_BINARY_NAME} ${CLIENT_BINARY_NAME}
+                     ${SERVER_BINARY_NAME} ${DAEMON_BINARY_NAME})
   endif()
 
 endmacro()

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -164,11 +164,8 @@ set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
           "Flags used by the shared libraries linker during coverage builds."
           FORCE)
 mark_as_advanced(
-  CMAKE_Fortran_FLAGS_COVERAGE
-  CMAKE_CXX_FLAGS_COVERAGE
-  CMAKE_C_FLAGS_COVERAGE
-  CMAKE_EXE_LINKER_FLAGS_COVERAGE
-  CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
+  CMAKE_Fortran_FLAGS_COVERAGE CMAKE_CXX_FLAGS_COVERAGE CMAKE_C_FLAGS_COVERAGE
+  CMAKE_EXE_LINKER_FLAGS_COVERAGE CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(
@@ -199,19 +196,10 @@ function(setup_target_for_coverage_lcov)
 
   set(options NO_DEMANGLE)
   set(oneValueArgs BASE_DIRECTORY NAME)
-  set(multiValueArgs
-      EXCLUDE
-      EXECUTABLE
-      EXECUTABLE_ARGS
-      DEPENDENCIES
-      LCOV_ARGS
-      GENHTML_ARGS)
-  cmake_parse_arguments(
-    Coverage
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN})
+  set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS
+                     GENHTML_ARGS)
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
 
   if(NOT LCOV_PATH)
     message(FATAL_ERROR "lcov not found! Aborting...")
@@ -233,12 +221,7 @@ function(setup_target_for_coverage_lcov)
   foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES}
                   ${COVERAGE_LCOV_EXCLUDES})
     if(CMAKE_VERSION VERSION_GREATER 3.4)
-      get_filename_component(
-        EXCLUDE
-        ${EXCLUDE}
-        ABSOLUTE
-        BASE_DIR
-        ${BASEDIR})
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
     list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
   endforeach()
@@ -278,10 +261,8 @@ function(setup_target_for_coverage_lcov)
     COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
             ${Coverage_NAME} ${Coverage_NAME}.info
     # Set output files as GENERATED (will be removed on 'make clean')
-    BYPRODUCTS ${Coverage_NAME}.base
-               ${Coverage_NAME}.capture
-               ${Coverage_NAME}.total
-               ${Coverage_NAME}.info
+    BYPRODUCTS ${Coverage_NAME}.base ${Coverage_NAME}.capture
+               ${Coverage_NAME}.total ${Coverage_NAME}.info
                ${Coverage_NAME} # report directory
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     DEPENDS ${Coverage_DEPENDENCIES}
@@ -324,12 +305,8 @@ function(setup_target_for_coverage_gcovr_xml)
   set(options NONE)
   set(oneValueArgs BASE_DIRECTORY NAME)
   set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-  cmake_parse_arguments(
-    Coverage
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN})
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
 
   if(NOT GCOVR_PATH)
     message(FATAL_ERROR "gcovr not found! Aborting...")
@@ -347,12 +324,7 @@ function(setup_target_for_coverage_gcovr_xml)
   foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES}
                   ${COVERAGE_GCOVR_EXCLUDES})
     if(CMAKE_VERSION VERSION_GREATER 3.4)
-      get_filename_component(
-        EXCLUDE
-        ${EXCLUDE}
-        ABSOLUTE
-        BASE_DIR
-        ${BASEDIR})
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
     list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
   endforeach()
@@ -402,12 +374,8 @@ function(setup_target_for_coverage_gcovr_html)
   set(options NONE)
   set(oneValueArgs BASE_DIRECTORY NAME)
   set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-  cmake_parse_arguments(
-    Coverage
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN})
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
 
   if(NOT GCOVR_PATH)
     message(FATAL_ERROR "gcovr not found! Aborting...")
@@ -425,12 +393,7 @@ function(setup_target_for_coverage_gcovr_html)
   foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES}
                   ${COVERAGE_GCOVR_EXCLUDES})
     if(CMAKE_VERSION VERSION_GREATER 3.4)
-      get_filename_component(
-        EXCLUDE
-        ${EXCLUDE}
-        ABSOLUTE
-        BASE_DIR
-        ${BASEDIR})
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
     list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
   endforeach()

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -417,12 +417,7 @@ macro(configure_xorg_libs)
 
     # Xtxt depends on X11.
     set(HAVE_X11)
-    list(
-      APPEND
-      libs
-      Xtst
-      X11
-      xkbfile)
+    list(APPEND libs Xtst X11 xkbfile)
 
   else()
 
@@ -476,12 +471,8 @@ macro(configure_windows_libs)
     comsuppw
     Shlwapi)
 
-  add_definitions(
-    /DWIN32
-    /D_WINDOWS
-    /D_CRT_SECURE_NO_WARNINGS
-    /DDESKFLOW_VERSION=\"${DESKFLOW_VERSION}\"
-    /D_XKEYCHECK_H)
+  add_definitions(/DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS
+                  /DDESKFLOW_VERSION=\"${DESKFLOW_VERSION}\" /D_XKEYCHECK_H)
 
   configure_file(${PROJECT_SOURCE_DIR}/res/win/version.rc.in
                  ${PROJECT_BINARY_DIR}/src/version.rc @ONLY)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -23,13 +23,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(res_dir ${GUI_RES_DIR})
 set(qrc_file ${GUI_QRC_FILE})
 
-file(
-  GLOB
-  sources
-  src/*.cpp
-  src/*.h
-  src/validators/*
-  src/widgets/*)
+file(GLOB sources src/*.cpp src/*.h src/validators/* src/widgets/*)
 file(GLOB ui_files src/*.ui)
 
 if(WIN32)
@@ -48,13 +42,8 @@ include_directories(${PROJECT_BINARY_DIR}/config)
 
 add_executable(${target} WIN32 ${sources} ${ui_files} ${rc_files} ${qrc_file})
 
-target_link_libraries(
-  ${target}
-  ${DESKFLOW_GUI_HOOK_LIB}
-  gui
-  Qt6::Core
-  Qt6::Widgets
-  Qt6::Network)
+target_link_libraries(${target} ${DESKFLOW_GUI_HOOK_LIB} gui Qt6::Core
+                      Qt6::Widgets Qt6::Network)
 
 target_compile_definitions(
   ${target} PRIVATE -DDESKFLOW_VERSION_STAGE="${DESKFLOW_VERSION_STAGE}")

--- a/src/lib/gui/CMakeLists.txt
+++ b/src/lib/gui/CMakeLists.txt
@@ -41,9 +41,5 @@ include_directories(${PROJECT_BINARY_DIR}/config)
 
 add_library(${target} STATIC ${sources} ${ui_files} ${qrc_file})
 
-target_link_libraries(
-  ${target}
-  ${DESKFLOW_GUI_HOOK_LIB}
-  Qt6::Core
-  Qt6::Widgets
-  Qt6::Network)
+target_link_libraries(${target} ${DESKFLOW_GUI_HOOK_LIB} Qt6::Core Qt6::Widgets
+                      Qt6::Network)

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -19,13 +19,7 @@ if(WIN32)
   file(GLOB sources "MSWindows*.cpp")
 elseif(APPLE)
   file(GLOB headers "OSX*.h" "IOSX*.h")
-  file(
-    GLOB
-    sources
-    "OSX*.cpp"
-    "IOSX*.cpp"
-    "OSX*.m"
-    "OSX*.mm")
+  file(GLOB sources "OSX*.cpp" "IOSX*.cpp" "OSX*.m" "OSX*.mm")
 elseif(UNIX)
   file(GLOB x_headers "XWindows*.h")
   file(GLOB x_sources "XWindows*.cpp")
@@ -41,18 +35,8 @@ elseif(UNIX)
     endif()
   endif()
 
-  list(
-    APPEND
-    headers
-    ${x_headers}
-    ${ei_headers}
-    ${portal_headers})
-  list(
-    APPEND
-    sources
-    ${x_sources}
-    ${ei_sources}
-    ${portal_sources})
+  list(APPEND headers ${x_headers} ${ei_headers} ${portal_headers})
+  list(APPEND sources ${x_sources} ${ei_sources} ${portal_sources})
 endif()
 
 if(ADD_HEADERS_TO_SOURCES)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -33,12 +33,8 @@ endmacro()
 
 macro(config_test)
 
-  include_directories(
-    ${test_base_dir}
-    ${src_dir}
-    ${src_dir}/lib
-    ${gui_dir}
-    ${ext_dir})
+  include_directories(${test_base_dir} ${src_dir} ${src_dir}/lib ${gui_dir}
+                      ${ext_dir})
 
   set_sources()
 


### PR DESCRIPTION
Solves horrible formatting problem.

e.g.
```
  string(REGEX MATCH [0-9]+\- PATCH ${GITREV})
```

Was formatted as:
```
string(REGEX
MATCH
[0-9]+
- PATCH
${GITREV})
```
