### PR TITLE
build: Add Nix Flake & derivation scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/valgrind-analysis.yml
 
+  nix-tests:
+    needs: lint-clang
+    uses: ./.github/workflows/nix-tests.yml
+
   analyse-sonarcloud:
     needs: pr-comment-flags
     if: ${{ needs.pr-comment-flags.outputs.no-sonar != 'true' }}

--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -1,0 +1,26 @@
+---
+name: Nix packaging tests
+
+on:
+  workflow_call:
+
+jobs:
+  check-nix-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix flake check --show-trace --print-build-logs --accept-flake-config --all-systems
+
+  build-nix-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build --print-build-logs --accept-flake-config

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024 The DeckCheatz Developers
+#
+# SPDX-License-Identifier: Apache-2.0
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/deskflow.nix
+++ b/deskflow.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  pkgs,
+  python3,
+  stdenv,
+  cmake,
+  withLibei ? true,
+  avahi,
+  curl,
+  libICE,
+  libSM,
+  libX11,
+  libXdmcp,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  libxkbfile,
+  openssl,
+  pkg-config,
+  qt6,
+  wrapGAppsHook3,
+  pugixml,
+  libnotify,
+  gtest,
+  lerc,
+  cli11,
+  tomlplusplus,
+}:
+let
+  isDarwin = lib.hasSuffix "-darwin" pkgs.system;
+in
+stdenv.mkDerivation rec {
+  pname = "deskflow";
+  version = "unstable";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    wrapGAppsHook3
+    qt6.wrapQtAppsHook
+    qt6.qttools
+  ];
+  buildInputs =
+    [
+      curl
+      qt6.qtbase
+      (avahi.override { withLibdnssdCompat = true; })
+      openssl
+      libX11
+      libXext
+      libXtst
+      libXinerama
+      libXrandr
+      libXdmcp
+      libxkbfile
+      libICE
+      libSM
+      pugixml
+      python3
+      libnotify
+      gtest
+      lerc
+      cli11
+      tomlplusplus
+    ]
+    ++ lib.optionals (withLibei && !isDarwin) (
+      with pkgs;
+      [
+        libei
+        libportal
+        qt6.qtwayland
+      ]
+    );
+
+  cmakeFlags = [
+    "-DDESKFLOW_REVISION=${version}"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+        --prefix PATH : "${lib.makeBinPath [ openssl ]}"
+    )
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/applications/deskflow.desktop \
+      --replace "Exec=deskflow" "Exec=$out/bin/deskflow"
+  '';
+
+  meta = with lib; {
+    description = "Mouse and keyboard sharing utility";
+    longDescription = ''
+      Deskflow lets you share one mouse and keyboard between multiple computers on Windows, macOS and Linux.
+      It's like a software KVM (but without video). 
+    '';
+    homepage = "https://github.com/deskflow/deskflow";
+    license = licenses.gpl2;
+    mainProgram = "deskflow";
+    maintainers = with maintainers; [ shymega ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Nix Flake for Deskflow";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.outputs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          deskflow = pkgs.qt6Packages.callPackage ./deskflow.nix { };
+          default = self.packages.${system}.deskflow;
+        };
+
+        devShells.default = pkgs.mkShell { buildInputs = [ self.packages.${system}.default ]; };
+      }
+    )
+    // {
+      overlays.default = final: prev: { inherit (self.packages.${final.system}) deskflow; };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Dom Rodriguez <shymega@shymega.org.uk>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
Blocked by: #7858

build: Add Nix Flake & derivation scaffolding
Also added a CI workflow for the Flake and derivation checks. Will be
upstreaming the derivation to Nixpkgs, but only on Deskflow releases.

Having the Flake & derivation in this repo allows people to build from
Git, or enter a development environment.

You will see `/.envrc` - this is for `direnv`, and if people have Nix
installed, it will automatically generate a developer environment,
Nixified.

One big benefit is that people can simply run the command:

`nix run github:deskflow/deskflow` - and Nix will fetch the latest
commit, build, and run Deskflow in one hit.

Later on, we should add 'Cachix' support, which means binaries will be
built and hosted on a Nix cache. This is free of charge.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>