### PR TITLE
fix: 8012

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -113,7 +113,7 @@ MainWindow::MainWindow(ConfigScopes &configScopes, AppConfig &appConfig)
   m_actionStopCore->setShortcut(QKeySequence(tr("Ctrl+T")));
 
 #ifdef Q_OS_MAC
-  ui->btnToggleLog->setFixedHeight(ui->lblLog->font().pixelSize());
+  ui->btnToggleLog->setFixedHeight(ui->lblLog->height() * 0.6);
 #endif
 
   ui->btnToggleLog->setStyleSheet(QStringLiteral("background:rgba(0,0,0,0);"));


### PR DESCRIPTION
fixes #8012 
 - On Mac os make the height 2/3 the label size