### PR TITLE
doc: correct target for documents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,7 @@ configure_build()
 configure_libs()
 configure_packaging()
 
-option(BUILD_DOCS "Build documentation" ON)
 add_subdirectory(doc)
-
 add_subdirectory(src)
 
 post_config_all()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 find_package(Doxygen QUIET)
-option(DOCS "Build and Install Documents" ${DOXYGEN_FOUND})
+option(BUILD_DOCS "Build and Install Documents" ${DOXYGEN_FOUND})
 
-if(DOCS)
+if(BUILD_DOCS)
   set(DOXYGEN_EXTRACT_ALL YES)
   set(DOXYGEN_STRIP_FROM_PATH ${CMAKE_SOURCE_DIR})
   set(DOXYGEN_USE_MDFILE_AS_MAINPAGE mainpage.md)
@@ -15,7 +15,7 @@ if(DOCS)
   doxygen_add_docs(user-docs ${CMAKE_SOURCE_DIR}/doc COMMENT "Generating User Documentation" ALL)
 
   # HACK Only these will show in your IDE
-  target_sources(docs PRIVATE
+  target_sources(user-docs PRIVATE
     mainpage.md
     configuration.md
   )


### PR DESCRIPTION
typo doc target is `user-docs`
- Remove `DOCS` option for `BUILD_DOCS` 
Breaks builds with `BUILD_DOCS` on or doxygen and it not specified . 