### PR TITLE
Gui: Expose Check for updates option

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -528,6 +528,7 @@ void MainWindow::open()
 
   if (!m_AppConfig.enableUpdateCheck().has_value()) {
     m_AppConfig.setEnableUpdateCheck(messages::showUpdateCheckOption(this));
+    m_ConfigScopes.save();
   }
 
   if (m_AppConfig.enableUpdateCheck().value()) {

--- a/src/gui/src/dialogs/SettingsDialog.cpp
+++ b/src/gui/src/dialogs/SettingsDialog.cpp
@@ -38,7 +38,7 @@
 using namespace deskflow::gui;
 
 SettingsDialog::SettingsDialog(
-    QWidget *parent, IAppConfig &appConfig, const IServerConfig &serverConfig, const CoreProcess &coreProcess
+    QWidget *parent, AppConfig &appConfig, const IServerConfig &serverConfig, const CoreProcess &coreProcess
 )
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::SettingsDialog>()},
@@ -188,6 +188,7 @@ void SettingsDialog::accept()
   m_appConfig.setLogFilename(ui->m_pLineEditLogFilename->text());
   m_appConfig.setElevateMode(static_cast<ElevateMode>(ui->m_pComboElevate->currentIndex()));
   m_appConfig.setAutoHide(ui->m_pCheckBoxAutoHide->isChecked());
+  m_appConfig.setEnableUpdateCheck(ui->m_pCheckBoxAutoUpdate->isChecked());
   m_appConfig.setPreventSleep(ui->m_pCheckBoxPreventSleep->isChecked());
   m_appConfig.setTlsCertPath(ui->m_pLineEditTlsCertPath->text());
   m_appConfig.setTlsKeyLength(ui->m_pComboBoxTlsKeyLength->currentText().toInt());
@@ -227,6 +228,12 @@ void SettingsDialog::loadFromConfig()
   ui->m_pCheckBoxServiceEnabled->setChecked(m_appConfig.enableService());
   ui->m_pCheckBoxCloseToTray->setChecked(m_appConfig.closeToTray());
   ui->m_pComboElevate->setCurrentIndex(static_cast<int>(m_appConfig.elevateMode()));
+
+  if (m_appConfig.enableUpdateCheck().has_value()) {
+    ui->m_pCheckBoxAutoUpdate->setChecked(m_appConfig.enableUpdateCheck().value());
+  } else {
+    ui->m_pCheckBoxAutoUpdate->setChecked(false);
+  }
 
   if (m_appConfig.isActiveScopeSystem()) {
     ui->m_pRadioSystemScope->setChecked(true);
@@ -311,6 +318,7 @@ void SettingsDialog::updateControls()
   ui->m_pComboLogLevel->setEnabled(writable);
   ui->m_pCheckBoxLogToFile->setEnabled(writable);
   ui->m_pCheckBoxAutoHide->setEnabled(writable);
+  ui->m_pCheckBoxAutoUpdate->setEnabled(writable);
   ui->m_pCheckBoxPreventSleep->setEnabled(writable);
   ui->m_pLineEditTlsCertPath->setEnabled(writable);
   ui->m_pComboBoxTlsKeyLength->setEnabled(writable);

--- a/src/gui/src/dialogs/SettingsDialog.h
+++ b/src/gui/src/dialogs/SettingsDialog.h
@@ -19,7 +19,7 @@
 #pragma once
 #include <QDialog>
 
-#include "gui/config/IAppConfig.h"
+#include "gui/config/AppConfig.h"
 #include "gui/config/IServerConfig.h"
 #include "gui/core/CoreProcess.h"
 #include "gui/tls/TlsUtility.h"
@@ -31,7 +31,6 @@ class SettingsDialog;
 
 class SettingsDialog : public QDialog
 {
-  using IAppConfig = deskflow::gui::IAppConfig;
   using IServerConfig = deskflow::gui::IServerConfig;
   using CoreProcess = deskflow::gui::CoreProcess;
 
@@ -40,7 +39,7 @@ class SettingsDialog : public QDialog
 public:
   void extracted();
   SettingsDialog(
-      QWidget *parent, IAppConfig &appConfig, const IServerConfig &serverConfig, const CoreProcess &coreProcess
+      QWidget *parent, AppConfig &appConfig, const IServerConfig &serverConfig, const CoreProcess &coreProcess
   );
   ~SettingsDialog() override;
 
@@ -85,7 +84,7 @@ private:
   bool m_wasOriginallySystemScope = false;
 
   std::unique_ptr<Ui::SettingsDialog> ui;
-  IAppConfig &m_appConfig;
+  AppConfig &m_appConfig;
   const IServerConfig &m_serverConfig;
   const CoreProcess &m_coreProcess;
   deskflow::gui::TlsUtility m_tlsUtility;

--- a/src/gui/src/dialogs/SettingsDialog.ui
+++ b/src/gui/src/dialogs/SettingsDialog.ui
@@ -119,6 +119,13 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
+           <widget class="QCheckBox" name="m_pCheckBoxAutoUpdate">
+            <property name="text">
+             <string>Check for updates on startup </string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="m_pCheckBoxCloseToTray">
             <property name="text">
              <string>Leave app running in notification area when the window is closed</string>

--- a/src/gui/src/dialogs/SettingsDialog.ui
+++ b/src/gui/src/dialogs/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>582</height>
+    <height>615</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,30 +19,21 @@
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_9">
-   <property name="spacing">
-    <number>15</number>
-   </property>
-   <item alignment="Qt::AlignTop">
+  <layout class="QVBoxLayout" name="verticalLayout_7">
+   <item>
     <widget class="QTabWidget" name="m_pTabWidget">
      <property name="tabPosition">
-      <enum>QTabWidget::North</enum>
+      <enum>QTabWidget::TabPosition::North</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="m_pTabRegular">
       <attribute name="title">
        <string>&amp;Regular</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="spacing">
-        <number>15</number>
-       </property>
-       <property name="topMargin">
-        <number>15</number>
-       </property>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupBasics">
          <property name="title">
           <string>Basics</string>
@@ -72,10 +63,10 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Maximum</enum>
+               <enum>QSizePolicy::Policy::Maximum</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -121,7 +112,7 @@
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupApp">
          <property name="title">
           <string>App</string>
@@ -144,7 +135,7 @@
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupSecurity">
          <property name="title">
           <string>Security</string>
@@ -177,7 +168,7 @@
             <item>
              <spacer name="horizontalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -245,10 +236,10 @@
             <item>
              <spacer name="horizontalSpacer_3">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Minimum</enum>
+               <enum>QSizePolicy::Policy::Minimum</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -291,7 +282,7 @@
             <item>
              <spacer name="horizontalSpacer_4">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -313,33 +304,14 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="m_pTabAdvanced">
       <attribute name="title">
        <string>&amp;Advanced</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_8">
-       <property name="spacing">
-        <number>15</number>
-       </property>
-       <property name="topMargin">
-        <number>15</number>
-       </property>
-       <item alignment="Qt::AlignTop">
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
         <widget class="QGroupBox" name="m_pGroupNetworking">
          <property name="title">
           <string>Networking</string>
@@ -414,7 +386,7 @@
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupLogs">
          <property name="title">
           <string>Logs</string>
@@ -432,7 +404,7 @@
           <item row="0" column="1">
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -516,10 +488,10 @@
             <item>
              <spacer name="horizontalSpacer_7">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Minimum</enum>
+               <enum>QSizePolicy::Policy::Minimum</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -563,7 +535,7 @@
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupService">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -605,7 +577,7 @@
                </size>
               </property>
               <property name="toolTip">
-                <string>Specify when the Windows background service should run the server or client
+               <string>Specify when the Windows background service should run the server or client
                   process at an elevated privilege level.</string>
               </property>
               <property name="whatsThis">
@@ -644,11 +616,8 @@
           </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="m_pCheckBoxServiceEnabled">
-            <property name="text">
-             <string>Use background service (daemon)</string>
-            </property>
             <property name="toolTip">
-              <string>Whether to launch the server or client process through the Windows background
+             <string>Whether to launch the server or client process through the Windows background
                 service or direct from the GUI.</string>
             </property>
             <property name="whatsThis">
@@ -661,31 +630,21 @@
               &lt;/ul&gt;
               </string>
             </property>
+            <property name="text">
+             <string>Use background service (daemon)</string>
+            </property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="m_pGroupScope">
          <property name="title">
           <string>Use settings profile from</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <property name="topMargin">
-           <number>5</number>
-          </property>
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="m_pRadioSystemScope">
-            <property name="text">
-             <string>All users</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
            <widget class="QRadioButton" name="m_pRadioUserScope">
             <property name="text">
              <string>Current user</string>
@@ -695,21 +654,18 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QRadioButton" name="m_pRadioSystemScope">
+            <property name="text">
+             <string>All users</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -718,12 +674,15 @@
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>
@@ -731,10 +690,10 @@
    <item>
     <widget class="QDialogButtonBox" name="m_pButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>
@@ -757,6 +716,7 @@
   <tabstop>m_pRadioSystemScope</tabstop>
   <tabstop>m_pComboElevate</tabstop>
  </tabstops>
+ <resources/>
  <connections>
   <connection>
    <sender>m_pButtonBox</sender>


### PR DESCRIPTION
Fixes #7890  By exposing a check box in the application settings to enable or disable the check

 - Add the option to enable or disable update checks in the settings dialog
 - Fix the SettingsDialog UI files so it stops generating invalid Alignment values when the form is edited.
 - Use `AppConfig` object directly in the SettingsDialog
 - Fix an issue where the initial setting for auto update is not set. 
