### PR TITLE
chore: Replace screen leave/enter asserts with warnings

### DIFF
--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -125,8 +125,11 @@ void Screen::disable()
 
 void Screen::enter(KeyModifierMask toggleMask)
 {
-  assert(m_entered == false);
   LOG((CLOG_INFO "entering screen"));
+
+  if (m_entered) {
+    LOG_WARN("screen already entered");
+  }
 
   // now on screen
   m_entered = true;
@@ -141,8 +144,11 @@ void Screen::enter(KeyModifierMask toggleMask)
 
 bool Screen::leave()
 {
-  assert(m_entered == true);
   LOG((CLOG_INFO "leaving screen"));
+
+  if (!m_entered) {
+    LOG_WARN("screen already left");
+  }
 
   if (!m_screen->canLeave()) {
     return false;


### PR DESCRIPTION
These asserts in particular keep catching me in debug. They don't seem to have any adverse effect in release build, so they'll probably be more useful as warnings.

Related to, but doesn't necessarily solve: #7863