### PR TITLE
ci: vcpkg cache working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{github.workspace}}/vcpkg
+            ${{github.workspace}}/build/vcpkg
 
           key: vcpkg-${{ runner.os }}-1
 


### PR DESCRIPTION
 
 - Cache the stuff vcpkg puts in the build folder.