### PR TITLE
docs: Make unstable download clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ and work seamlessly between them.
 It's like a software KVM (but without the video).
 TLS encryption is enabled by default. Wayland is supported. Clipboard sharing is supported.
 
-[![Downloads: Stable Release](https://img.shields.io/github/downloads/deskflow/deskflow/v1.17.0/total?style=for-the-badge&logo=github&label=Download%20Stable)](https://github.com/deskflow/deskflow/releases/tag/v1.17.0)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Downloads: Continuous Build](https://img.shields.io/github/downloads/deskflow/deskflow/continuous/total?style=for-the-badge&logo=github&label=Download%20Continuous)](https://github.com/deskflow/deskflow/releases)
+[![Downloads: Stable Release](https://img.shields.io/github/downloads/deskflow/deskflow/v1.17.0/total?style=for-the-badge&logo=github&label=Download%20Stable)](https://github.com/deskflow/deskflow/releases/tag/v1.17.0) &nbsp;&nbsp;
+[![Downloads: Unstable Continuous](https://img.shields.io/github/downloads/deskflow/deskflow/continuous/total?style=for-the-badge&logo=github&label=Download%20Unstable%20Continuous)](https://github.com/deskflow/deskflow/releases)
 
 To use Deskflow you can use one of our [packages](https://github.com/deskflow/deskflow/releases), install `deskflow` (if available in your package repository), or [build it](#build-quick-start) yourself from source.
 


### PR DESCRIPTION
Some users may be downloading the continuous build thinking it's stable. e.g. Continuous doesn't work with Wayland on Ubuntu right now.

Maybe we should warn them that it's unstable, otherwise perhaps it's unfair on them.

Only an idea, happy for this to not be landed. This change it makes the button a bit uglier, and also makes the button a bit bigger which may backfire due to prominence effect, aka big red button effect.

[Preview](https://github.com/deskflow/deskflow/blob/readme-unstable/README.md)