### PR TITLE
docs: Checkbox for continuous build on bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,6 +80,15 @@ body:
         - label: I have authorized the app to run on my Mac
         - label: I am not using macOS
 
+  - type: checkboxes
+    id: continuous-build
+    attributes:
+      label: Continuous build
+      description: Please try the latest [continuous build](https://github.com/deskflow/deskflow/releases) of Deskflow. It may have a fix for your issue.
+      options:
+        - label: I have tried the latest continuous build and the issue persists
+        - label: I am unable to try the latest continuous build
+
   - type: textarea
     id: os-version
     attributes:


### PR DESCRIPTION
I hate to add one more checkbox, but this is important as we keep asking it and sometimes forget. I also made one more field optional to reduce friction. Still no support for [radio buttons](https://github.com/orgs/community/discussions/4318) yet from GitHub.