### PR TITLE
Prepare 1.17.1

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -8,7 +8,7 @@ runs:
     - run: |
         echo "DESKFLOW_VERSION=$(git describe --long | sed 's/-/./g;s/v//g'  | grep -o '^[0-9]*.[0-9]*.[0-9]*.[0-9]*')">> $GITHUB_ENV
         if [[ "$GITHUB_REF" == *"tags/v"* ]]; then
-          echo "DESKFLOW_PACKAGE_VERSION=$(echo $GITHUB_REF | sed 's/v//g')">> $GITHUB_ENV
+          echo "DESKFLOW_PACKAGE_VERSION=$(echo $GITHUB_REF | sed 's,refs/tags/v,,g')">> $GITHUB_ENV
         else
           echo "DESKFLOW_PACKAGE_VERSION=continuous">> $GITHUB_ENV
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
 
   release:
     needs: ci-passed
-    if: (github.ref == 'refs/heads/master')
+    if: (github.ref == 'refs/heads/master') || (contains(github.ref, '/tags/v'))
     runs-on: ubuntu-latest
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ cmake_minimum_required(VERSION 3.24)
 # Fallback for when git can not be found
 set(DESKFLOW_VERSION_MAJOR 1)
 set(DESKFLOW_VERSION_MINOR 17)
-set(DESKFLOW_VERSION_PATCH 0)
+set(DESKFLOW_VERSION_PATCH 1)
 set(DESKFLOW_VERSION_TWEAK 0)
 
 # Get the version from git if it's a git repository


### PR DESCRIPTION
A Change to the release workflow that we missed having not tagged yet. 
 - Strip `refs/tags/v` from the `DESKFLOW_PACKAGE_VERSION`  that the get-version action reports when run on a `v` tag
 - Release step can run if the ref is 'master ' or a tag   It can not be both

Note: release steps:
   - Bump the version in the main CMakeLists.txt
   - Make PR (like this)  

After landing.
   - Tag the commit with an annotated tag like `git tag -a v1.71.1 -m "v1.17.1"`
   - Push the tag  `git push origin v1.17.1`

