### PR TITLE
Flatpak nits

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Get version
         uses: ./.github/actions/get-version
 
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@master
         name: "Build"
         with:
           bundle: deskflow-${{env.DESKFLOW_PACKAGE_VERSION}}-linux-x86_64.flatpak

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -309,7 +309,7 @@ jobs:
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         name: "Build"
         with:
-          bundle: deskflow-${{env.DESKFLOW_PACKAGE_VERSION}}-x86_64.flatpak
+          bundle: deskflow-${{env.DESKFLOW_PACKAGE_VERSION}}-linux-x86_64.flatpak
           manifest-path: deploy/dist/flatpak/org.deskflow.deskflow.yml
           cache-key: flatpak-builder-${{ github.sha }}
           upload-artifact: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -134,35 +134,35 @@ jobs:
             timeout: 20
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" -DMACOSX_DEPLOYMENT_TARGET=12"
 
-          - name: "debian-13-amd64"
+          - name: "debian-13-x86_64"
             runs-on: ubuntu-latest
             container: debian:trixie-slim
             like: "debian"
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "fedora-41-amd64"
+          - name: "fedora-41-x86_64"
             runs-on: ubuntu-latest
             container: fedora:41
             like: "fedora"
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "fedora-40-amd64"
+          - name: "fedora-40-x86_84"
             runs-on: ubuntu-latest
             container: fedora:40
             like: "fedora"
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "opensuse-amd64"
+          - name: "opensuse-x86_84"
             runs-on: ubuntu-latest
             container: opensuse/tumbleweed:latest
             like: "suse"
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "archlinux-amd64"
+          - name: "archlinux-x86_84"
             runs-on: ubuntu-latest
             container: archlinux:latest
             like: "arch"

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -68,6 +68,10 @@ macro(configure_linux_package_name)
     set(CN_STRING "${DISTRO_CODENAME}-")
   endif()
 
+  if("${DISTRO_NAME}" STREQUAL "")
+    set(DISTRO_NAME "linux")
+  endif()
+
   set(OS_STRING "${DISTRO_NAME}-${CN_STRING}${CMAKE_SYSTEM_PROCESSOR}")
 
 endmacro()

--- a/deploy/dist/flatpak/org.deskflow.deskflow.yml
+++ b/deploy/dist/flatpak/org.deskflow.deskflow.yml
@@ -21,7 +21,6 @@ cleanup:
   - /share/cmake
   - /share/doc
   - /share/gir-1.0
-  - /lib/debug
   - /lib/girepository-1.0
 modules:
   - name: python3-attrs

--- a/deploy/org.deskflow.deskflow.metainfo.xml
+++ b/deploy/org.deskflow.deskflow.metainfo.xml
@@ -8,7 +8,7 @@
 	<summary>Software Keyboard and mouse sharing</summary>
 	<description>
 		<p>
-			Use your keyboard and mouse to control other machines on the network or be controle
+			Use the keyboard, mouse, or trackpad of one computer to control nearby computers, and work seamlessly between them.
 		</p>
 	</description>
 	<launchable type="desktop-id">org.deskflow.deskflow.desktop</launchable>


### PR DESCRIPTION
 - Adjust the generated name for flatpak artifacts. `deskflow-version-linux-arch.flatpak`
 - Do not cleanup /lib/debug from the generated flatpak
 - Fallback to 'linux' if `DISTRO_NAME` is empty
 - Update the description in the metadata
 - User `master` version of flatpak builder
 - Use `x86_64` for linux job name sufixes
 