### PR TITLE
docs: Remove confusing value line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ To use Deskflow you can use one of our [packages](https://github.com/deskflow/de
 
 - Motivated by the community interests (not business-driven)
 - Privacy by default (e.g. update check is off by default)
-- Nothing customer-related (this is all moved downstream to Synergy)
 - Leading edge releases (we don't focus on supporting older systems)
 - Decisions are discussed and documented publicly with majority rule
 - Have fun; we don't need to worry about impressing anyone


### PR DESCRIPTION
# Problem

Someone told me they got confused when they read this recently:
> Nothing customer-related (this is all moved downstream to Synergy)

They thought it meant:
> "No GUI here, downstream keeps all the good stuff to themselves."

People are cynical.

Perhaps we should remove it, or reword it?

# Original intent

The original intent was to mean:

> "We removed the code that checks for serial keys, switches features based on the serial key, etc. That is now only in Synergy downstream."

It was also meant to communicate:

> "Deskflow isn't orchestrated by Symless and isn't directed to satisfy only Synergy customer needs."

# Alternatives

Perhaps one of these ideas or something else:
- We don't put the cart before the horse; downstream does not dictate what we work on.
- Commercial needs have been moved downstream, keeping us focused on open development.
- Serial key requirement and feature gating have been moved entirely downstream.
- Free from commercial dependencies, with those aspects managed separately downstream.
- No commercial constraints here; those are now handled downstream, keeping the project open.