### PR TITLE
fix: 8017, move wayland notes to debug context

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -63,7 +63,7 @@ void EiKeyState::init(int fd, size_t len)
   auto sz = read(fd, buffer.get(), len);
 
   if ((size_t)sz < len) {
-    LOG_NOTE("failed to create xkb context: %s", strerror(errno));
+    LOG_DEBUG("failed to create xkb context: %s", strerror(errno));
     return;
   }
 

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -440,7 +440,7 @@ void EiScreen::update_shape()
     }
   }
 
-  LOG_NOTE("logical output size: %dx%d@%d.%d", w_, h_, x_, y_);
+  LOG_DEBUG("logical output size: %dx%d@%d.%d", w_, h_, x_, y_);
   cursor_x_ = x_ + w_ / 2;
   cursor_y_ = y_ + h_ / 2;
 


### PR DESCRIPTION
fixes #8017 

For the wayland backend these messages are now under the `Debug` Context
  - `failed to create xkb context: Resource temporarily unavailable`
  -  `logical output size: 1536x864@0.0`
