### PR TITLE
MacOS Hide and Show from dock on close / hide of the GUI

### DIFF
--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -110,11 +110,13 @@ bool isOSXInterfaceStyleDark()
 void forceAppActive()
 {
   [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+  [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyRegular];
 }
 
 void macOSNativeHide()
 {
   [NSApp hide:nil];
+  [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
 }
 
 IconsTheme getOSXIconsTheme()


### PR DESCRIPTION
-  Add to our native mac calls on hide and showAndActivate the hints to tell mac os to remove/restore the dock icon

 In  #8034 we moved to native mac os hiding, This does not remove the dock icon.  

