### PR TITLE
Clean smells

### DIFF
--- a/scripts/package.py
+++ b/scripts/package.py
@@ -24,7 +24,6 @@ import platform
 from dotenv import load_dotenv  # type: ignore
 
 ENV_FILE = ".env"
-DEFAULT_PRODUCT_NAME = "Deskflow"
 DEFAULT_FILENAME_BASE = "deskflow"
 DEFAULT_PROJECT_BUILD_DIR = "build"
 DEFAULT_DIST_DIR = "dist"
@@ -50,7 +49,6 @@ def main():
         DEFAULT_FILENAME_BASE,
         DEFAULT_PROJECT_BUILD_DIR,
         DEFAULT_DIST_DIR,
-        DEFAULT_PRODUCT_NAME,
         version=args.package_version,
     )
 
@@ -58,9 +56,7 @@ def package(
     filename_prefix,
     project_build_dir,
     dist_dir,
-    product_name,
     version,
-    source_dir=None,
 ):
     filename_base = get_filename_base(version, filename_prefix)
     print(f"Package filename base: {filename_base}")

--- a/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.cpp
+++ b/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.cpp
@@ -203,7 +203,7 @@ void MSWindowsClientTaskBarReceiver::primaryAction()
   showStatus();
 }
 
-const IArchTaskBarReceiver::Icon MSWindowsClientTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon MSWindowsClientTaskBarReceiver::getIcon() const
 {
   return static_cast<Icon>(m_icon[getStatus()]);
 }

--- a/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.h
@@ -34,10 +34,10 @@ public:
   virtual ~MSWindowsClientTaskBarReceiver();
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
   void cleanup();
 
 protected:

--- a/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/MSWindowsClientTaskBarReceiver.h
@@ -37,7 +37,7 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
   void cleanup();
 
 protected:

--- a/src/cmd/deskflowc/OSXClientTaskBarReceiver.cpp
+++ b/src/cmd/deskflowc/OSXClientTaskBarReceiver.cpp
@@ -52,7 +52,7 @@ void OSXClientTaskBarReceiver::primaryAction()
 
 IArchTaskBarReceiver::Icon OSXClientTaskBarReceiver::getIcon() const
 {
-  return NULL;
+  return nullptr;
 }
 
 IArchTaskBarReceiver *createTaskBarReceiver(const BufferedLogOutputter *logBuffer, IEventQueue *events)

--- a/src/cmd/deskflowc/OSXClientTaskBarReceiver.cpp
+++ b/src/cmd/deskflowc/OSXClientTaskBarReceiver.cpp
@@ -50,7 +50,7 @@ void OSXClientTaskBarReceiver::primaryAction()
   // do nothing
 }
 
-const IArchTaskBarReceiver::Icon OSXClientTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon OSXClientTaskBarReceiver::getIcon() const
 {
   return NULL;
 }

--- a/src/cmd/deskflowc/OSXClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/OSXClientTaskBarReceiver.h
@@ -34,5 +34,5 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
 };

--- a/src/cmd/deskflowc/OSXClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/OSXClientTaskBarReceiver.h
@@ -31,8 +31,8 @@ public:
   virtual ~OSXClientTaskBarReceiver();
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
 };

--- a/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.cpp
+++ b/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.cpp
@@ -50,7 +50,7 @@ void CXWindowsClientTaskBarReceiver::primaryAction()
   // do nothing
 }
 
-const IArchTaskBarReceiver::Icon CXWindowsClientTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon CXWindowsClientTaskBarReceiver::getIcon() const
 {
   return NULL;
 }

--- a/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.cpp
+++ b/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.cpp
@@ -52,7 +52,7 @@ void CXWindowsClientTaskBarReceiver::primaryAction()
 
 IArchTaskBarReceiver::Icon CXWindowsClientTaskBarReceiver::getIcon() const
 {
-  return NULL;
+  return nullptr;
 }
 
 IArchTaskBarReceiver *createTaskBarReceiver(const BufferedLogOutputter *logBuffer, IEventQueue *events)

--- a/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.h
@@ -39,5 +39,5 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
 };

--- a/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.h
+++ b/src/cmd/deskflowc/XWindowsClientTaskBarReceiver.h
@@ -36,8 +36,8 @@ public:
   CXWindowsClientTaskBarReceiver &operator=(CXWindowsClientTaskBarReceiver &&) = delete;
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
 };

--- a/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.cpp
+++ b/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.cpp
@@ -229,7 +229,7 @@ void MSWindowsServerTaskBarReceiver::primaryAction()
   showStatus();
 }
 
-const IArchTaskBarReceiver::Icon MSWindowsServerTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon MSWindowsServerTaskBarReceiver::getIcon() const
 {
   return static_cast<Icon>(m_icon[getStatus()]);
 }

--- a/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.h
@@ -37,7 +37,7 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
   void cleanup();
 
 protected:

--- a/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/MSWindowsServerTaskBarReceiver.h
@@ -34,10 +34,10 @@ public:
   virtual ~MSWindowsServerTaskBarReceiver();
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
   void cleanup();
 
 protected:

--- a/src/cmd/deskflows/OSXServerTaskBarReceiver.cpp
+++ b/src/cmd/deskflows/OSXServerTaskBarReceiver.cpp
@@ -52,7 +52,7 @@ void OSXServerTaskBarReceiver::primaryAction()
 
 IArchTaskBarReceiver::Icon OSXServerTaskBarReceiver::getIcon() const
 {
-  return NULL;
+  return nullptr;
 }
 
 IArchTaskBarReceiver *createTaskBarReceiver(const BufferedLogOutputter *logBuffer, IEventQueue *events)

--- a/src/cmd/deskflows/OSXServerTaskBarReceiver.cpp
+++ b/src/cmd/deskflows/OSXServerTaskBarReceiver.cpp
@@ -50,7 +50,7 @@ void OSXServerTaskBarReceiver::primaryAction()
   // do nothing
 }
 
-const IArchTaskBarReceiver::Icon OSXServerTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon OSXServerTaskBarReceiver::getIcon() const
 {
   return NULL;
 }

--- a/src/cmd/deskflows/OSXServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/OSXServerTaskBarReceiver.h
@@ -30,8 +30,8 @@ public:
   virtual ~OSXServerTaskBarReceiver();
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
 };

--- a/src/cmd/deskflows/OSXServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/OSXServerTaskBarReceiver.h
@@ -33,5 +33,5 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
 };

--- a/src/cmd/deskflows/XWindowsServerTaskBarReceiver.cpp
+++ b/src/cmd/deskflows/XWindowsServerTaskBarReceiver.cpp
@@ -50,7 +50,7 @@ void CXWindowsServerTaskBarReceiver::primaryAction()
   // do nothing
 }
 
-const IArchTaskBarReceiver::Icon CXWindowsServerTaskBarReceiver::getIcon() const
+IArchTaskBarReceiver::Icon CXWindowsServerTaskBarReceiver::getIcon() const
 {
   return NULL;
 }

--- a/src/cmd/deskflows/XWindowsServerTaskBarReceiver.cpp
+++ b/src/cmd/deskflows/XWindowsServerTaskBarReceiver.cpp
@@ -52,7 +52,7 @@ void CXWindowsServerTaskBarReceiver::primaryAction()
 
 IArchTaskBarReceiver::Icon CXWindowsServerTaskBarReceiver::getIcon() const
 {
-  return NULL;
+  return nullptr;
 }
 
 IArchTaskBarReceiver *createTaskBarReceiver(const BufferedLogOutputter *logBuffer, IEventQueue *events)

--- a/src/cmd/deskflows/XWindowsServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/XWindowsServerTaskBarReceiver.h
@@ -39,5 +39,5 @@ public:
   virtual void showStatus();
   virtual void runMenu(int x, int y);
   virtual void primaryAction();
-  virtual const Icon getIcon() const;
+  virtual Icon getIcon() const;
 };

--- a/src/cmd/deskflows/XWindowsServerTaskBarReceiver.h
+++ b/src/cmd/deskflows/XWindowsServerTaskBarReceiver.h
@@ -36,8 +36,8 @@ public:
   CXWindowsServerTaskBarReceiver &operator=(const CXWindowsServerTaskBarReceiver &&) = delete;
 
   // IArchTaskBarReceiver overrides
-  virtual void showStatus();
-  virtual void runMenu(int x, int y);
-  virtual void primaryAction();
-  virtual Icon getIcon() const;
+  void showStatus() override;
+  void runMenu(int x, int y) override;
+  void primaryAction() override;
+  Icon getIcon() const override;
 };

--- a/src/gui/src/Action.cpp
+++ b/src/gui/src/Action.cpp
@@ -30,14 +30,6 @@ const char *Action::m_SwitchDirectionNames[] = {"left", "right", "up", "down"};
 const char *Action::m_LockCursorModeNames[] = {"toggle", "on", "off"};
 
 Action::Action()
-    : m_KeySequence(),
-      m_Type(keystroke),
-      m_TypeScreenNames(),
-      m_SwitchScreenName(),
-      m_SwitchDirection(switchLeft),
-      m_LockCursorMode(lockCursorToggle),
-      m_ActiveOnRelease(false),
-      m_HasScreens(false)
 {
 }
 

--- a/src/gui/src/Action.cpp
+++ b/src/gui/src/Action.cpp
@@ -29,10 +29,6 @@ const char *Action::m_ActionTypeNames[] = {
 const char *Action::m_SwitchDirectionNames[] = {"left", "right", "up", "down"};
 const char *Action::m_LockCursorModeNames[] = {"toggle", "on", "off"};
 
-Action::Action()
-{
-}
-
 QString Action::text() const
 {
   QString text = QString(m_ActionTypeNames[keySequence().isMouseButton() ? type() + 6 : type()]) + "(";

--- a/src/gui/src/Action.h
+++ b/src/gui/src/Action.h
@@ -165,6 +165,6 @@ private:
   static const char *m_LockCursorModeNames[];
 };
 
-typedef QList<Action> ActionList;
+using ActionList = QList<Action>;
 
 QTextStream &operator<<(QTextStream &outStream, const Action &action);

--- a/src/gui/src/Action.h
+++ b/src/gui/src/Action.h
@@ -151,13 +151,13 @@ protected:
 
 private:
   KeySequence m_KeySequence;
-  int m_Type;
-  QStringList m_TypeScreenNames;
-  QString m_SwitchScreenName;
-  int m_SwitchDirection;
-  int m_LockCursorMode;
-  bool m_ActiveOnRelease;
-  bool m_HasScreens;
+  int m_Type = keystroke;
+  QStringList m_TypeScreenNames = QStringList();
+  QString m_SwitchScreenName = QString();
+  int m_SwitchDirection = switchLeft;
+  int m_LockCursorMode = lockCursorToggle;
+  bool m_ActiveOnRelease = false;
+  bool m_HasScreens = false;
   bool m_restartServer;
 
   static const char *m_ActionTypeNames[];

--- a/src/gui/src/Action.h
+++ b/src/gui/src/Action.h
@@ -62,7 +62,7 @@ public:
   };
 
 public:
-  Action();
+  Action() = default;
 
 public:
   QString text() const;

--- a/src/gui/src/Hotkey.h
+++ b/src/gui/src/Hotkey.h
@@ -72,6 +72,6 @@ private:
   ActionList m_Actions;
 };
 
-typedef QList<Hotkey> HotkeyList;
+using HotkeyList = QList<Hotkey>;
 
 QTextStream &operator<<(QTextStream &outStream, const Hotkey &hotkey);

--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -33,7 +33,7 @@ class ArchCondImpl;
 \brief Opaque condition variable type.
 An opaque type representing a condition variable.
 */
-typedef ArchCondImpl *ArchCond;
+using ArchCond = ArchCondImpl *;
 
 /*!
 \class ArchMutexImpl
@@ -47,7 +47,7 @@ class ArchMutexImpl;
 \brief Opaque mutex type.
 An opaque type representing a mutex.
 */
-typedef ArchMutexImpl *ArchMutex;
+using ArchMutex = ArchMutexImpl *;
 
 /*!
 \class ArchThreadImpl
@@ -61,7 +61,7 @@ class ArchThreadImpl;
 \brief Opaque thread type.
 An opaque type representing a thread.
 */
-typedef ArchThreadImpl *ArchThread;
+using ArchThread = ArchThreadImpl *;
 
 //! Interface for architecture dependent multithreading
 /*!
@@ -74,7 +74,7 @@ public:
   //! Type of thread entry point
   typedef void *(*ThreadFunc)(void *);
   //! Type of thread identifier
-  typedef unsigned int ThreadID;
+  using ThreadID = unsigned int;
   //! Types of signals
   /*!
   Not all platforms support all signals.  Unsupported signals are

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 class ArchThreadImpl;
-typedef ArchThreadImpl *ArchThread;
+using ArchThread = ArchThreadImpl *;
 
 /*!
 \class ArchSocketImpl
@@ -38,7 +38,7 @@ class ArchSocketImpl;
 \brief Opaque socket type.
 An opaque type representing a socket.
 */
-typedef ArchSocketImpl *ArchSocket;
+using ArchSocket = ArchSocketImpl *;
 
 /*!
 \class ArchNetAddressImpl
@@ -53,7 +53,7 @@ class ArchNetAddressImpl;
 \brief Opaque network address type.
 An opaque type representing a network address.
 */
-typedef ArchNetAddressImpl *ArchNetAddress;
+using ArchNetAddress = ArchNetAddressImpl *;
 
 //! Interface for architecture dependent networking
 /*!

--- a/src/lib/arch/IArchTaskBarReceiver.h
+++ b/src/lib/arch/IArchTaskBarReceiver.h
@@ -34,7 +34,7 @@ class IArchTaskBarReceiver : public IInterface
 {
 public:
   // Icon data is architecture dependent
-  typedef void *Icon;
+  using Icon = void *;
 
   //! @name manipulators
   //@{

--- a/src/lib/arch/IArchTaskBarReceiver.h
+++ b/src/lib/arch/IArchTaskBarReceiver.h
@@ -81,7 +81,7 @@ public:
   to set the icon is left to subclasses.  Getting and setting
   the icon must be thread safe.
   */
-  virtual const Icon getIcon() const = 0;
+  virtual Icon getIcon() const = 0;
 
   //! Get tooltip
   /*!

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -106,7 +106,7 @@ private:
   static void *threadSignalHandler(void *vrep);
 
 private:
-  typedef std::list<ArchThread> ThreadList;
+  using ThreadList = std::list<ArchThread>;
 
   static ArchMultithreadPosix *s_instance;
 

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -41,7 +41,7 @@ struct sockaddr_storage
 #endif
 
 #if !HAVE_SOCKLEN_T
-typedef int socklen_t;
+using socklen_t = int;
 #endif
 
 #include <poll.h>
@@ -52,7 +52,7 @@ typedef int socklen_t;
 // old systems may use char* for [gs]etsockopt()'s optval argument.
 // this should be void on modern systems but char is forwards
 // compatible so we always use it.
-typedef char optval_t;
+using optval_t = char;
 
 class ArchSocketImpl
 {

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -385,8 +385,8 @@ void ArchDaemonWindows::setStatusError(DWORD error)
 
 void ArchDaemonWindows::serviceMain(DWORD argc, LPTSTR *argvIn)
 {
-  typedef std::vector<LPCTSTR> ArgList;
-  typedef std::vector<std::string> Arguments;
+  using ArgList = std::vector<LPCTSTR>;
+  using Arguments = std::vector<std::string>;
   const char **argv = const_cast<const char **>(argvIn);
 
   // create synchronization objects

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -38,7 +38,7 @@
 #ifndef ES_CONTINUOUS
 #define ES_CONTINUOUS ((DWORD)0x80000000)
 #endif
-typedef DWORD EXECUTION_STATE;
+using EXECUTION_STATE = DWORD;
 
 //
 // ArchMiscWindows

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -190,7 +190,7 @@ private:
   static DWORD WINAPI dummySetThreadExecutionState(DWORD);
 
 private:
-  typedef std::set<HWND> Dialogs;
+  using Dialogs = std::set<HWND>;
   typedef DWORD(WINAPI *STES_t)(DWORD);
 
   static Dialogs *s_dialogs;

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -109,7 +109,7 @@ private:
   static unsigned int __stdcall threadFunc(void *vrep);
 
 private:
-  typedef std::list<ArchThread> ThreadList;
+  using ThreadList = std::list<ArchThread>;
 
   static ArchMultithreadWindows *s_instance;
 

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -106,7 +106,7 @@ private:
   void throwNameError(int);
 
 private:
-  typedef std::list<WSAEVENT> EventList;
+  using EventList = std::list<WSAEVENT>;
 
   ArchMutex m_mutex;
   EventList m_unblockEvents;

--- a/src/lib/arch/win32/ArchTaskBarWindows.h
+++ b/src/lib/arch/win32/ArchTaskBarWindows.h
@@ -63,10 +63,10 @@ private:
     UINT m_id;
   };
 
-  typedef std::map<IArchTaskBarReceiver *, ReceiverInfo> ReceiverToInfoMap;
-  typedef std::map<UINT, ReceiverToInfoMap::iterator> CIDToReceiverMap;
-  typedef std::vector<UINT> CIDStack;
-  typedef std::map<HWND, bool> Dialogs;
+  using ReceiverToInfoMap = std::map<IArchTaskBarReceiver *, ReceiverInfo>;
+  using CIDToReceiverMap = std::map<UINT, ReceiverToInfoMap::iterator>;
+  using CIDStack = std::vector<UINT>;
+  using Dialogs = std::map<HWND, bool>;
 
   UINT getNextID();
   void recycleID(UINT);

--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -39,7 +39,7 @@ A \c Event holds an event type and a pointer to event data.
 class Event
 {
 public:
-  typedef UInt32 Type;
+  using Type = UInt32;
   enum
   {
     kUnknown, //!< The event type is unknown
@@ -49,7 +49,7 @@ public:
     kLast     //!< Must be last
   };
 
-  typedef UInt32 Flags;
+  using Flags = UInt32;
   enum
   {
     kNone = 0x00,               //!< No flags

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -102,14 +102,14 @@ private:
     double m_time;
   };
 
-  typedef std::set<EventQueueTimer *> Timers;
-  typedef PriorityQueue<Timer> TimerQueue;
-  typedef std::map<UInt32, Event> EventTable;
-  typedef std::vector<UInt32> EventIDList;
-  typedef std::map<Event::Type, const char *> TypeMap;
-  typedef std::map<String, Event::Type> NameMap;
-  typedef std::map<Event::Type, IEventJob *> TypeHandlerTable;
-  typedef std::map<void *, TypeHandlerTable> HandlerTable;
+  using Timers = std::set<EventQueueTimer *>;
+  using TimerQueue = PriorityQueue<Timer>;
+  using EventTable = std::map<UInt32, Event>;
+  using EventIDList = std::vector<UInt32>;
+  using TypeMap = std::map<Event::Type, const char *>;
+  using NameMap = std::map<String, Event::Type>;
+  using TypeHandlerTable = std::map<Event::Type, IEventJob *>;
+  using HandlerTable = std::map<void *, TypeHandlerTable>;
 
   int m_systemTarget;
   ArchMutex m_mutex;

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -136,7 +136,7 @@ private:
   void output(ELevel priority, char *msg);
 
 private:
-  typedef std::list<ILogOutputter *> OutputterList;
+  using OutputterList = std::list<ILogOutputter *>;
 
   static Log *s_log;
 

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -39,11 +39,11 @@ template <
 class PriorityQueue
 {
 public:
-  typedef typename Container::value_type value_type;
-  typedef typename Container::size_type size_type;
-  typedef typename Container::iterator iterator;
-  typedef typename Container::const_iterator const_iterator;
-  typedef Container container_type;
+  using value_type = Container::value_type;
+  using size_type = Container::size_type;
+  using iterator = Container::iterator;
+  using const_iterator = Container::const_iterator;
+  using container_type = Container;
 
   PriorityQueue()
   {

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -49,7 +49,7 @@ public:
   virtual void deleteTimer(EventQueueTimer *) const;
 
 private:
-  typedef std::deque<UInt32> EventDeque;
+  using EventDeque = std::deque<UInt32>;
 
   ArchMutex m_queueMutex;
   ArchCond m_queueReadyCond;

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -137,10 +137,10 @@ This outputter records the last N log messages.
 class BufferedLogOutputter : public ILogOutputter
 {
 private:
-  typedef std::deque<String> Buffer;
+  using Buffer = std::deque<String>;
 
 public:
-  typedef Buffer::const_iterator const_iterator;
+  using const_iterator = Buffer::const_iterator;
 
   BufferedLogOutputter(UInt32 maxBufferSize);
   virtual ~BufferedLogOutputter();

--- a/src/lib/common/basic_types.h
+++ b/src/lib/common/basic_types.h
@@ -84,12 +84,12 @@
 #if defined(__APPLE__)
 #include <CoreServices/CoreServices.h>
 #else
-typedef signed TYPE_OF_SIZE_1 SInt8;
-typedef signed TYPE_OF_SIZE_2 SInt16;
-typedef signed TYPE_OF_SIZE_4 SInt32;
-typedef unsigned TYPE_OF_SIZE_1 UInt8;
-typedef unsigned TYPE_OF_SIZE_2 UInt16;
-typedef unsigned TYPE_OF_SIZE_4 UInt32;
+using SInt8 = signed TYPE_OF_SIZE_1;
+using SInt16 = signed TYPE_OF_SIZE_2;
+using SInt32 = signed TYPE_OF_SIZE_4;
+using UInt8 = unsigned TYPE_OF_SIZE_1;
+using UInt16 = unsigned TYPE_OF_SIZE_2;
+using UInt32 = unsigned TYPE_OF_SIZE_4;
 #endif
 #endif
 //

--- a/src/lib/common/stdsstream.h
+++ b/src/lib/common/stdsstream.h
@@ -63,10 +63,10 @@ namespace std {
 class stringbuf : public streambuf
 {
 public:
-  typedef char char_type;
-  typedef int int_type;
-  typedef streampos pos_type;
-  typedef streamoff off_type;
+  using char_type = char;
+  using int_type = int;
+  using pos_type = streampos;
+  using off_type = streamoff;
 
   explicit stringbuf(int which = ios::in | ios::out)
       : streambuf(),
@@ -231,10 +231,10 @@ private:
 class istringstream : public istream
 {
 public:
-  typedef char char_type;
-  typedef int int_type;
-  typedef streampos pos_type;
-  typedef streamoff off_type;
+  using char_type = char;
+  using int_type = int;
+  using pos_type = streampos;
+  using off_type = streamoff;
 
   explicit istringstream(int which = ios::in) : istream(&sb), sb(which | ios::in)
   {
@@ -265,10 +265,10 @@ private:
 class ostringstream : public ostream
 {
 public:
-  typedef char char_type;
-  typedef int int_type;
-  typedef streampos pos_type;
-  typedef streamoff off_type;
+  using char_type = char;
+  using int_type = int;
+  using pos_type = streampos;
+  using off_type = streamoff;
 
   explicit ostringstream(int which = ios::out) : ostream(&sb), sb(which | ios::out)
   {
@@ -300,10 +300,10 @@ private:
 class stringstream : public iostream
 {
 public:
-  typedef char char_type;
-  typedef int int_type;
-  typedef streampos pos_type;
-  typedef streamoff off_type;
+  using char_type = char;
+  using int_type = int;
+  using pos_type = streampos;
+  using off_type = streamoff;
 
   explicit stringstream(int which = ios::out | ios::in) : iostream(&sb), sb(which)
   {

--- a/src/lib/deskflow/ClientTaskBarReceiver.h
+++ b/src/lib/deskflow/ClientTaskBarReceiver.h
@@ -54,7 +54,7 @@ public:
   virtual void primaryAction() = 0;
   virtual void lock() const;
   virtual void unlock() const;
-  virtual const Icon getIcon() const = 0;
+  virtual Icon getIcon() const = 0;
   virtual std::string getToolTip() const;
   virtual void cleanup()
   {

--- a/src/lib/deskflow/DragInformation.h
+++ b/src/lib/deskflow/DragInformation.h
@@ -22,7 +22,7 @@
 #include "common/stdvector.h"
 
 class DragInformation;
-typedef std::vector<DragInformation> DragFileList;
+using DragFileList = std::vector<DragInformation>;
 
 class DragInformation
 {

--- a/src/lib/deskflow/IClipboard.h
+++ b/src/lib/deskflow/IClipboard.h
@@ -35,7 +35,7 @@ public:
   arbitrary starting time.  Timestamps will wrap around to 0
   after about 49 3/4 days.
   */
-  typedef UInt32 Time;
+  using Time = UInt32;
 
   //! Clipboard formats
   /*!

--- a/src/lib/deskflow/IKeyState.h
+++ b/src/lib/deskflow/IKeyState.h
@@ -64,7 +64,7 @@ public:
     char m_screensBuffer[1];
   };
 
-  typedef std::set<KeyButton> KeyButtonSet;
+  using KeyButtonSet = std::set<KeyButton>;
 
   //! @name manipulators
   //@{

--- a/src/lib/deskflow/KeyMap.h
+++ b/src/lib/deskflow/KeyMap.h
@@ -76,7 +76,7 @@ public:
   any modifier keys unless the KeyID is a modifier, in which case
   it has exactly one KeyItem for the modifier itself.
   */
-  typedef std::vector<KeyItem> KeyItemList;
+  using KeyItemList = std::vector<KeyItem>;
 
   //! A keystroke
   class Keystroke
@@ -119,13 +119,13 @@ public:
   };
 
   //! A sequence of keystrokes
-  typedef std::vector<Keystroke> Keystrokes;
+  using Keystrokes = std::vector<Keystroke>;
 
   //! A mapping of a modifier to keys for that modifier
-  typedef std::multimap<KeyModifierMask, KeyItem> ModifierToKeys;
+  using ModifierToKeys = std::multimap<KeyModifierMask, KeyItem>;
 
   //! A set of buttons
-  typedef std::map<KeyButton, const KeyItem *> ButtonToKeyMap;
+  using ButtonToKeyMap = std::map<KeyButton, const KeyItem *>;
 
   //! Callback type for \c foreachKey
   typedef void (*ForeachKeyCallback)(KeyID, SInt32 group, KeyItem &, void *userData);
@@ -353,7 +353,7 @@ private:
   };
 
   // A list of ways to synthesize a KeyID
-  typedef std::vector<KeyItemList> KeyEntryList;
+  using KeyEntryList = std::vector<KeyItemList>;
 
   // computes the number of groups
   SInt32 findNumGroups() const;
@@ -440,7 +440,7 @@ private:
   static void initKeyNameMaps();
 
   // Ways to synthesize a KeyID over multiple keyboard groups
-  typedef std::vector<KeyEntryList> KeyGroupTable;
+  using KeyGroupTable = std::vector<KeyEntryList>;
 
   void addGroupToKeystroke(Keystrokes &keys, SInt32 &group, const String &lang) const;
 
@@ -454,25 +454,25 @@ private:
 
 private:
   // Table of KeyID to ways to synthesize that KeyID
-  typedef std::map<KeyID, KeyGroupTable> KeyIDMap;
+  using KeyIDMap = std::map<KeyID, KeyGroupTable>;
 
   // List of KeyItems that generate a particular modifier
-  typedef std::vector<const KeyItem *> ModifierKeyItemList;
+  using ModifierKeyItemList = std::vector<const KeyItem *>;
 
   // Map a modifier to the KeyItems that synthesize that modifier
-  typedef std::vector<ModifierKeyItemList> ModifierToKeyTable;
+  using ModifierToKeyTable = std::vector<ModifierKeyItemList>;
 
   // A set of keys
-  typedef std::set<KeyID> KeySet;
+  using KeySet = std::set<KeyID>;
 
   // A set of buttons
-  typedef std::set<KeyButton> KeyButtonSet;
+  using KeyButtonSet = std::set<KeyButton>;
 
   // Key maps for parsing/formatting
-  typedef std::map<String, KeyID, deskflow::string::CaselessCmp> NameToKeyMap;
-  typedef std::map<String, KeyModifierMask, deskflow::string::CaselessCmp> NameToModifierMap;
-  typedef std::map<KeyID, String> KeyToNameMap;
-  typedef std::map<KeyModifierMask, String> ModifierToNameMap;
+  using NameToKeyMap = std::map<String, KeyID, deskflow::string::CaselessCmp>;
+  using NameToModifierMap = std::map<String, KeyModifierMask, deskflow::string::CaselessCmp>;
+  using KeyToNameMap = std::map<KeyID, String>;
+  using ModifierToNameMap = std::map<KeyModifierMask, String>;
 
   // KeyID info
   KeyIDMap m_keyIDMap;

--- a/src/lib/deskflow/KeyState.h
+++ b/src/lib/deskflow/KeyState.h
@@ -89,7 +89,7 @@ public:
   }
 
 protected:
-  typedef deskflow::KeyMap::Keystroke Keystroke;
+  using Keystroke = deskflow::KeyMap::Keystroke;
 
   //! @name protected manipulators
   //@{
@@ -140,8 +140,8 @@ protected:
   //@}
 
 private:
-  typedef deskflow::KeyMap::Keystrokes Keystrokes;
-  typedef deskflow::KeyMap::ModifierToKeys ModifierToKeys;
+  using Keystrokes = deskflow::KeyMap::Keystrokes;
+  using ModifierToKeys = deskflow::KeyMap::ModifierToKeys;
 
 public:
   struct AddActiveModifierContext

--- a/src/lib/deskflow/ServerTaskBarReceiver.h
+++ b/src/lib/deskflow/ServerTaskBarReceiver.h
@@ -57,7 +57,7 @@ public:
   virtual void primaryAction() = 0;
   virtual void lock() const;
   virtual void unlock() const;
-  virtual const Icon getIcon() const = 0;
+  virtual Icon getIcon() const = 0;
   virtual std::string getToolTip() const;
 
 protected:

--- a/src/lib/deskflow/ServerTaskBarReceiver.h
+++ b/src/lib/deskflow/ServerTaskBarReceiver.h
@@ -61,7 +61,7 @@ public:
   virtual std::string getToolTip() const;
 
 protected:
-  typedef std::vector<String> Clients;
+  using Clients = std::vector<String>;
   enum EState
   {
     kNotRunning,

--- a/src/lib/deskflow/clipboard_types.h
+++ b/src/lib/deskflow/clipboard_types.h
@@ -24,7 +24,7 @@
 /*!
 Type to hold a clipboard identifier.
 */
-typedef UInt8 ClipboardID;
+using ClipboardID = UInt8;
 
 //! @name Clipboard identifiers
 //@{

--- a/src/lib/deskflow/key_types.h
+++ b/src/lib/deskflow/key_types.h
@@ -26,7 +26,12 @@ Type to hold a key symbol identifier.  The encoding is UTF-32, using
 U+E000 through U+EFFF for the various control keys (e.g. arrow
 keys, function keys, modifier keys, etc).
 */
+// Typedef has to be used on mac os as this is used in objective-C
+#if __APPLE__
 typedef UInt32 KeyID;
+#else
+using KeyID = UInt32;
+#endif
 
 //! Key Code
 /*!
@@ -35,19 +40,31 @@ physical key on the keyboard.  KeyButton 0 is reserved to be an
 invalid key;  platforms that use 0 as a physical key identifier
 will have to remap that value to some arbitrary unused id.
 */
+#if __APPLE__
 typedef UInt16 KeyButton;
+#else
+using KeyButton = UInt16;
+#endif
 
 //! Modifier key mask
 /*!
 Type to hold a bitmask of key modifiers (e.g. shift keys).
 */
+#if __APPLE__
 typedef UInt32 KeyModifierMask;
+#else
+using KeyModifierMask = UInt32;
+#endif
 
 //! Modifier key ID
 /*!
 Type to hold the id of a key modifier (e.g. a shift key).
 */
+#if __APPLE__
 typedef UInt32 KeyModifierID;
+#else
+using KeyModifierID = UInt32;
+#endif
 
 //! @name Modifier key masks
 //@{

--- a/src/lib/deskflow/mouse_types.h
+++ b/src/lib/deskflow/mouse_types.h
@@ -24,7 +24,7 @@
 /*!
 Type to hold a mouse button identifier.
 */
-typedef UInt8 ButtonID;
+using ButtonID = UInt8;
 
 //! @name Mouse button identifiers
 //@{

--- a/src/lib/deskflow/option_types.h
+++ b/src/lib/deskflow/option_types.h
@@ -25,16 +25,16 @@
 /*!
 Type to hold an option identifier.
 */
-typedef UInt32 OptionID;
+using OptionID = UInt32;
 
 //! Option Value
 /*!
 Type to hold an option value.
 */
-typedef SInt32 OptionValue;
+using OptionValue = SInt32;
 
 // for now, options are just pairs of integers
-typedef std::vector<UInt32> OptionsList;
+using OptionsList = std::vector<UInt32>;
 
 // macro for packing 4 character strings into 4 byte integers
 #define OPTION_CODE(_s)                                                                                                \

--- a/src/lib/io/StreamBuffer.h
+++ b/src/lib/io/StreamBuffer.h
@@ -71,8 +71,8 @@ public:
 private:
   static const UInt32 kChunkSize;
 
-  typedef std::vector<UInt8> Chunk;
-  typedef std::list<Chunk> ChunkList;
+  using Chunk = std::vector<UInt8>;
+  using ChunkList = std::list<Chunk>;
 
   ChunkList m_chunks;
   UInt32 m_size;

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -98,7 +98,7 @@ private:
   bool isRunning();
 
 private:
-  typedef std::deque<String> Buffer;
+  using Buffer = std::deque<String>;
 
   IpcServer &m_ipcServer;
   Buffer m_buffer;

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -77,7 +77,7 @@ private:
   void deleteClient(IpcClientProxy *proxy);
 
 private:
-  typedef std::list<IpcClientProxy *> ClientList;
+  using ClientList = std::list<IpcClientProxy *>;
 
   bool m_mock;
   IEventQueue *m_events;

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -62,9 +62,9 @@ public:
 private:
   // list of jobs.  we use a list so we can safely iterate over it
   // while other threads modify it.
-  typedef std::list<ISocketMultiplexerJob *> SocketJobs;
-  typedef SocketJobs::iterator JobCursor;
-  typedef std::map<ISocket *, JobCursor> SocketJobMap;
+  using SocketJobs = std::list<ISocketMultiplexerJob *>;
+  using JobCursor = SocketJobs::iterator;
+  using SocketJobMap = std::map<ISocket *, JobCursor>;
 
   // service sockets.  the service thread will only access m_sockets
   // and m_update while m_pollable and m_polling are true.  all other

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -75,7 +75,7 @@ private:
   static UINT getOwnershipFormat();
 
 private:
-  typedef std::vector<IMSWindowsClipboardConverter *> ConverterList;
+  using ConverterList = std::vector<IMSWindowsClipboardConverter *>;
 
   HWND m_window;
   mutable Time m_time;

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -202,7 +202,7 @@ private:
     HWND m_foregroundWindow;
     bool m_lowLevel;
   };
-  typedef std::map<String, Desk *> Desks;
+  using Desks = std::map<String, Desk *>;
 
   // initialization and shutdown operations
   HCURSOR createBlankCursor() const;

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -178,7 +178,7 @@ protected:
   virtual KeyModifierMask &getActiveModifiersRValue();
 
 private:
-  typedef std::vector<HKL> GroupList;
+  using GroupList = std::vector<HKL>;
 
   // send ctrl+alt+del hotkey event on NT family
   static void ctrlAltDelThread(void *);
@@ -198,8 +198,8 @@ private:
   MSWindowsKeyState &operator=(const MSWindowsKeyState &);
 
 private:
-  typedef std::map<HKL, SInt32> GroupMap;
-  typedef std::map<KeyID, UINT> KeyToVKMap;
+  using GroupMap = std::map<HKL, SInt32>;
+  using KeyToVKMap = std::map<KeyID, UINT>;
 
   void *m_eventTarget;
   MSWindowsDesks *m_desks;

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -260,10 +260,10 @@ private:
     UINT m_keycode;
     UINT m_mask;
   };
-  typedef std::map<UInt32, HotKeyItem> HotKeyMap;
-  typedef std::vector<UInt32> HotKeyIDList;
-  typedef std::map<HotKeyItem, UInt32> HotKeyToIDMap;
-  typedef std::vector<KeyButton> PrimaryKeyDownList;
+  using HotKeyMap = std::map<UInt32, HotKeyItem>;
+  using HotKeyIDList = std::vector<UInt32>;
+  using HotKeyToIDMap = std::map<HotKeyItem, UInt32>;
+  using PrimaryKeyDownList = std::vector<KeyButton>;
 
   static HINSTANCE s_windowInstance;
 

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -50,7 +50,7 @@ private:
   void clearConverters();
 
 private:
-  typedef std::vector<IOSXClipboardConverter *> ConverterList;
+  using ConverterList = std::vector<IOSXClipboardConverter *>;
 
   mutable Time m_time;
   ConverterList m_converters;

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -35,7 +35,7 @@ A key state for OS X.
 class OSXKeyState : public KeyState
 {
 public:
-  typedef std::vector<KeyID> KeyIDs;
+  using KeyIDs = std::vector<KeyID>;
 
   OSXKeyState(IEventQueue *events, std::vector<String> layouts, bool isLangSyncEnabled);
   OSXKeyState(IEventQueue *events, deskflow::KeyMap &keyMap, std::vector<String> layouts, bool isLangSyncEnabled);
@@ -160,8 +160,8 @@ private:
     KeyButtonOffset = 1
   };
 
-  typedef std::map<CFDataRef, SInt32> GroupMap;
-  typedef std::map<UInt32, KeyID> VirtualKeyMap;
+  using GroupMap = std::map<CFDataRef, SInt32>;
+  using VirtualKeyMap = std::map<UInt32, KeyID>;
 
   VirtualKeyMap m_virtualKeyMap;
   mutable UInt32 m_deadKeyState;

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -36,7 +36,7 @@
 
 extern "C"
 {
-  typedef int CGSConnectionID;
+  using CGSConnectionID = int;
   CGError CGSSetConnectionProperty(CGSConnectionID cid, CGSConnectionID targetCID, CFStringRef key, CFTypeRef value);
   int _CGSDefaultConnection();
 }
@@ -242,10 +242,10 @@ private:
     std::bitset<NumButtonIDs> m_buttons;
   };
 
-  typedef std::map<UInt32, HotKeyItem> HotKeyMap;
-  typedef std::vector<UInt32> HotKeyIDList;
-  typedef std::map<KeyModifierMask, UInt32> ModifierHotKeyMap;
-  typedef std::map<HotKeyItem, UInt32> HotKeyToIDMap;
+  using HotKeyMap = std::map<UInt32, HotKeyItem>;
+  using HotKeyIDList = std::vector<UInt32>;
+  using ModifierHotKeyMap = std::map<KeyModifierMask, UInt32>;
+  using HotKeyToIDMap = std::map<HotKeyItem, UInt32>;
 
   // true if screen is being used as a primary screen, false otherwise
   bool m_isPrimary;
@@ -272,7 +272,7 @@ private:
      Evil, and this should be moved to a place where it need not
      be mutable as soon as possible. */
   mutable MouseButtonState m_buttonState;
-  typedef std::map<UInt16, CGEventType> MouseButtonEventMapType;
+  using MouseButtonEventMapType = std::map<UInt16, CGEventType>;
   std::vector<MouseButtonEventMapType> MouseButtonEventMap;
 
   bool m_cursorHidden;

--- a/src/lib/platform/OSXUchrKeyResource.h
+++ b/src/lib/platform/OSXUchrKeyResource.h
@@ -22,7 +22,7 @@
 
 #include <Carbon/Carbon.h>
 
-typedef TISInputSourceRef KeyLayout;
+using KeyLayout = TISInputSourceRef;
 
 class OSXUchrKeyResource : public IOSXKeyResource
 {
@@ -38,7 +38,7 @@ public:
   virtual KeyID getKey(UInt32 table, UInt32 button) const;
 
 private:
-  typedef std::vector<KeyID> KeySequence;
+  using KeySequence = std::vector<KeyID>;
 
   bool getDeadKey(KeySequence &keys, UInt16 index) const;
   bool getKeyRecord(KeySequence &keys, UInt16 index, UInt16 &state) const;

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -680,7 +680,7 @@ void XWindowsClipboard::motifFillCache()
   auto formats = static_cast<const SInt32 *>(static_cast<const void *>(item.m_size + data.data()));
 
   // get the available formats
-  typedef std::map<Atom, String> MotifFormatMap;
+  using MotifFormatMap = std::map<Atom, String>;
   MotifFormatMap motifFormats;
   for (SInt32 i = 0; i < numFormats; ++i) {
     // get Motif format property from the root window

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -258,9 +258,9 @@ protected:
     // index of next byte in m_data to send
     UInt32 m_ptr;
   };
-  typedef std::list<Reply *> ReplyList;
-  typedef std::map<Window, ReplyList> ReplyMap;
-  typedef std::map<Window, long> ReplyEventMask;
+  using ReplyList = std::list<Reply *>;
+  using ReplyMap = std::map<Window, ReplyList>;
+  using ReplyEventMask = std::map<Window, long>;
 
   // ICCCM interoperability methods
   void icccmFillCache();
@@ -291,7 +291,7 @@ protected:
   Atom getTimestampData(String &, int *format) const;
 
 private:
-  typedef std::vector<IXWindowsClipboardConverter *> ConverterList;
+  using ConverterList = std::vector<IXWindowsClipboardConverter *>;
 
   Display *m_display;
   Window m_window;

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -59,7 +59,7 @@ private:
   int getPendingCountLocked();
 
 private:
-  typedef std::vector<XEvent> EventList;
+  using EventList = std::vector<XEvent>;
 
   Mutex m_mutex;
   Display *m_display;

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -45,7 +45,7 @@ A key state for X Windows.
 class XWindowsKeyState : public KeyState
 {
 public:
-  typedef std::vector<int> KeycodeList;
+  using KeycodeList = std::vector<int>;
   enum
   {
     kGroupPoll = -1,
@@ -142,13 +142,13 @@ private:
 #ifdef TEST_ENV
 public: // yuck
 #endif
-  typedef std::vector<KeyModifierMask> KeyModifierMaskList;
+  using KeyModifierMaskList = std::vector<KeyModifierMask>;
 
 private:
-  typedef std::map<KeyModifierMask, unsigned int> KeyModifierToXMask;
-  typedef std::multimap<KeyID, KeyCode> KeyToKeyCodeMap;
-  typedef std::map<KeyCode, unsigned int> NonXKBModifierMap;
-  typedef std::map<UInt32, XKBModifierInfo> XKBModifierMap;
+  using KeyModifierToXMask = std::map<KeyModifierMask, unsigned int>;
+  using KeyToKeyCodeMap = std::multimap<KeyID, KeyCode>;
+  using NonXKBModifierMap = std::map<KeyCode, unsigned int>;
+  using XKBModifierMap = std::map<UInt32, XKBModifierInfo>;
 
   Display *m_display;
 #if HAVE_XKB_EXTENSION

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -172,11 +172,11 @@ private:
     int m_keycode;
     unsigned int m_mask;
   };
-  typedef std::set<bool> FilteredKeycodes;
-  typedef std::vector<std::pair<int, unsigned int>> HotKeyList;
-  typedef std::map<UInt32, HotKeyList> HotKeyMap;
-  typedef std::vector<UInt32> HotKeyIDList;
-  typedef std::map<HotKeyItem, UInt32> HotKeyToIDMap;
+  using FilteredKeycodes = std::set<bool>;
+  using HotKeyList = std::vector<std::pair<int, unsigned int>>;
+  using HotKeyMap = std::map<UInt32, HotKeyList>;
+  using HotKeyIDList = std::vector<UInt32>;
+  using HotKeyToIDMap = std::map<HotKeyItem, UInt32>;
 
   // true if screen is being used as a primary screen, false otherwise
   bool m_isPrimary;

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -116,7 +116,7 @@ private:
   bool isDPMSActivated() const;
 
 private:
-  typedef std::map<Window, long> WatchList;
+  using WatchList = std::map<Window, long>;
 
   // the X display
   Display *m_display;

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -89,9 +89,9 @@ private:
   void removeUnknownClient(ClientProxyUnknown *unknownClient);
 
 private:
-  typedef std::set<ClientProxyUnknown *> NewClients;
-  typedef std::deque<ClientProxy *> WaitingClients;
-  typedef std::set<IDataSocket *> ClientSockets;
+  using NewClients = std::set<ClientProxyUnknown *>;
+  using WaitingClients = std::deque<ClientProxy *>;
+  using ClientSockets = std::set<IDataSocket *>;
 
   IListenSocket *m_listen;
   ISocketFactory *m_socketFactory;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -715,7 +715,7 @@ void Config::readSectionOptions(ConfigReadContext &s)
     if (handled) {
       // make sure handled options aren't followed by more values
       if (i < line.size() && (line[i] == ',' || line[i] == ';')) {
-        throw XConfigRead(s, "to many arguments to %s", name.c_str());
+        throw XConfigRead(s, "to many arguments to %s", name);
       }
     } else {
       // make filter rule

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1655,7 +1655,7 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
   // aliases section (if there are any)
   if (config.m_map.size() != config.m_nameToCanonicalName.size()) {
     // map canonical to alias
-    typedef std::multimap<String, String, CaselessCmp> CMNameMap;
+    using CMNameMap = std::multimap<String, String, CaselessCmp>;
     CMNameMap aliases;
     for (Config::NameMap::const_iterator index = config.m_nameToCanonicalName.begin();
          index != config.m_nameToCanonicalName.end(); ++index) {

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -40,11 +40,11 @@ class IEventQueue;
 namespace std {
 template <> struct iterator_traits<deskflow::server::Config>
 {
-  typedef String value_type;
-  typedef ptrdiff_t difference_type;
-  typedef bidirectional_iterator_tag iterator_category;
-  typedef String *pointer;
-  typedef String &reference;
+  using value_type = String;
+  using difference_type = ptrdiff_t;
+  using iterator_category = bidirectional_iterator_tag;
+  using pointer = String *;
+  using reference = String &;
 };
 }; // namespace std
 
@@ -63,8 +63,8 @@ namespace and must be unique.
 class Config
 {
 public:
-  typedef std::map<OptionID, OptionValue> ScreenOptions;
-  typedef std::pair<float, float> Interval;
+  using ScreenOptions = std::map<OptionID, OptionValue>;
+  using Interval = std::pair<float, float>;
 
   class CellEdge
   {
@@ -119,10 +119,10 @@ private:
   class Cell
   {
   private:
-    typedef std::map<CellEdge, CellEdge> EdgeLinks;
+    using EdgeLinks = std::map<CellEdge, CellEdge>;
 
   public:
-    typedef EdgeLinks::const_iterator const_iterator;
+    using const_iterator = EdgeLinks::const_iterator;
 
     bool add(const CellEdge &src, const CellEdge &dst);
     void remove(EDirection side);
@@ -147,13 +147,13 @@ private:
   public:
     ScreenOptions m_options;
   };
-  typedef std::map<String, Cell, deskflow::string::CaselessCmp> CellMap;
-  typedef std::map<String, String, deskflow::string::CaselessCmp> NameMap;
+  using CellMap = std::map<String, Cell, deskflow::string::CaselessCmp>;
+  using NameMap = std::map<String, String, deskflow::string::CaselessCmp>;
 
 public:
-  typedef Cell::const_iterator link_const_iterator;
-  typedef CellMap::const_iterator internal_const_iterator;
-  typedef NameMap::const_iterator all_const_iterator;
+  using link_const_iterator = Cell::const_iterator;
+  using internal_const_iterator = CellMap::const_iterator;
+  using all_const_iterator = NameMap::const_iterator;
   class const_iterator : std::iterator_traits<Config>
   {
   public:
@@ -522,7 +522,7 @@ Maintains a context when reading a configuration from a stream.
 class ConfigReadContext
 {
 public:
-  typedef std::vector<String> ArgList;
+  using ArgList = std::vector<String>;
 
   ConfigReadContext(std::istream &, SInt32 firstLine = 1);
   ~ConfigReadContext();

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -354,7 +354,7 @@ public:
     void copy(const Rule &);
 
   private:
-    typedef std::vector<Action *> ActionList;
+    using ActionList = std::vector<Action *>;
 
     Condition *m_condition;
     ActionList m_activateActions;
@@ -364,7 +364,7 @@ public:
   // -------------------------------------------------------------------------
   // Input Filter Class
   // -------------------------------------------------------------------------
-  typedef std::vector<Rule> RuleList;
+  using RuleList = std::vector<Rule>;
 
   InputFilter(IEventQueue *events);
   InputFilter(const InputFilter &);

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -2112,7 +2112,7 @@ void Server::closeClients(const ServerConfig &config)
 {
   // collect the clients that are connected but are being dropped
   // from the configuration (or who's canonical name is changing).
-  typedef std::set<BaseClientProxy *> RemovedClients;
+  using RemovedClients = std::set<BaseClientProxy *>;
   RemovedClients removed;
   for (ClientList::iterator index = m_clients.begin(); index != m_clients.end(); ++index) {
     if (!config.isCanonicalName(index->first)) {

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -436,13 +436,13 @@ private:
   PrimaryClient *m_primaryClient;
 
   // all clients (including the primary client) indexed by name
-  typedef std::map<String, BaseClientProxy *> ClientList;
-  typedef std::set<BaseClientProxy *> ClientSet;
+  using ClientList = std::map<String, BaseClientProxy *>;
+  using ClientSet = std::set<BaseClientProxy *>;
   ClientList m_clients;
   ClientSet m_clientSet;
 
   // all old connections that we're waiting to hangup
-  typedef std::map<BaseClientProxy *, EventQueueTimer *> OldClients;
+  using OldClients = std::map<BaseClientProxy *, EventQueueTimer *>;
   OldClients m_oldClients;
 
   // the client with focus

--- a/src/test/mock/deskflow/MockKeyState.h
+++ b/src/test/mock/deskflow/MockKeyState.h
@@ -50,6 +50,6 @@ public:
 
 typedef ::testing::NiceMock<MockKeyState> KeyStateImpl;
 
-typedef UInt32 KeyID;
+using KeyID = UInt32;
 
 typedef void (*ForeachKeyCallback)(KeyID, SInt32 group, deskflow::KeyMap::KeyItem &, void *userData);


### PR DESCRIPTION
 - Clean up code smells reported by sonar cloud
   - scripts/package.py, remove unused vars in package method
   - IArchTaskBarReciver subclasses Icon pointer should not be a const
   - IArchTaskBarReeiver subclasses should return nullptr for empty icon not NULL
   - IArchTrayBarReceiver subclass should override virtual methods not mark them virtual
   - src/gui/Action initilize items in class when possible
   - Replace most cases of `typedef` with `using`

 