### PR TITLE
refactor: Copy the full version string on the about dialog

### DIFF
--- a/src/apps/deskflow-gui/dialogs/AboutDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.cpp
@@ -39,19 +39,19 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 
   auto btnCopyVersion = new QPushButton(copyIcon, QString(), this);
   btnCopyVersion->setFlat(true);
-  connect(btnCopyVersion, &QPushButton::clicked, this, [] { QGuiApplication::clipboard()->setText(kVersion); });
+  connect(btnCopyVersion, &QPushButton::clicked, this, &AboutDialog::copyVersionText);
 
   // Set up the displayed version number
-  auto versionString = QString(kVersion);
-  if (versionString.endsWith(QStringLiteral(".0"))) {
-    versionString.chop(2);
+  m_versionString = QString(kVersion);
+  if (m_versionString.endsWith(QStringLiteral(".0"))) {
+    m_versionString.chop(2);
   } else {
-    versionString.append(QStringLiteral(" (%1)").arg(kVersionGitSha));
+    m_versionString.append(QStringLiteral(" (%1)").arg(kVersionGitSha));
   }
 
   auto versionLayout = new QHBoxLayout();
   versionLayout->addWidget(new QLabel(tr("Version:")));
-  versionLayout->addWidget(new QLabel(versionString, this));
+  versionLayout->addWidget(new QLabel(m_versionString, this));
   versionLayout->addWidget(btnCopyVersion);
   versionLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
 
@@ -85,4 +85,9 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
   setLayout(mainLayout);
   adjustSize();
   setFixedSize(size());
+}
+
+void AboutDialog::copyVersionText()
+{
+  QGuiApplication::clipboard()->setText(m_versionString);
 }

--- a/src/apps/deskflow-gui/dialogs/AboutDialog.h
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.h
@@ -29,6 +29,9 @@ public:
   ~AboutDialog() = default;
 
 private:
+  void copyVersionText();
+
+  QString m_versionString;
   inline static const auto s_lightCopy = QStringLiteral(":/icons/64x64/copy-light.png");
   inline static const auto s_darkCopy = QStringLiteral(":/icons/64x64/copy-dark.png");
   inline static const auto s_lightLogo = QStringLiteral(":/image/logo-light.png");


### PR DESCRIPTION
 Set it so the AboutDialog's copy version button copies the entire version number shown. 

Before it would capture only the kVersion (x.y.z.t) now its also will include any SHA if added to the dialo. This will make it easier to compare dev versions that are still PRs in cases where the generated version would be the same as another PR version due to them having the same number of commits to add on top of master. 