### PR TITLE
Fix windows debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,13 @@ elseif(UNIX AND NOT APPLE)
 endif()
 
 option(BUILD_INSTALLER "Build installer" ON)
+
+# Building of packages with debug config is forbidden
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  message(STATUS "Disabling packaging in debug mode")
+  set(BUILD_INSTALLER OFF)
+endif()
+
 if(BUILD_INSTALLER)
     add_subdirectory(deploy)
 endif()

--- a/deploy/windows/deploy.cmake
+++ b/deploy/windows/deploy.cmake
@@ -12,6 +12,12 @@ configure_file(
   ${PROJECT_BINARY_DIR}/src/version.rc @ONLY
 )
 
+# Install Qt Depends to stage
+find_program(DEPLOYQT windeployqt6)
+install(CODE "execute_process(
+  COMMAND ${DEPLOYQT} --no-compiler-runtime --no-system-d3d-compiler --no-quick-import -network \"\${CMAKE_INSTALL_PREFIX}/deskflow.exe\"
+)")
+
 # Setup OS_STRING
 if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
   set(OS_STRING "win-x64")

--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -76,17 +76,6 @@ if(WIN32)
       ".*system32.*"
     RUNTIME DESTINATION .
   )
-  find_program(DEPLOYQT windeployqt6)
-  add_custom_command(
-    TARGET ${target} POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/qtDeploy
-      COMMAND ${DEPLOYQT} --no-compiler-runtime --no-system-d3d-compiler --no-quick-import -network --dir ${CMAKE_BINARY_DIR}/qtDeploy $<TARGET_FILE:${target}>
-  )
-  install(
-    DIRECTORY ${CMAKE_BINARY_DIR}/qtDeploy/
-    DESTINATION .
-    FILES_MATCHING PATTERN "*.*"
-  )
 elseif(APPLE)
   set_target_properties(${target} PROPERTIES
     INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks"


### PR DESCRIPTION
 - Run `windeployqt` at install time on package stage
 - Prevent package creation when the build is configured for debug