### PR TITLE
Add Requirement for Qt 6.7+

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -345,7 +345,7 @@ endmacro()
 macro(configure_qt)
 
   find_package(
-    Qt6
+    Qt6 6.7.0
     COMPONENTS Core Widgets Network
     REQUIRED)
 


### PR DESCRIPTION
 - Added missing Qt Version to CMake

Without it those without Qt 6.7 can configure successfully but the will have build failures.