### PR TITLE
build: arch package requires tomlplusplus and cli11

### DIFF
--- a/res/dist/arch/PKGBUILD.in
+++ b/res/dist/arch/PKGBUILD.in
@@ -25,6 +25,8 @@ depends=(
   'qt6-tools'
   'libei'
   'libportal'
+  'tomlplusplus'
+  'cli11'
 )
 conflicts=('synergy-git' 'synergy1-bin' 'synergy2-bin' 'synergy3-bin')
 options=('!debug')


### PR DESCRIPTION
 In testing our ci arch build i noticed we were missing 
  - tomlplusplus 
  - cli11 

from our depends list, since our ci has them we need them on the machine using the package.