### PR TITLE
fix: Unify both Quit actions to use the same function

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -271,12 +271,7 @@ void MainWindow::connectSlots()
   connect(m_actionHelp, &QAction::triggered, this, &MainWindow::openHelpUrl);
   connect(m_actionMinimize, &QAction::triggered, this, &MainWindow::hide);
 
-  connect(m_actionQuit, &QAction::triggered, qApp, [this] {
-    qDebug() << "quitting application";
-    m_Quitting = true;
-    QApplication::quit();
-  });
-
+  connect(m_actionQuit, &QAction::triggered, this, &MainWindow::quitApp);
   connect(m_actionRestore, &QAction::triggered, this, &MainWindow::showAndActivate);
   connect(m_actionSave, &QAction::triggered, this, &MainWindow::saveConfig);
   connect(m_actionSettings, &QAction::triggered, this, &MainWindow::openSettings);
@@ -534,6 +529,13 @@ void MainWindow::setModeClient()
   m_ConfigScopes.save();
 }
 
+void MainWindow::quitApp()
+{
+  qDebug() << "quitting application";
+  m_Quitting = true;
+  QApplication::quit();
+}
+
 void MainWindow::onWindowSaveTimerTimeout()
 {
   saveWindow();
@@ -580,6 +582,7 @@ void MainWindow::open()
   // Duplicate quit needed for mac os tray menu
   QAction *actionTrayQuit = new QAction(tr("Quit Deskflow"), this);
   actionTrayQuit->setShortcut(QKeySequence::Quit);
+  connect(actionTrayQuit, &QAction::triggered, this, &MainWindow::quitApp);
 
   m_actionRestore->setText(tr("Open Deskflow"));
   trayActions.insert(3, m_actionRestore);

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -138,6 +138,7 @@ private slots:
 private:
   std::unique_ptr<Ui::MainWindow> ui;
 
+  void quitApp();
   void updateSize();
   AppConfig &appConfig()
   {


### PR DESCRIPTION
  Fixes the mac os tray quit not working (forgot to connect it to something) 
  Added a single method `MainWindow::quitApp` for both quit actions to call