### PR TITLE
fix: Use `OPENSSL_EXE_DIR` instead of `OPENSSL_ROOT_DIR` on Windows

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -525,9 +525,9 @@ macro(configure_openssl)
   if(WIN32) #Used for dev in TLS and WIX
     cmake_path(SET OPENSSL_ROOT_DIR NORMALIZE
                "${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows")
-    message(STATUS "SET OPENSSL ROOT: ${OPENSSL_ROOT_DIR}")
+    message(VERBOSE "Set OPENSSL_ROOT_DIR: ${OPENSSL_ROOT_DIR}")
     set(OPENSSL_EXE_DIR "${OPENSSL_ROOT_DIR}/tools/openssl")
-    add_definitions(-DOPENSSL_EXE_DIR="${OPENSSL_ROOT_DIR}")
+    add_definitions(-DOPENSSL_EXE_DIR="${OPENSSL_EXE_DIR}")
   endif()
 
 endmacro()

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -52,11 +52,14 @@ QString openSslWindowsDir() {
   }
 
   // if the path still isn't found, something is seriously wrong.
-  if (!openSslDir.exists()) {
-    qFatal() << "openssl dir not found: " << openSslDir;
+  const auto path = openSslDir.absolutePath();
+  if (openSslDir.exists()) {
+    qDebug("openssl dir: %s", qUtf8Printable(path));
+  } else {
+    qFatal("openssl dir not found: %s", qUtf8Printable(path));
   }
 
-  return QDir::cleanPath(openSslDir.absolutePath());
+  return QDir::cleanPath(path);
 }
 
 QString openSslWindowsBinary() {


### PR DESCRIPTION
Fixes: #7719