### PR TITLE
fix: `qDebug` doesn't work on Fedora

### DIFF
--- a/src/apps/deskflow-gui/main.cpp
+++ b/src/apps/deskflow-gui/main.cpp
@@ -44,6 +44,10 @@
 #include <cstdlib>
 #endif
 
+#if defined(Q_OS_UNIX) && defined(QT_DEBUG)
+#include <QLoggingCategory>
+#endif
+
 using namespace deskflow::gui;
 
 class QThreadImpl : public QThread
@@ -66,6 +70,10 @@ bool hasArg(const QString &arg, const QStringList &args)
 
 int main(int argc, char *argv[])
 {
+#if defined(Q_OS_UNIX) && defined(QT_DEBUG)
+  // Fixes Fedora bug where qDebug() messages aren't printed.
+  QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true\nqt.*=false"));
+#endif
 
 #if defined(Q_OS_MAC)
   /* Workaround for QTBUG-40332 - "High ping when QNetworkAccessManager is


### PR DESCRIPTION
IDK why, but on Fedora, `QT_LOGGING_RULES` is set in a way that turns off `qDebug()`. We have our own env var, `DESKFLOW_GUI_DEBUG` to turn on debug logging, so I think overriding `QT_LOGGING_RULES` should be ok. 

Open to alternatives.