### PR TITLE
Allow only one instance of the gui

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -55,6 +55,7 @@ class QCheckBox;
 class QRadioButton;
 class QMessageBox;
 class QAbstractButton;
+class QLocalServer;
 
 class DeskflowApplication;
 class SetupWizard;
@@ -209,6 +210,9 @@ private:
   deskflow::gui::TlsUtility m_TlsUtility;
   QTimer m_WindowSaveTimer;
   QSize m_expandedSize = QSize();
+
+  QLocalServer *m_guiDupeChecker = nullptr;
+  inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
 
   // Window Actions
   QAction *m_actionAbout = nullptr;


### PR DESCRIPTION
 - allow only one instance of the gui to be running 
 - When in the background opening a new instance should pop up the current one , this should work nicely in places with out tray support. 
 - fixes #7975 
 - fixes #5304 (as a tray icon is not really needed to get the running instance back now)

Test Results: 

 -  [x] Mac OS:
    -  [X] macOS Restores when window is minimized
    -  [X] macOS Restores when window is hidden
    -  [X] macOS Restores when window was closed, Needs: https://github.com/deskflow/deskflow/pull/8034
 
 -  [X] Linux (Wayland):
    -  [X] Wayland Restores when window is minimized
        *Wayland doesn't allow for this on all De's the Icon flashes to request you look at the window instead
    -  [X] Wayland Restores when window is hidden
    -  [X] Wayland Restores when window was closed
 
 -  [X] Linux (X11):
    -  [X] X11 Restores when window is minimized
    -  [X] X11 Restores when window is hidden
    -  [X] X11 Restores when window was closed

  - [X] Windows:
    -  [X] Windows Restores when window is minimized
    -  [X] Windows Restores when window is hidden
    -  [X] Windows Restores when window was closed
