### PR TITLE
Restart Qt app instance instead of process

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -164,5 +164,5 @@ _last = "moe:24800"
 # DESKFLOW_GUI_VERBOSE=true
 
 # Reset all settings and delete all data on startup
-# DESKFLOW_RESET_ALL=true
+# DESKFLOW_CLEAR_SETTINGS=true
 ```

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -367,7 +367,12 @@ void MainWindow::on_m_pActionClearSettings_triggered()
 
   m_Quitting = true;
   m_SaveOnExit = false;
-  diagnostic::clearSettings(m_ConfigScopes, true);
+  diagnostic::clearSettings(m_ConfigScopes);
+
+  // Expected to cause the app to restart after exiting.
+  Q_EMIT clearedSettings();
+
+  QApplication::quit();
 }
 
 bool MainWindow::on_m_pActionSave_triggered()

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -96,6 +96,7 @@ public:
 signals:
   void created();
   void shown();
+  void clearedSettings();
 
 public slots:
   void onAppAboutToQuit();

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
   // --no-reset
   QStringList arguments = QCoreApplication::arguments();
   const auto noReset = hasArg("--no-reset", arguments);
-  const auto resetEnvVar = strToTrue(qEnvironmentVariable("DESKFLOW_RESET_ALL"));
+  const auto resetEnvVar = strToTrue(qEnvironmentVariable("DESKFLOW_CLEAR_SETTINGS"));
   if (resetEnvVar && !noReset) {
     diagnostic::clearSettings(configScopes, false);
   }

--- a/src/lib/gui/diagnostic.cpp
+++ b/src/lib/gui/diagnostic.cpp
@@ -26,22 +26,7 @@
 
 namespace deskflow::gui::diagnostic {
 
-void restart()
-{
-  QString program = QCoreApplication::applicationFilePath();
-  QStringList arguments = QCoreApplication::arguments();
-
-  // prevent infinite reset loop when env var set.
-  arguments << "--no-reset";
-
-  qInfo("launching new process: %s", qPrintable(program));
-  QProcess::startDetached(program, arguments);
-
-  qDebug("exiting current process");
-  QApplication::exit();
-}
-
-void clearSettings(ConfigScopes &scopes, bool enableRestart)
+void clearSettings(ConfigScopes &scopes)
 {
   qDebug("clearing settings");
   scopes.clear();
@@ -57,13 +42,6 @@ void clearSettings(ConfigScopes &scopes, bool enableRestart)
   auto profileDir = paths::coreProfileDir();
   qDebug("removing profile dir: %s", qPrintable(profileDir.absolutePath()));
   profileDir.removeRecursively();
-
-  if (enableRestart) {
-    qDebug("restarting");
-    restart();
-  } else {
-    qDebug("skipping restart");
-  }
 }
 
 } // namespace deskflow::gui::diagnostic

--- a/src/lib/gui/diagnostic.h
+++ b/src/lib/gui/diagnostic.h
@@ -21,6 +21,6 @@
 
 namespace deskflow::gui::diagnostic {
 
-void clearSettings(ConfigScopes &scopes, bool enableRestart);
+void clearSettings(ConfigScopes &scopes);
 
 }


### PR DESCRIPTION
fixes: #7896

Instead of launching a new process, which is a bit hacky, this simply starts a new Qt app instance after the existing one exits. As well as fixing a bug (where the new process hangs on exit), this also makes the process far easier to debug, since there is no new process to attach to.

I suggest we land this before: #7896

**To test:**
1. Clear settings (Help -> Clear settings)
2. Enter computer name
3. File -> Quit

Expect: Instead of the app hanging like before (I had to press ctrl+C to kill the process), it should exit cleanly.