### PR TITLE
Configure with the Fallback version if git found with out tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ set(DESKFLOW_VERSION_PATCH 0)
 set(DESKFLOW_VERSION_TWEAK 0)
 
 # Get the version from git if it's a git repository
-# cmake-format: off
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git)
   if(GIT_FOUND)
@@ -50,36 +49,44 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --long --match v* --always
+      COMMAND ${GIT_EXECUTABLE} rev-list --tags --count
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE GITREV
-      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(FIND ${GITREV} "v" isRev)
-    if(NOT ifRev EQUAL -1)
-      string(REGEX MATCH [0-9]+ MAJOR ${GITREV})
-      string(REGEX MATCH \\.[0-9]+ MINOR ${GITREV})
-      string(REPLACE "." "" MINOR "${MINOR}")
-      string(REGEX MATCH [0-9]+\- PATCH ${GITREV})
-      string(REPLACE "-" "" PATCH "${PATCH}")
-      string(REGEX MATCH \-[0-9]+\- TWEAK ${GITREV})
-      string(REPLACE "-" "" TWEAK "${TWEAK}")
-      set(DESKFLOW_VERSION_MAJOR ${MAJOR})
-      set(DESKFLOW_VERSION_MINOR ${MINOR})
-      set(DESKFLOW_VERSION_PATCH ${PATCH})
-      set(DESKFLOW_VERSION_TWEAK ${TWEAK})
-    elseif(NOT ${GITREV} STREQUAL "")
-      set(DESKFLOW_VERSION_TWEAK ${GITREV})
+      OUTPUT_VARIABLE GIT_TAG_COUNT
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(GIT_TAG_COUNT EQUAL 0)
+      set(DESKFLOW_VERSION_TWEAK "9999")
+    else()
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --long --match v* --always
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        OUTPUT_VARIABLE GITREV
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+      string(FIND ${GITREV} "v" isRev)
+      if(NOT ifRev EQUAL -1)
+        string(REGEX MATCH [0-9]+ MAJOR ${GITREV})
+        string(REGEX MATCH \\.[0-9]+ MINOR ${GITREV})
+        string(REPLACE "." "" MINOR "${MINOR}")
+        string(REGEX MATCH [0-9]+\- PATCH ${GITREV})
+        string(REPLACE "-" "" PATCH "${PATCH}")
+        string(REGEX MATCH \-[0-9]+\- TWEAK ${GITREV})
+        string(REPLACE "-" "" TWEAK "${TWEAK}")
+        set(DESKFLOW_VERSION_MAJOR ${MAJOR})
+        set(DESKFLOW_VERSION_MINOR ${MINOR})
+        set(DESKFLOW_VERSION_PATCH ${PATCH})
+        set(DESKFLOW_VERSION_TWEAK ${TWEAK})
+      elseif(NOT ${GITREV} STREQUAL "")
+        set(DESKFLOW_VERSION_TWEAK ${GITREV})
+      endif()
     endif()
   endif()
 endif()
-# cmake-format: on
 
-set(DESKFLOW_VERSION
-    "${DESKFLOW_VERSION_MAJOR}.${DESKFLOW_VERSION_MINOR}.${DESKFLOW_VERSION_PATCH}.${DESKFLOW_VERSION_TWEAK}"
-)
-set(DESKFLOW_VERSION_MS_CSV
-    "${DESKFLOW_VERSION_MAJOR},${DESKFLOW_VERSION_MINOR},${DESKFLOW_VERSION_PATCH},${DESKFLOW_VERSION_TWEAK}"
-)
+set(DESKFLOW_VERSION "${DESKFLOW_VERSION_MAJOR}.${DESKFLOW_VERSION_MINOR}.${DESKFLOW_VERSION_PATCH}.${DESKFLOW_VERSION_TWEAK}")
+
+set(DESKFLOW_VERSION_MS_CSV "${DESKFLOW_VERSION_MAJOR},${DESKFLOW_VERSION_MINOR},${DESKFLOW_VERSION_PATCH},${DESKFLOW_VERSION_TWEAK}")
 
 #Define our project
 project(


### PR DESCRIPTION
  fixes https://github.com/deskflow/deskflow/issues/8033

 - Use the fallback version if the local copy has no tags 
 - This version will have a tweak of `9999` to make sure the SHA is show in the about dialog