### PR TITLE
Proper hide to tray

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -314,13 +314,6 @@ void MainWindow::connectSlots()
   connect(ui->btnToggleLog, &QAbstractButton::toggled, this, &MainWindow::toggleLogVisible);
 }
 
-void MainWindow::onAppAboutToQuit()
-{
-  if (m_SaveOnExit) {
-    m_ConfigScopes.save();
-  }
-}
-
 void MainWindow::toggleLogVisible(bool visible)
 {
   if (visible) {

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -36,9 +36,6 @@
 #include "gui/tls/TlsFingerprint.h"
 #include "platform/wayland.h"
 
-#if defined(Q_OS_MAC)
-#include "gui/OSXHelpers.h"
-#endif
 #if defined(Q_OS_LINUX)
 #include "config.h"
 #endif

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -97,9 +97,6 @@ public:
 signals:
   void shown();
 
-public slots:
-  void onAppAboutToQuit();
-
 private slots:
   void toggleLogVisible(bool visible);
   //

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -138,7 +138,6 @@ private slots:
 private:
   std::unique_ptr<Ui::MainWindow> ui;
 
-  void quitApp();
   void updateSize();
   AppConfig &appConfig()
   {
@@ -152,7 +151,6 @@ private:
   void createStatusBar();
   void createTrayIcon();
   void applyConfig();
-  void applyCloseToTray() const;
   void setIcon();
   bool checkForApp(int which, QString &app);
   void setStatus(const QString &status);
@@ -190,7 +188,6 @@ private:
   QAbstractButton *m_pCancelButton = nullptr;
   bool m_SecureSocket = false;
   bool m_SaveWindow = false;
-  bool m_Quitting = false;
   deskflow::gui::config::ServerConfigDialogState m_ServerConfigDialogState;
   bool m_SaveOnExit = true;
   deskflow::gui::core::WaylandWarnings m_WaylandWarnings;

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -39,6 +39,10 @@
 #include "gui/core/WaylandWarnings.h"
 #include "gui/tls/TlsUtility.h"
 
+#ifdef Q_OS_MAC
+#include "gui/OSXHelpers.h"
+#endif
+
 class QAction;
 class QMenu;
 class QLineEdit;
@@ -93,6 +97,13 @@ public:
     return m_ServerConfig;
   }
   void autoAddScreen(const QString name);
+
+#ifdef Q_OS_MAC
+  void hide()
+  {
+    macOSNativeHide();
+  }
+#endif
 
 signals:
   void shown();

--- a/src/lib/gui/OSXHelpers.h
+++ b/src/lib/gui/OSXHelpers.h
@@ -31,4 +31,5 @@ bool isOSXDevelopmentBuild();
 bool showOSXNotification(const QString &title, const QString &body);
 bool isOSXInterfaceStyleDark();
 void forceAppActive();
+void macOSNativeHide();
 IconsTheme getOSXIconsTheme();

--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -112,6 +112,11 @@ void forceAppActive()
   [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 }
 
+void macOSNativeHide()
+{
+  [NSApp hide:nil];
+}
+
 IconsTheme getOSXIconsTheme()
 {
   if (@available(macOS 11, *))


### PR DESCRIPTION
 - Resolving Quitting vs Hiding in the `MainWindow::CloseEvent`
 - This simplifies the code around hiding and quiting alot
 - Remove unneeded `MainWindow::onAppAboutToQuit` slot 
 - Use Mac OS Native Hide on macOS to "hide to tray"