### PR TITLE
Run MacDeployQt at install time on staged app only

### DIFF
--- a/deploy/mac/deploy.cmake
+++ b/deploy/mac/deploy.cmake
@@ -5,6 +5,10 @@
 # calling CMAKE_CURRENT_LIST_DIR after include would return the wrong scope var
 set(MY_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+# Install depends into our staged copy
+find_program(MACDEPLOYQT_BIN macdeployqt6)
+install(CODE "execute_process(COMMAND ${MACDEPLOYQT_BIN} \"\${CMAKE_INSTALL_PREFIX}/Deskflow.app\")")
+
 set(OS_STRING "macos-${CMAKE_SYSTEM_PROCESSOR}")
 set(CMAKE_INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks")
 set(CPACK_PACKAGE_ICON "${MY_DIR}/dmg-volume.icns")

--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -99,11 +99,6 @@ elseif(APPLE)
     MACOSX_BUNDLE_LONG_VERSION_STRING ${CMAKE_PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${CMAKE_PROJECT_VERSION}
   )
-  find_program(MACDEPLOYQT_BIN macdeployqt6)
-  add_custom_command(
-    TARGET ${target} POST_BUILD
-    COMMAND ${MACDEPLOYQT_BIN} "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${target}.app"
-  )
   install(TARGETS ${target} BUNDLE DESTINATION .)
 else()
   install(TARGETS ${target} DESTINATION bin)


### PR DESCRIPTION
Make it easier to run the locally built binaries on mac os by not running macdeployqt on app copies outside of a package staging directory. 
