### PR TITLE
build: add deskflow devs to binaries copyright

### DIFF
--- a/res/dist/mac/bundle/Contents/Info.plist.in
+++ b/res/dist/mac/bundle/Contents/Info.plist.in
@@ -24,7 +24,7 @@
     <key>CFBundleVersion</key>
     <string>@DESKFLOW_VERSION@</string>
     <key>NSHumanReadableCopyright</key>
-    <string>© 2012-@DESKFLOW_BUILD_YEAR@ Symless Ltd</string>
+    <string>© 2024 Deskflow Developers</string>
     <key>LSMinimumSystemVersion</key>
     <string>10.9.0</string>
   </dict>

--- a/res/win/version.rc.in
+++ b/res/win/version.rc.in
@@ -15,7 +15,7 @@ https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource?redi
 #define VER_COMPANYNAME_STR         "@DESKFLOW_AUTHOR_NAME@\0"
 #define VER_FILEDESCRIPTION_STR     "@DESKFLOW_APP_NAME@\0"
 #define VER_INTERNALNAME_STR        "@DESKFLOW_APP_NAME@\0"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) Symless Ltd. @DESKFLOW_BUILD_YEAR@\0"
+#define VER_LEGALCOPYRIGHT_STR      "© 2024 Deskflow Developers\0"
 #define VER_LEGALTRADEMARKS1_STR    "All Rights Reserved\0"
 #define VER_LEGALTRADEMARKS2_STR    "\0"
 #define VER_ORIGINALFILENAME_STR    "\0"

--- a/res/win/version.rc.in
+++ b/res/win/version.rc.in
@@ -10,7 +10,7 @@ https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource?redi
 #define VER_FILEVERSION_STR         "@DESKFLOW_VERSION_MS@\0"
 
 #define VER_PRODUCTVERSION          @DESKFLOW_VERSION_MS_CSV@
-#define VER_PRODUCTVERSION_STR      "@DESKFLOW_VERSION_MS@\0"
+#define VER_PRODUCTVERSION_STR      "@DESKFLOW_VERSION@\0"
 
 #define VER_COMPANYNAME_STR         "@DESKFLOW_AUTHOR_NAME@\0"
 #define VER_FILEDESCRIPTION_STR     "@DESKFLOW_APP_NAME@\0"


### PR DESCRIPTION
Have the entry for windows / mac binaries say 

© 2024 Deskflow Developers
