### PR TITLE
build:  set macOS RPATH for the gui via property

### DIFF
--- a/deploy/mac/deploy.cmake
+++ b/deploy/mac/deploy.cmake
@@ -10,7 +10,6 @@ find_program(MACDEPLOYQT_BIN macdeployqt6)
 install(CODE "execute_process(COMMAND ${MACDEPLOYQT_BIN} \"\${CMAKE_INSTALL_PREFIX}/Deskflow.app\")")
 
 set(OS_STRING "macos-${CMAKE_SYSTEM_PROCESSOR}")
-set(CMAKE_INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks")
 set(CPACK_PACKAGE_ICON "${MY_DIR}/dmg-volume.icns")
 set(CPACK_DMG_BACKGROUND_IMAGE "${MY_DIR}/dmg-background.tiff")
 set(CPACK_DMG_DS_STORE_SETUP_SCRIPT "${MY_DIR}/generate_ds_store.applescript")

--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -89,6 +89,7 @@ if(WIN32)
   )
 elseif(APPLE)
   set_target_properties(${target} PROPERTIES
+    INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks"
     MACOSX_BUNDLE_BUNDLE_NAME "Deskflow"
     MACOSX_BUNDLE_DISPLAY_NAME "Deskflow"
     MACOSX_BUNDLE_GUI_IDENTIFIER "org.deskflow.deskflow"


### PR DESCRIPTION
#8037 now breaks mac os CI builds as they are made w/o rpath this fixes that by defining the rpath in the gui's properties. 