### PR TITLE
ci: Catch std::exception on toml::parse_file

### DIFF
--- a/src/lib/deskflow/Config.cpp
+++ b/src/lib/deskflow/Config.cpp
@@ -67,6 +67,9 @@ bool Config::load(const std::string &firstArg)
   } catch (const toml::parse_error &err) {
     LOG((CLOG_ERR "toml parse error: %s", err.what()));
     throw ParseError();
+  } catch (const std::exception &err) {
+    LOG((CLOG_ERR "unknown parse error: %s", err.what()));
+    throw ParseError();
   }
 
   if (!configTable.contains(m_section)) {

--- a/src/test/integtests/deskflow/ConfigTests.cpp
+++ b/src/test/integtests/deskflow/ConfigTests.cpp
@@ -62,9 +62,6 @@ TEST(ConfigTests, load_fileDoesNotExist_returnsFalse)
   ASSERT_FALSE(result);
 }
 
-// HACK: Disable on FreeBSD, because of error:
-// "Error while parsing key-value pair: encountered end-of-file".
-#if !defined(__FreeBSD__)
 TEST(ConfigTests, load_invalidConfig_throwsException)
 {
   EXPECT_THROW(
@@ -80,7 +77,6 @@ TEST(ConfigTests, load_invalidConfig_throwsException)
       Config::ParseError
   );
 }
-#endif
 
 TEST(ConfigTests, load_sectionMissing_returnsFalse)
 {


### PR DESCRIPTION
Fixes: #7751