### PR TITLE
fix: The Tls Fingerprint label not being shown on start up

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -204,7 +204,6 @@ void MainWindow::setupControls()
   setWindowTitle(kAppName);
 
   secureSocket(false);
-  updateLocalFingerprint();
 
   ui->m_pLabelUpdate->setStyleSheet(kStyleNoticeLabel);
   ui->m_pLabelUpdate->hide();
@@ -360,7 +359,6 @@ void MainWindow::onConfigScopesSaving()
 
 void MainWindow::onAppConfigTlsChanged()
 {
-  updateLocalFingerprint();
   if (m_TlsUtility.isEnabled()) {
     m_TlsUtility.generateCertificate();
   }
@@ -674,6 +672,7 @@ void MainWindow::applyConfig()
 
   ui->lineHostname->setText(m_AppConfig.serverHostname());
   ui->lineClientIp->setText(m_ServerConfig.getClientAddress());
+  updateLocalFingerprint();
 }
 
 void MainWindow::applyCloseToTray() const

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -1011,7 +1011,7 @@ void MainWindow::updateLocalFingerprint()
     qFatal() << "failed to check if fingerprint exists";
   }
 
-  if (m_AppConfig.tlsEnabled() && fingerprintExists && ui->rbModeServer->isChecked()) {
+  if (m_AppConfig.tlsEnabled() && fingerprintExists) {
     ui->lblMyFingerprint->setVisible(true);
   } else {
     ui->lblMyFingerprint->setVisible(false);

--- a/src/apps/deskflow-gui/MainWindow.ui
+++ b/src/apps/deskflow-gui/MainWindow.ui
@@ -90,6 +90,16 @@
      </widget>
     </item>
     <item>
+     <widget class="QLabel" name="lblMyFingerprint">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;TLS enabled (&lt;a href=&quot;#&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#4285f4;&quot;&gt;fingerprint&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::RichText</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QWidget" name="m_pWidgetModes" native="true">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -239,19 +249,6 @@
               <widget class="deskflow::gui::widgets::ServerStateLabel" name="m_pLabelServerState">
                <property name="text">
                 <string>No clients connected</string>
-               </property>
-               <property name="indent">
-                <number>20</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="lblMyFingerprint">
-               <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;TLS enabled (&lt;a href=&quot;#&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#4285f4;&quot;&gt;fingerprint&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::TextFormat::RichText</enum>
                </property>
                <property name="indent">
                 <number>20</number>


### PR DESCRIPTION
This fixes the TLS fingerprint not being visible when enabled. moves it from the server box to the main window area and shows it no matter the mode.
 - Be sure to call `updateLocalFingerprint` when we apply a new config

 
![Screenshot_20241230_082629](https://github.com/user-attachments/assets/179db992-5311-4249-909f-fb2485d6e0fb)

fixes: #7924 