### PR TITLE
ci: use pre-release for continuous to stop it from grabbing latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "continuous"
-          prerelease: false
+          prerelease: true
           title: "Continuous Build"
           files: |
             package-*/*


### PR DESCRIPTION
This is in response to the discussion  https://github.com/deskflow/deskflow/discussions/7837 

 Ideally we would like to have the continuous not marked a pre-release while also not being tagged the `latest` release . Since we are not able todo this without making the release step more complicated then it should be we will use `pre-release` until we are able to either not create or not hyjack the latest tag.