### PR TITLE
Macos Sign the App with local cert

### DIFF
--- a/deploy/mac/deploy.cmake
+++ b/deploy/mac/deploy.cmake
@@ -7,7 +7,12 @@ set(MY_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # Install depends into our staged copy
 find_program(MACDEPLOYQT_BIN macdeployqt6)
-install(CODE "execute_process(COMMAND ${MACDEPLOYQT_BIN} \"\${CMAKE_INSTALL_PREFIX}/Deskflow.app\")")
+
+install(CODE "execute_process(COMMAND
+  ${MACDEPLOYQT_BIN}
+  \"\${CMAKE_INSTALL_PREFIX}/Deskflow.app\"
+  -timestamp -codesign=-
+)")
 
 set(OS_STRING "macos-${CMAKE_SYSTEM_PROCESSOR}")
 set(CPACK_PACKAGE_ICON "${MY_DIR}/dmg-volume.icns")


### PR DESCRIPTION
TLDR:
 1. We can use "Open Anyway" again
 2. Removes the need for the second Deskflow permission in accessibility 
 3. Fingers crossed No more permission removal and reassignment after "upgrading" Deskflow

Sign the app with a local dummy cert when building. This allows us to "distribute" and have users see the old this is untrusted dialog where they can use "Open Anyway" in setting to bypass it (no longer do they have to use xattr -c as the only method to initially run the application

This also seams to have the added side effect of the accessibility panel only showing ONE Deskflow entry and only asking once not neeed to ask again when connected to a server or when switching to server mode.

