### PR TITLE
chore: add link to wayland discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
       label: Wayland on Linux
       description: If using Wayland on Linux, please review the [known issues](https://github.com/deskflow/deskflow/discussions/7499) before reporting.
       options:
-        - label: I have reviewed the Wayland known issues and my issue is new
+        - label: I have reviewed the Wayland [known issues](https://github.com/deskflow/deskflow/discussions/7499) and my issue is new
         - label: I am not using Wayland on Linux
 
   - type: checkboxes


### PR DESCRIPTION
added an additional link to the linux wayland question pointing to the discussion