### PR TITLE
Fix: #7940 and #7941

### DIFF
--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -22,6 +22,7 @@
 #include "arch/IArchMultithread.h"
 #include "base/EventTypes.h"
 #include "base/String.h"
+#include "common/constants.h"
 #include "deskflow/App.h"
 #include "net/NetworkAddress.h"
 #include "server/Config.h"
@@ -146,8 +147,8 @@ private:
   EventQueueTimer *m_timer;
   NetworkAddress *m_deskflowAddress;
 #if SYSAPI_WIN32
-  inline static const std::string CONFIG_NAME = "%s.sgc", kAppName;
+  inline static const std::string CONFIG_NAME = std::string(kAppName) + ".sgc";
 #elif SYSAPI_UNIX
-  inline static const std::string CONFIG_NAME = "%s.conf", kAppName;
+  inline static const std::string CONFIG_NAME = std::string(kAppName) + ".conf";
 #endif
 };


### PR DESCRIPTION
fixes: #7940 
fixes: #7941 

by using std::string 's insert method in place is %s sub for the static string