### PR TITLE
fix: Mac os gui nits

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -577,9 +577,14 @@ void MainWindow::open()
   QList<QAction *> trayActions{m_actionStartCore, m_actionStopCore, nullptr, m_actionQuit};
 
 #ifdef Q_OS_MAC
+  // Duplicate quit needed for mac os tray menu
+  QAction *actionTrayQuit = new QAction(tr("Quit Deskflow"), this);
+  actionTrayQuit->setShortcut(QKeySequence::Quit);
+
   m_actionRestore->setText(tr("Open Deskflow"));
   trayActions.insert(3, m_actionRestore);
-  trayActions.insert(4, nullptr);
+  trayActions.append(nullptr);
+  trayActions.append(actionTrayQuit);
 #endif
   m_TrayIcon.create(trayActions);
 

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -1103,7 +1103,7 @@ void MainWindow::showAndActivate()
 #ifdef Q_OS_MAC
   forceAppActive();
 #endif
-  show();
+  showNormal();
   raise();
   activateWindow();
 }

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -113,7 +113,7 @@ MainWindow::MainWindow(ConfigScopes &configScopes, AppConfig &appConfig)
   m_actionStopCore->setShortcut(QKeySequence(tr("Ctrl+T")));
 
 #ifdef Q_OS_MAC
-  ui->btnToggleLog->setFixedHeight(ui->lblLog->font().pixelSize());
+  ui->btnToggleLog->setFixedHeight(ui->lblLog->height() * 0.6);
 #endif
 
   ui->btnToggleLog->setStyleSheet(QStringLiteral("background:rgba(0,0,0,0);"));


### PR DESCRIPTION
 - Fix show and activate on mac os (need showNormal after all)
 - make a duplicate quit action for the tray menu on mac os
 - Fixes #8012 