### PR TITLE
Fix: #7949 Use correct sizing for Settings Dialog

### DIFF
--- a/src/gui/src/dialogs/SettingsDialog.cpp
+++ b/src/gui/src/dialogs/SettingsDialog.cpp
@@ -39,7 +39,7 @@ using namespace deskflow::gui;
 SettingsDialog::SettingsDialog(
     QWidget *parent, AppConfig &appConfig, const IServerConfig &serverConfig, const CoreProcess &coreProcess
 )
-    : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
+    : QDialog(parent),
       ui{std::make_unique<Ui::SettingsDialog>()},
       m_appConfig(appConfig),
       m_serverConfig(serverConfig),
@@ -82,6 +82,10 @@ SettingsDialog::SettingsDialog(
 #ifdef DESKFLOW_GUI_HOOK_SETTINGS
   DESKFLOW_GUI_HOOK_SETTINGS
 #endif
+  adjustSize();
+  qApp->processEvents();
+  setFixedHeight(height());
+  setWindowFlags((windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMinMaxButtonsHint);
 }
 
 //

--- a/src/gui/src/dialogs/SettingsDialog.ui
+++ b/src/gui/src/dialogs/SettingsDialog.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>615</height>
+    <height>625</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
+   <property name="spacing">
+    <number>20</number>
+   </property>
    <item>
     <widget class="QTabWidget" name="m_pTabWidget">
      <property name="tabPosition">
@@ -29,12 +29,27 @@
       <number>0</number>
      </property>
      <widget class="QWidget" name="m_pTabRegular">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
        <string>&amp;Regular</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>15</number>
+       </property>
        <item>
         <widget class="QGroupBox" name="m_pGroupBasics">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Basics</string>
          </property>
@@ -114,6 +129,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="m_pGroupApp">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>App</string>
          </property>
@@ -144,6 +165,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="m_pGroupSecurity">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Security</string>
          </property>
@@ -314,12 +341,27 @@
       </layout>
      </widget>
      <widget class="QWidget" name="m_pTabAdvanced">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
        <string>&amp;Advanced</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <property name="spacing">
+        <number>15</number>
+       </property>
        <item>
         <widget class="QGroupBox" name="m_pGroupNetworking">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Networking</string>
          </property>
@@ -395,6 +437,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="m_pGroupLogs">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Logs</string>
          </property>
@@ -545,7 +593,7 @@
        <item>
         <widget class="QGroupBox" name="m_pGroupService">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -647,6 +695,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="m_pGroupScope">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Use settings profile from</string>
          </property>
@@ -677,22 +731,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Policy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="m_pButtonBox">


### PR DESCRIPTION
fixes #7949 

 - Adjust Settings Dialog groupboxes to be maximum (take up the most vertical space they could need)
 - Adjust Settings Dialog to have a fixedHeight based on content height
 - Settings Dialog is now Modal 
 - Remove Unneeed window hints from the settings dialog

![Screenshot_20241212_094045](https://github.com/user-attachments/assets/49f548f1-b458-441f-ad70-e47707d72dd6)
![Screenshot_20241212_094055](https://github.com/user-attachments/assets/129ebda3-801e-4925-875a-6c56bdbe9cd8)

