### PR TITLE
ci: git-version-action: Always report described version

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -6,9 +6,5 @@ runs:
 
   steps:
     - run: |
-        if [[ "$GITHUB_REF" == *"tags/v"* ]]; then
-          echo "DESKFLOW_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-        else
-          echo "DESKFLOW_VERSION=$(git describe --long | sed 's/-/./g;s/v//g'  | grep -o '^[0-9]*.[0-9]*.[0-9]*.[0-9]*')">> $GITHUB_ENV
-        fi
+        echo "DESKFLOW_VERSION=$(git describe --long | sed 's/-/./g;s/v//g'  | grep -o '^[0-9]*.[0-9]*.[0-9]*.[0-9]*')">> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
 the get-version action should always return a full 4 part version string from describe