### PR TITLE
fix: single typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To add our tap, run:
 brew tap deskflow/homebrew-tap
 ```
 Then install either:
-- Stable: `brew instal deskflow`
+- Stable: `brew install deskflow`
 - Continuous: `brew install deskflow-dev`
 
 


### PR DESCRIPTION
`brew instal` works as intended, but only because Homebrew has aliases for a few common typos. Changed to `brew install`