### PR TITLE
ReAdd NDEBUG define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,14 @@ set(REQUIRED_LIBEI_VERSION 1.3)
 set(REQUIRED_LIBPORTAL_VERSION 0.8)
 set(REQUIRED_QT_VERSION 6.7.0)
 
+# Control debug item visibility
+# When not set logging is forced to DEBUG and show code locations
+# Also exposes a test menu
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message(STATUS "Disabling debug build")
+  add_definitions(-DNDEBUG)
+endif()
+
 # Set required macOS SDK
 if(APPLE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET 12)


### PR DESCRIPTION
 Removing the Define for `NDEBUG` was a mistake 
 
1. Set `NDEBUG` in main CMakeLists.txt when needed
2. Make note to unify the logic to not need this define