### PR TITLE
Fix(CVE-2021-42075): Close TCP connections after handshake failures

### DIFF
--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -208,6 +208,11 @@ void ClientListener::handleUnknownClient(const Event &, void *vclient)
         m_events->forClientProxy().disconnected(), client,
         new TMethodEventJob<ClientListener>(this, &ClientListener::handleClientDisconnected, client)
     );
+  } else {
+    auto *stream = unknownClient->getStream();
+    if (stream) {
+      stream->close();
+    }
   }
 
   // now finished with unknown client


### PR DESCRIPTION
With this You will be prompted to allow new clients the first time they attempt to connect.
If you ignore them they are ignored until the server restarts. If you accept them you will be asked to add them to your server layout (once).

Part of #7806 