### PR TITLE
Clazy nits

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -65,7 +65,7 @@ ActionDialog::ActionDialog(QWidget *parent, ServerConfig &config, Hotkey &hotkey
   ui->m_pGroupBoxScreens->setChecked(m_Action.haveScreens());
 
   int idx = 0;
-  foreach (const Screen &screen, serverConfig().screens())
+  for (const Screen &screen : serverConfig().screens()) {
     if (!screen.isNull()) {
       QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
       ui->m_pListScreens->addItem(pListItem);
@@ -78,6 +78,7 @@ ActionDialog::ActionDialog(QWidget *parent, ServerConfig &config, Hotkey &hotkey
 
       idx++;
     }
+  }
 }
 
 void ActionDialog::accept()
@@ -90,7 +91,8 @@ void ActionDialog::accept()
   m_Action.setHaveScreens(ui->m_pGroupBoxScreens->isChecked());
 
   m_Action.typeScreenNames().clear();
-  foreach (const QListWidgetItem *pItem, ui->m_pListScreens->selectedItems())
+
+  for (const QListWidgetItem *pItem : ui->m_pListScreens->selectedItems())
     m_Action.typeScreenNames().append(pItem->text());
 
   m_Action.setSwitchScreenName(ui->m_pComboSwitchToScreen->currentText());

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -92,7 +92,8 @@ void ActionDialog::accept()
 
   m_Action.typeScreenNames().clear();
 
-  for (const QListWidgetItem *pItem : ui->m_pListScreens->selectedItems())
+  const auto &selection = ui->m_pListScreens->selectedItems();
+  for (const QListWidgetItem *pItem : selection)
     m_Action.typeScreenNames().append(pItem->text());
 
   m_Action.setSwitchScreenName(ui->m_pComboSwitchToScreen->currentText());

--- a/src/gui/src/DataDownloader.cpp
+++ b/src/gui/src/DataDownloader.cpp
@@ -34,7 +34,7 @@ void DataDownloader::complete(QNetworkReply *reply)
 
   if (!m_Data.isEmpty()) {
     m_IsFinished = true;
-    emit isComplete();
+    Q_EMIT isComplete();
   }
 }
 

--- a/src/gui/src/DeskflowApplication.cpp
+++ b/src/gui/src/DeskflowApplication.cpp
@@ -20,9 +20,6 @@
 
 #include "MainWindow.h"
 
-#include <QtCore>
-#include <QtGui>
-
 DeskflowApplication::DeskflowApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
 

--- a/src/gui/src/HotkeyDialog.cpp
+++ b/src/gui/src/HotkeyDialog.cpp
@@ -19,9 +19,6 @@
 #include "HotkeyDialog.h"
 #include "ui_HotkeyDialog.h"
 
-#include <QtCore>
-#include <QtGui>
-
 HotkeyDialog::HotkeyDialog(QWidget *parent, Hotkey &hotkey)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::HotkeyDialog>()},

--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -17,9 +17,7 @@
  */
 
 #include "KeySequence.h"
-
-#include <QtCore>
-#include <QtGui>
+#include <QSettings>
 
 // this table originally comes from Qt sources (gui/kernel/qkeysequence.cpp)
 // and is heavily modified for Deskflow

--- a/src/gui/src/KeySequenceWidget.cpp
+++ b/src/gui/src/KeySequenceWidget.cpp
@@ -79,7 +79,7 @@ void KeySequenceWidget::stopRecording()
   focusNextChild();
   releaseKeyboard();
   setStatus(Stopped);
-  emit keySequenceChanged();
+  Q_EMIT keySequenceChanged();
 }
 
 bool KeySequenceWidget::event(QEvent *event)

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -48,12 +48,11 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QNetworkAccessManager>
+#include <QNetworkInterface>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QScrollBar>
-#include <QtCore>
-#include <QtGui>
-#include <QtNetwork>
+
 #include <memory>
 
 #if defined(Q_OS_MAC)

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -1012,8 +1012,7 @@ void MainWindow::updateScreenName()
 {
   ui->m_pLabelComputerName->setText(QString("This computer's name: %1 "
                                             R"((<a href="#" style="color: %2">change</a>))")
-                                        .arg(m_AppConfig.screenName())
-                                        .arg(kColorSecondary));
+                                        .arg(m_AppConfig.screenName(), kColorSecondary));
   m_ServerConfig.updateServerName();
 }
 

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -90,7 +90,7 @@ MainWindow::MainWindow(ConfigScopes &configScopes, AppConfig &appConfig)
   connectSlots();
 
   // handled by `onCreated`
-  emit created();
+  Q_EMIT created();
 }
 
 MainWindow::~MainWindow()
@@ -741,7 +741,7 @@ QString MainWindow::getTimeStamp() const
 void MainWindow::showEvent(QShowEvent *event)
 {
   QMainWindow::showEvent(event);
-  emit shown();
+  Q_EMIT shown();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -691,7 +691,7 @@ void MainWindow::checkConnected(const QString &line)
 
 void MainWindow::checkFingerprint(const QString &line)
 {
-  QRegularExpression re(".*server fingerprint: ([A-F0-9:]+)");
+  static const QRegularExpression re(".*server fingerprint: ([A-F0-9:]+)");
   auto match = re.match(line);
   if (!match.hasMatch()) {
     return;

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -198,7 +198,7 @@ void MainWindow::connectSlots()
   connect(&m_CoreProcess, &CoreProcess::error, this, &MainWindow::onCoreProcessError);
 
   connect(
-      &m_CoreProcess, &CoreProcess::logLine, //
+      &m_CoreProcess, &CoreProcess::logLine, this, //
       [this](const QString &line) { handleLogLine(line); }
   );
 
@@ -211,7 +211,7 @@ void MainWindow::connectSlots()
   connect(ui->m_pActionMinimize, &QAction::triggered, this, &MainWindow::hide);
 
   connect(
-      ui->m_pActionRestore, &QAction::triggered, //
+      ui->m_pActionRestore, &QAction::triggered, this, //
       [this]() { showAndActivate(); }
   );
 
@@ -269,7 +269,7 @@ void MainWindow::onShown()
   // this we delay the error dialog raise by a split second. this seems a bit
   // hacky and fragile, so maybe there's a better approach.
   const auto kCriticalDialogDelay = 100;
-  QTimer::singleShot(kCriticalDialogDelay, [] { messages::raiseCriticalDialog(); });
+  QTimer::singleShot(kCriticalDialogDelay, this, [] { messages::raiseCriticalDialog(); });
 }
 
 void MainWindow::onConfigScopesSaving()

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -26,8 +26,6 @@
 #include "gui/validators/ValidationError.h"
 
 #include <QMessageBox>
-#include <QtCore>
-#include <QtGui>
 
 using namespace deskflow::gui;
 using enum ScreenConfig::Modifier;

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -18,10 +18,11 @@
 
 #include "ScreenSetupModel.h"
 
-#include "gui/config/Screen.h"
+#include <QIODevice>
+#include <QIcon>
+#include <QMimeData>
 
-#include <QtCore>
-#include <QtGui>
+#include "gui/config/Screen.h"
 
 const QString ScreenSetupModel::m_MimeType = "application/x-" DESKFLOW_APP_ID "-screen";
 

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -100,9 +100,10 @@ QMimeData *ScreenSetupModel::mimeData(const QModelIndexList &indexes) const
 
   QDataStream stream(&encodedData, QIODevice::WriteOnly);
 
-  foreach (const QModelIndex &index, indexes)
+  for (const QModelIndex &index : indexes) {
     if (index.isValid())
       stream << index.column() << index.row() << screen(index);
+  }
 
   pMimeData->setData(m_MimeType, encodedData);
 

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -150,7 +150,7 @@ bool ScreenSetupModel::dropMimeData(
 
   screen(parent.column(), parent.row()) = droppedScreen;
 
-  emit screensChanged();
+  Q_EMIT screensChanged();
 
   return true;
 }
@@ -158,7 +158,7 @@ bool ScreenSetupModel::dropMimeData(
 void ScreenSetupModel::addScreen(const Screen &newScreen)
 {
   m_Screens.addScreenByPriority(newScreen);
-  emit screensChanged();
+  Q_EMIT screensChanged();
 }
 
 bool ScreenSetupModel::isFull() const

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -78,7 +78,7 @@ void ScreenSetupView::mouseDoubleClickEvent(QMouseEvent *event)
     if (!model()->screen(col, row).isNull()) {
       ScreenSettingsDialog dlg(this, &model()->screen(col, row), &model()->m_Screens);
       dlg.exec();
-      emit model() -> screensChanged();
+      Q_EMIT model()->screensChanged();
     }
   } else
     event->ignore();
@@ -145,7 +145,7 @@ void ScreenSetupView::startDrag(Qt::DropActions)
     else
       model()->screen(indexes[0]).setSwapped(false);
 
-    emit model() -> screensChanged();
+    Q_EMIT model()->screensChanged();
   }
 }
 

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -21,9 +21,13 @@
 #include "ScreenSettingsDialog.h"
 #include "ScreenSetupModel.h"
 
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
 #include <QHeaderView>
-#include <QtCore>
-#include <QtGui>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QResizeEvent>
 
 ScreenSetupView::ScreenSetupView(QWidget *parent) : QTableView(parent)
 {

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -25,7 +25,6 @@
 #include <QAbstractButton>
 #include <QMessageBox>
 #include <QPushButton>
-#include <QtCore>
 
 using namespace deskflow::gui::proxy;
 using enum ScreenConfig::Modifier;

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -249,23 +249,25 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 
   outStream << "section: screens" << Qt::endl;
 
-  foreach (const Screen &s, config.screens())
+  for (const Screen &s : config.screens()) {
     if (!s.isNull())
       s.writeScreensSection(outStream);
+  }
 
   outStream << "end" << Qt::endl << Qt::endl;
 
   outStream << "section: aliases" << Qt::endl;
 
-  foreach (const Screen &s, config.screens())
+  for (const Screen &s : config.screens()) {
     if (!s.isNull())
       s.writeAliasesSection(outStream);
+  }
 
   outStream << "end" << Qt::endl << Qt::endl;
 
   outStream << "section: links" << Qt::endl;
 
-  for (int i = 0; i < config.screens().size(); i++)
+  for (int i = 0; i < config.screens().size(); i++) {
     if (!config.screens()[i].isNull()) {
       outStream << "\t" << config.screens()[i].name() << ":" << Qt::endl;
 
@@ -275,6 +277,7 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
           outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << Qt::endl;
       }
     }
+  }
 
   outStream << "end" << Qt::endl << Qt::endl;
 
@@ -325,7 +328,7 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   outStream << "\t"
             << "switchCornerSize = " << config.switchCornerSize() << Qt::endl;
 
-  foreach (const Hotkey &hotkey, config.hotkeys())
+  for (const Hotkey &hotkey : config.hotkeys())
     outStream << hotkey;
 
   outStream << "end" << Qt::endl << Qt::endl;
@@ -337,9 +340,10 @@ int ServerConfig::numScreens() const
 {
   int rval = 0;
 
-  foreach (const Screen &s, screens())
+  for (const Screen &s : screens()) {
     if (!s.isNull())
       rval++;
+  }
 
   return rval;
 }

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -77,7 +77,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config, Ap
   ui->m_pSpinBoxClipboardSizeLimit->setValue(clipboardSharingSizeM);
   ui->m_pSpinBoxClipboardSizeLimit->setEnabled(serverConfig().clipboardSharing());
 
-  foreach (const Hotkey &hotkey, serverConfig().hotkeys())
+  for (const Hotkey &hotkey : serverConfig().hotkeys())
     ui->m_pListHotkeys->addItem(hotkey.text());
 
   ui->m_pScreenSetupView->setModel(&m_ScreenSetupModel);
@@ -353,7 +353,7 @@ void ServerConfigDialog::on_m_pListHotkeys_itemSelectionChanged()
     Q_ASSERT(idx >= 0 && idx < serverConfig().hotkeys().size());
 
     const Hotkey &hotkey = serverConfig().hotkeys()[idx];
-    foreach (const Action &action, hotkey.actions())
+    for (const Action &action : hotkey.actions())
       ui->m_pListActions->addItem(action.text());
   }
 }

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -77,7 +77,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config, Ap
   ui->m_pSpinBoxClipboardSizeLimit->setValue(clipboardSharingSizeM);
   ui->m_pSpinBoxClipboardSizeLimit->setEnabled(serverConfig().clipboardSharing());
 
-  for (const Hotkey &hotkey : serverConfig().hotkeys())
+  for (const Hotkey &hotkey : std::as_const(serverConfig().hotkeys()))
     ui->m_pListHotkeys->addItem(hotkey.text());
 
   ui->m_pScreenSetupView->setModel(&m_ScreenSetupModel);

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -26,8 +26,6 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QtCore>
-#include <QtGui>
 
 using enum ScreenConfig::SwitchCorner;
 using ServerProtocol = synergy::gui::ServerProtocol;

--- a/src/gui/src/TrashScreenWidget.cpp
+++ b/src/gui/src/TrashScreenWidget.cpp
@@ -17,10 +17,12 @@
  */
 
 #include "TrashScreenWidget.h"
-#include "ScreenSetupModel.h"
 
-#include <QtCore>
-#include <QtGui>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMimeData>
+
+#include "ScreenSetupModel.h"
 
 void TrashScreenWidget::dragEnterEvent(QDragEnterEvent *event)
 {

--- a/src/gui/src/TrashScreenWidget.cpp
+++ b/src/gui/src/TrashScreenWidget.cpp
@@ -37,7 +37,7 @@ void TrashScreenWidget::dropEvent(QDropEvent *event)
 {
   if (event->mimeData()->hasFormat(ScreenSetupModel::mimeType())) {
     event->acceptProposedAction();
-    emit screenRemoved();
+    Q_EMIT screenRemoved();
   } else {
     event->ignore();
   }

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -40,9 +40,7 @@
 #include <QGuiApplication>
 #include <QMessageBox>
 #include <QObject>
-#include <QtCore>
 #include <QtGlobal>
-#include <QtGui>
 
 #if defined(Q_OS_MAC)
 #include <Carbon/Carbon.h>

--- a/src/lib/arch/unix/ArchSystemUnix.cpp
+++ b/src/lib/arch/unix/ArchSystemUnix.cpp
@@ -20,8 +20,12 @@
 #include <array>
 
 #include <sys/utsname.h>
+
 #ifndef __APPLE__
-#include <QtDBus>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <QDBusInterface>
+#include <QDBusReply>
 #endif
 
 //

--- a/src/lib/gui/Logger.cpp
+++ b/src/lib/gui/Logger.cpp
@@ -123,7 +123,7 @@ void Logger::handleMessage(const QtMsgType type, const QString &fileLine, const 
   }
 
   const auto logLine = printLine(out, typeString, message, fileLine);
-  emit newLine(logLine);
+  Q_EMIT newLine(logLine);
 }
 
 } // namespace deskflow::gui

--- a/src/lib/gui/Logger.cpp
+++ b/src/lib/gui/Logger.cpp
@@ -42,7 +42,7 @@ QString printLine(FILE *out, const QString &type, const QString &message, const 
 {
 
   auto datetime = QDateTime::currentDateTime().toString("yyyy-MM-ddTHH:mm:ss");
-  auto logLine = QString("[%1] %2: %3").arg(datetime).arg(type).arg(message);
+  auto logLine = QString("[%1] %2: %3").arg(datetime, type, message);
 
   QTextStream stream(&logLine);
   stream << Qt::endl;

--- a/src/lib/gui/VersionChecker.cpp
+++ b/src/lib/gui/VersionChecker.cpp
@@ -108,9 +108,6 @@ int VersionChecker::compareVersions(const QString &left, const QString &right)
   QStringList leftParts = left.split("-");
   QStringList rightParts = right.split("-");
 
-  QString leftNumber = leftParts.at(0);
-  QString rightNumber = rightParts.at(0);
-
   QStringList leftNumberParts = left.split(".");
   QStringList rightNumberParts = right.split(".");
 

--- a/src/lib/gui/VersionChecker.cpp
+++ b/src/lib/gui/VersionChecker.cpp
@@ -86,11 +86,12 @@ int VersionChecker::getStageVersion(QString stage)
   if (stage.isEmpty() || stage == stableName) {
     return stableValue;
   } else if (stage.toLower().startsWith(rcName)) {
-    QRegularExpression re("\\d*", QRegularExpression::CaseInsensitiveOption);
-    if (re.match(stage).hasMatch()) {
+    static QRegularExpression re("\\d*", QRegularExpression::CaseInsensitiveOption);
+    auto match = re.match(stage);
+    if (match.hasMatch()) {
       // return the rc value plus the rc number (e.g. 2 + 1)
       // this should be ok since stable is max int.
-      return rcValue + re.match(stage).captured(1).toInt();
+      return rcValue + match.captured(1).toInt();
     }
   } else if (stage == betaName) {
     return betaValue;

--- a/src/lib/gui/VersionChecker.cpp
+++ b/src/lib/gui/VersionChecker.cpp
@@ -42,7 +42,7 @@ void VersionChecker::checkLatest() const
   const QString url = env_vars::versionUrl();
   qDebug("checking for updates at: %s", qPrintable(url));
   auto request = QNetworkRequest(url);
-  auto userAgent = QString("%1 %2 on %3").arg(kAppName).arg(kVersion).arg(QSysInfo::prettyProductName());
+  auto userAgent = QString("%1 %2 on %3").arg(kAppName, kVersion, QSysInfo::prettyProductName());
   request.setHeader(QNetworkRequest::UserAgentHeader, userAgent);
   request.setRawHeader("X-" DESKFLOW_APP_NAME "-Version", kVersion);
   request.setRawHeader("X-" DESKFLOW_APP_NAME "-Language", QLocale::system().name().toStdString().c_str());

--- a/src/lib/gui/VersionChecker.cpp
+++ b/src/lib/gui/VersionChecker.cpp
@@ -65,7 +65,7 @@ void VersionChecker::replyFinished(QNetworkReply *reply)
 
   if (!newestVersion.isEmpty() && compareVersions(DESKFLOW_VERSION, newestVersion) > 0) {
     qDebug("update found");
-    emit updateFound(newestVersion);
+    Q_EMIT updateFound(newestVersion);
   } else {
     qDebug("no updates found");
   }

--- a/src/lib/gui/config/AppConfig.cpp
+++ b/src/lib/gui/config/AppConfig.cpp
@@ -220,7 +220,7 @@ void AppConfig::commit()
 
   if (m_TlsChanged) {
     m_TlsChanged = false;
-    emit tlsChanged();
+    Q_EMIT tlsChanged();
   }
 }
 
@@ -663,7 +663,7 @@ void AppConfig::setLastVersion(const QString &version)
 void AppConfig::setScreenName(const QString &s)
 {
   m_ScreenName = s;
-  emit screenNameChanged();
+  Q_EMIT screenNameChanged();
 }
 
 void AppConfig::setPort(int i)
@@ -739,7 +739,7 @@ void AppConfig::setCloseToTray(bool minimize)
 void AppConfig::setInvertConnection(bool value)
 {
   m_InvertConnection = value;
-  emit invertConnectionChanged();
+  Q_EMIT invertConnectionChanged();
 }
 
 void AppConfig::setMainWindowSize(const QSize &size)

--- a/src/lib/gui/config/AppConfig.cpp
+++ b/src/lib/gui/config/AppConfig.cpp
@@ -24,8 +24,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QVariant>
-#include <QtCore>
-#include <QtNetwork>
 #include <functional>
 
 using namespace deskflow::gui;

--- a/src/lib/gui/config/ConfigScopes.cpp
+++ b/src/lib/gui/config/ConfigScopes.cpp
@@ -65,14 +65,14 @@ void ConfigScopes::clear() const
 
 void ConfigScopes::signalReady()
 {
-  emit ready();
+  Q_EMIT ready();
 }
 
 void ConfigScopes::save(bool emitSaving)
 {
   if (emitSaving) {
     qDebug("emitting config saving signal");
-    emit saving();
+    Q_EMIT saving();
   }
 
   qDebug("writing config to filesystem");

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -119,7 +119,7 @@ QTextStream &Screen::writeAliasesSection(QTextStream &outStream) const
   if (!aliases().isEmpty()) {
     outStream << "\t" << name() << ":" << Qt::endl;
 
-    foreach (const QString &alias, aliases())
+    for (const QString &alias : aliases())
       outStream << "\t\t" << alias << Qt::endl;
   }
 

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -19,9 +19,6 @@
 #include "Screen.h"
 #include "config/ScreenConfig.h"
 
-#include <QtCore>
-#include <QtGui>
-
 using namespace deskflow::gui::proxy;
 using enum ScreenConfig::Modifier;
 using enum ScreenConfig::SwitchCorner;

--- a/src/lib/gui/core/ClientConnection.cpp
+++ b/src/lib/gui/core/ClientConnection.cpp
@@ -66,7 +66,7 @@ void ClientConnection::showMessage(const QString &logLine)
 {
   using enum messages::ClientError;
 
-  emit messageShowing();
+  Q_EMIT messageShowing();
 
   const auto address = m_appConfig.serverHostname();
 

--- a/src/lib/gui/core/ClientConnection.cpp
+++ b/src/lib/gui/core/ClientConnection.cpp
@@ -69,7 +69,6 @@ void ClientConnection::showMessage(const QString &logLine)
   emit messageShowing();
 
   const auto address = m_appConfig.serverHostname();
-  auto message = QString("<p>The connection to server '%1' didn't work.</p>").arg(address);
 
   if (logLine.contains("server already has a connected client with our name")) {
     m_deps->showError(m_pParent, AlreadyConnected, address);

--- a/src/lib/gui/core/CommandProcess.cpp
+++ b/src/lib/gui/core/CommandProcess.cpp
@@ -53,7 +53,7 @@ QString CommandProcess::run()
     );
   }
 
-  emit finished();
+  Q_EMIT finished();
 
   return output;
 }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -645,7 +645,6 @@ bool CoreProcess::addClientArgs(QStringList &args, QString &app)
 
 QString CoreProcess::persistServerConfig() const
 {
-  QString configFullPath;
   if (m_appConfig.useExternalConfig()) {
     return m_appConfig.configFile();
   }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -287,7 +287,7 @@ void CoreProcess::startDesktop(const QString &app, const QStringList &args)
     setProcessState(Started);
   } else {
     setProcessState(Stopped);
-    emit error(Error::StartFailed);
+    Q_EMIT error(Error::StartFailed);
   }
 }
 
@@ -365,7 +365,7 @@ void CoreProcess::handleLogLines(const QString &text)
 #endif
 
     checkLogLine(line);
-    emit logLine(line);
+    Q_EMIT logLine(line);
   }
 }
 
@@ -384,7 +384,7 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
 
   // allow external listeners to abort the start process (e.g. licensing issue).
   setProcessState(ProcessState::Starting);
-  emit starting();
+  Q_EMIT starting();
   if (m_processState == ProcessState::Stopped) {
     qDebug("core process start was cancelled by listener");
     return;
@@ -574,7 +574,7 @@ bool CoreProcess::addServerArgs(QStringList &args, QString &app)
     qDebug("inverting server connection");
 
     if (correctedAddress().isEmpty()) {
-      emit error(Error::AddressMissing);
+      Q_EMIT error(Error::AddressMissing);
       qDebug("address is missing for server args");
       return false;
     }
@@ -632,7 +632,7 @@ bool CoreProcess::addClientArgs(QStringList &args, QString &app)
   } else {
 
     if (correctedAddress().isEmpty()) {
-      emit error(Error::AddressMissing);
+      Q_EMIT error(Error::AddressMissing);
       qDebug("address is missing for client args");
       return false;
     }
@@ -684,7 +684,7 @@ void CoreProcess::setConnectionState(ConnectionState state)
   }
 
   m_connectionState = state;
-  emit connectionStateChanged(state);
+  Q_EMIT connectionStateChanged(state);
 }
 
 void CoreProcess::setProcessState(ProcessState state)
@@ -698,7 +698,7 @@ void CoreProcess::setProcessState(ProcessState state)
       qPrintable(processStateToString(m_processState)), qPrintable(processStateToString(state))
   );
   m_processState = state;
-  emit processStateChanged(state);
+  Q_EMIT processStateChanged(state);
 }
 
 void CoreProcess::checkLogLine(const QString &line)
@@ -733,7 +733,7 @@ bool CoreProcess::checkSecureSocket(const QString &line)
     return false;
   }
 
-  emit secureSocket(true);
+  Q_EMIT secureSocket(true);
   m_secureSocketVersion = line.mid(index + tlsCheckString.size());
   return true;
 }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -97,7 +97,7 @@ QString makeQuotedArgs(const QString &app, const QStringList &args)
   command << args;
 
   QStringList quoted;
-  for (const auto &arg : command) {
+  for (const auto &arg : std::as_const(command)) {
     if (arg.contains(' ')) {
       quoted << QString("\"%1\"").arg(arg);
     } else {
@@ -350,7 +350,8 @@ void CoreProcess::stopService()
 
 void CoreProcess::handleLogLines(const QString &text)
 {
-  for (const auto &line : text.split(kLineSplitRegex)) {
+  const auto lines = text.split(kLineSplitRegex);
+  for (const auto &line : lines) {
     if (line.isEmpty()) {
       continue;
     }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -188,7 +188,7 @@ CoreProcess::CoreProcess(const IAppConfig &appConfig, const IServerConfig &serve
       &m_pDeps->process(), &QProcessProxy::readyReadStandardError, this, &CoreProcess::onProcessReadyReadStandardError
   );
 
-  connect(&m_retryTimer, &QTimer::timeout, [this] {
+  connect(&m_retryTimer, &QTimer::timeout, this, [this] {
     if (m_processState == ProcessState::RetryPending) {
       start();
     } else {

--- a/src/lib/gui/core/ServerConnection.cpp
+++ b/src/lib/gui/core/ServerConnection.cpp
@@ -101,7 +101,7 @@ void ServerConnection::handleNewClient(const QString &clientName)
     return;
   }
 
-  emit messageShowing();
+  Q_EMIT messageShowing();
 
   m_messageShowing = true;
   const auto result = m_pDeps->showNewClientPrompt(m_pParent, clientName);
@@ -109,7 +109,7 @@ void ServerConnection::handleNewClient(const QString &clientName)
 
   if (result == Add) {
     qDebug("accepted dialog, adding client: %s", qPrintable(clientName));
-    emit configureClient(clientName);
+    Q_EMIT configureClient(clientName);
   } else if (result == Ignore) {
     qDebug("declined dialog, ignoring client: %s", qPrintable(clientName));
   } else {

--- a/src/lib/gui/dialogs/AboutDialog.cpp
+++ b/src/lib/gui/dialogs/AboutDialog.cpp
@@ -24,7 +24,6 @@
 
 #include <QDateTime>
 #include <QGuiApplication>
-#include <QtCore>
 
 using namespace deskflow::gui;
 

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -157,7 +157,7 @@ void SettingsDialog::on_m_pCheckBoxServiceEnabled_toggled(bool)
 void SettingsDialog::showEvent(QShowEvent *event)
 {
   QDialog::showEvent(event);
-  emit shown();
+  Q_EMIT shown();
 }
 
 void SettingsDialog::showReadOnlyMessage()

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -33,8 +33,6 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QtCore>
-#include <QtGui>
 
 using namespace deskflow::gui;
 

--- a/src/lib/gui/env_vars.h
+++ b/src/lib/gui/env_vars.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <QString>
-#include <QtCore>
 
 namespace deskflow::gui::env_vars {
 

--- a/src/lib/gui/ipc/IpcReader.cpp
+++ b/src/lib/gui/ipc/IpcReader.cpp
@@ -65,10 +65,10 @@ void IpcReader::onSocketReadyRead()
       readStream(dataBuf.data(), len);
       QString text = QString::fromUtf8(dataBuf.data(), len);
 
-      emit read(text);
+      Q_EMIT read(text);
     } else if (memcmp(codeBuf, kIpcMsgHelloBack, 4) == 0) {
       logVerbose("reading hello back");
-      emit helloBack();
+      Q_EMIT helloBack();
     } else {
       qCritical("aborting ipc read, message invalid");
       return;

--- a/src/lib/gui/ipc/QIpcClient.cpp
+++ b/src/lib/gui/ipc/QIpcClient.cpp
@@ -167,10 +167,10 @@ void QIpcClient::onIpcReaderHelloBack()
   }
 
   m_isConnected = true;
-  serviceReady();
+  Q_EMIT serviceReady();
 }
 
 void QIpcClient::onIpcReaderRead(const QString &text)
 {
-  emit read(text);
+  Q_EMIT read(text);
 }

--- a/src/lib/gui/proxy/QNetworkAccessManagerProxy.cpp
+++ b/src/lib/gui/proxy/QNetworkAccessManagerProxy.cpp
@@ -27,7 +27,7 @@ void QNetworkAccessManagerProxy::init()
   m_network = std::make_shared<QNetworkAccessManager>();
 
   connect(m_network.get(), &QNetworkAccessManager::finished, this, [this](QNetworkReply *reply) {
-    emit finished(reply);
+    Q_EMIT finished(reply);
   });
 }
 

--- a/src/lib/gui/proxy/QProcessProxy.cpp
+++ b/src/lib/gui/proxy/QProcessProxy.cpp
@@ -24,17 +24,17 @@ void QProcessProxy::create()
   m_pProcess = std::make_unique<QProcess>();
 
   connect(m_pProcess.get(), &QProcess::finished, this, [this](int exitCode, QProcess::ExitStatus exitStatus) {
-    emit finished(exitCode, exitStatus);
+    Q_EMIT finished(exitCode, exitStatus);
   });
 
   connect(
       m_pProcess.get(), &QProcess::readyReadStandardOutput, //
-      this, [this]() { emit readyReadStandardOutput(); }
+      this, [this]() { Q_EMIT readyReadStandardOutput(); }
   );
 
   connect(
       m_pProcess.get(), &QProcess::readyReadStandardError, //
-      this, [this]() { emit readyReadStandardError(); }
+      this, [this]() { Q_EMIT readyReadStandardError(); }
   );
 }
 

--- a/src/lib/gui/proxy/QSettingsProxy.cpp
+++ b/src/lib/gui/proxy/QSettingsProxy.cpp
@@ -73,7 +73,8 @@ void migrateLegacySystemSettings(QSettings &settings)
   );
 
   if (QFile(oldSystemSettings.fileName()).exists()) {
-    for (const auto &key : oldSystemSettings.allKeys()) {
+    const auto keys = oldSystemSettings.allKeys();
+    for (const auto &key : keys) {
       settings.setValue(key, oldSystemSettings.value(key));
     }
   }
@@ -112,7 +113,7 @@ void migrateLegacyUserSettings(QSettings &newSettings)
   );
 
   QStringList keys = oldSettings.allKeys();
-  for (const QString &key : keys) {
+  for (const QString &key : std::as_const(keys)) {
     QVariant oldValue = oldSettings.value(key);
     newSettings.setValue(key, oldValue);
     logVerbose(QString("migrating setting '%1' = '%2'").arg(key, oldValue.toString()));

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -116,7 +116,7 @@ bool TlsCertificate::runTool(const QStringList &args)
 
   QProcess process;
   process.setEnvironment(environment);
-  for (const auto &envVar : environment) {
+  for (const auto &envVar : std::as_const(environment)) {
     qDebug("set env var: %s", qUtf8Printable(envVar));
   }
 

--- a/src/lib/gui/tls/TlsFingerprint.cpp
+++ b/src/lib/gui/tls/TlsFingerprint.cpp
@@ -64,8 +64,8 @@ bool TlsFingerprint::fileExists() const
 
 bool TlsFingerprint::isTrusted(const QString &fingerprintText) const
 {
-  QStringList list = readList();
-  for (QString trusted : list) {
+  const QStringList list = readList();
+  for (const auto &trusted : list) {
     if (trusted == fingerprintText) {
       return true;
     }

--- a/src/lib/gui/tls/TlsFingerprint.cpp
+++ b/src/lib/gui/tls/TlsFingerprint.cpp
@@ -65,7 +65,7 @@ bool TlsFingerprint::fileExists() const
 bool TlsFingerprint::isTrusted(const QString &fingerprintText) const
 {
   QStringList list = readList();
-  foreach (QString trusted, list) {
+  for (QString trusted : list) {
     if (trusted == fingerprintText) {
       return true;
     }

--- a/src/lib/gui/tls/TlsFingerprint.cpp
+++ b/src/lib/gui/tls/TlsFingerprint.cpp
@@ -107,7 +107,7 @@ QString TlsFingerprint::readFirst() const
 QString TlsFingerprint::filePath() const
 {
   QString dir = TlsFingerprint::directoryPath();
-  return QString("%1/%2").arg(dir).arg(m_Filename);
+  return QString("%1/%2").arg(dir, m_Filename);
 }
 
 void TlsFingerprint::persistDirectory()
@@ -123,7 +123,7 @@ QString TlsFingerprint::directoryPath()
   CoreTool coreTool;
   QString profileDir = coreTool.getProfileDir();
 
-  return QString("%1/%2").arg(profileDir).arg(kDirName);
+  return QString("%1/%2").arg(profileDir, kDirName);
 }
 
 TlsFingerprint TlsFingerprint::local()

--- a/src/lib/gui/validators/ComputerNameValidator.cpp
+++ b/src/lib/gui/validators/ComputerNameValidator.cpp
@@ -27,10 +27,8 @@ ComputerNameValidator::ComputerNameValidator(const QString &message) : IStringVa
 
 bool ComputerNameValidator::validate(const QString &input) const
 {
-  const QRegularExpression re("^[\\w\\._-]{0,255}$", QRegularExpression::CaseInsensitiveOption);
-  auto match = re.match(input);
-  auto result = match.hasMatch();
-  return result;
+  auto match = m_nameValidator.match(input);
+  return match.hasMatch();
 }
 
 } // namespace validators

--- a/src/lib/gui/validators/ComputerNameValidator.h
+++ b/src/lib/gui/validators/ComputerNameValidator.h
@@ -28,6 +28,10 @@ class ComputerNameValidator : public IStringValidator
 public:
   explicit ComputerNameValidator(const QString &message);
   bool validate(const QString &input) const override;
+
+private:
+  inline static const QRegularExpression m_nameValidator =
+      QRegularExpression(QStringLiteral("^[\\w\\._-]{0,255}$"), QRegularExpression::CaseInsensitiveOption);
 };
 
 } // namespace validators

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -16,8 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QString>
 #ifndef __APPLE__
-#include <QtDBus>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusPendingReply>
 #endif
 
 #include "platform/XWindowsKeyState.h"


### PR DESCRIPTION
- remove `foreach` macro for c++11 style ranged for
- ensure ranged loops do not detach
- Use Q_EMIT in place of emit 
- Do not #include full QModules 
- use multi arg
- add context object for lambdas