### PR TITLE
Improve the Action Dialog UX

### DIFF
--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -36,6 +36,8 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 {
   ui->setupUi(this);
   connect(ui->keySequenceWidget, &KeySequenceWidget::keySequenceChanged, this, &ActionDialog::keySequenceChanged);
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ActionDialog::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ActionDialog::reject);
 
   // work around Qt Designer's lack of a QButtonGroup; we need it to get
   // at the button id of the checked radio button

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -35,6 +35,7 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
       m_buttonGroupType(new QButtonGroup(this))
 {
   ui->setupUi(this);
+  connect(ui->keySequenceWidget, &KeySequenceWidget::keySequenceChanged, this, &ActionDialog::keySequenceChanged);
 
   // work around Qt Designer's lack of a QButtonGroup; we need it to get
   // at the button id of the checked radio button
@@ -51,8 +52,8 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
   for (unsigned int i = 0; i < sizeof(typeButtons) / sizeof(typeButtons[0]); i++)
     m_buttonGroupType->addButton(typeButtons[i], i);
 
-  ui->m_pKeySequenceWidgetHotkey->setText(m_action.keySequence().toString());
-  ui->m_pKeySequenceWidgetHotkey->setKeySequence(m_action.keySequence());
+  ui->keySequenceWidget->setText(m_action.keySequence().toString());
+  ui->keySequenceWidget->setKeySequence(m_action.keySequence());
   m_buttonGroupType->button(m_action.type())->setChecked(true);
   ui->m_pComboSwitchInDirection->setCurrentIndex(m_action.switchDirection());
   ui->m_pComboLockCursorToScreen->setCurrentIndex(m_action.lockCursorMode());
@@ -80,10 +81,10 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 
 void ActionDialog::accept()
 {
-  if (!sequenceWidget()->valid() && m_buttonGroupType->checkedId() >= 0 && m_buttonGroupType->checkedId() < 3)
+  if (!ui->keySequenceWidget->valid() && m_buttonGroupType->checkedId() >= 0 && m_buttonGroupType->checkedId() < 3)
     return;
 
-  m_action.setKeySequence(sequenceWidget()->keySequence());
+  m_action.setKeySequence(ui->keySequenceWidget->keySequence());
   m_action.setType(m_buttonGroupType->checkedId());
   m_action.setHaveScreens(ui->m_pGroupBoxScreens->isChecked());
 
@@ -102,20 +103,15 @@ void ActionDialog::accept()
   QDialog::accept();
 }
 
-void ActionDialog::on_m_pKeySequenceWidgetHotkey_keySequenceChanged()
+void ActionDialog::keySequenceChanged()
 {
-  if (sequenceWidget()->keySequence().isMouseButton()) {
+  if (ui->keySequenceWidget->keySequence().isMouseButton()) {
     ui->m_pGroupBoxScreens->setEnabled(false);
     ui->m_pListScreens->setEnabled(false);
   } else {
     ui->m_pGroupBoxScreens->setEnabled(true);
     ui->m_pListScreens->setEnabled(true);
   }
-}
-
-const KeySequenceWidget *ActionDialog::sequenceWidget() const
-{
-  return ui->m_pKeySequenceWidgetHotkey;
 }
 
 ActionDialog::~ActionDialog() = default;

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -64,7 +64,6 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 
   ui->m_pGroupBoxScreens->setChecked(m_Action.haveScreens());
 
-  int idx = 0;
   for (const Screen &screen : config.screens()) {
     if (screen.isNull())
       continue;
@@ -75,9 +74,7 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 
     ui->m_pComboSwitchToScreen->addItem(screen.name());
     if (screen.name() == m_Action.switchScreenName())
-      ui->m_pComboSwitchToScreen->setCurrentIndex(idx);
-
-    idx++;
+      ui->m_pComboSwitchToScreen->setCurrentIndex(ui->m_pComboSwitchToScreen->count() - 1);
   }
 }
 

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -107,13 +107,8 @@ void ActionDialog::accept()
 
 void ActionDialog::keySequenceChanged()
 {
-  if (ui->keySequenceWidget->keySequence().isMouseButton()) {
-    ui->m_pGroupBoxScreens->setEnabled(false);
-    ui->m_pListScreens->setEnabled(false);
-  } else {
-    ui->m_pGroupBoxScreens->setEnabled(true);
-    ui->m_pListScreens->setEnabled(true);
-  }
+  ui->m_pGroupBoxScreens->setEnabled(!ui->keySequenceWidget->keySequence().isMouseButton());
+  ui->m_pListScreens->setEnabled(!ui->keySequenceWidget->keySequence().isMouseButton());
 }
 
 ActionDialog::~ActionDialog() = default;

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -60,10 +60,7 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
   ui->m_pComboSwitchInDirection->setCurrentIndex(m_action.switchDirection());
   ui->m_pComboLockCursorToScreen->setCurrentIndex(m_action.lockCursorMode());
 
-  if (m_action.activeOnRelease())
-    ui->m_pRadioHotkeyReleased->setChecked(true);
-  else
-    ui->m_pRadioHotkeyPressed->setChecked(true);
+  ui->comboTriggerOn->setCurrentIndex(m_action.haveScreens());
 
   ui->m_pGroupBoxScreens->setChecked(m_action.haveScreens());
 
@@ -99,7 +96,7 @@ void ActionDialog::accept()
   m_action.setSwitchScreenName(ui->m_pComboSwitchToScreen->currentText());
   m_action.setSwitchDirection(ui->m_pComboSwitchInDirection->currentIndex());
   m_action.setLockCursorMode(ui->m_pComboLockCursorToScreen->currentIndex());
-  m_action.setActiveOnRelease(ui->m_pRadioHotkeyReleased->isChecked());
+  m_action.setActiveOnRelease(ui->comboTriggerOn->currentIndex());
   m_action.setRestartServer(ui->m_pRadioRestartAllConnections->isChecked());
 
   QDialog::accept();

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -114,6 +114,14 @@ void ActionDialog::accept()
   QDialog::accept();
 }
 
+void ActionDialog::updateSize()
+{
+  setMaximumSize(QSize(16777215, 1677215));
+  adjustSize();
+  if (!isKeyAction(ui->comboActionType->currentIndex()))
+    setMaximumSize(size());
+}
+
 void ActionDialog::keySequenceChanged()
 {
   ui->listScreens->setEnabled(!ui->keySequenceWidget->keySequence().isMouseButton());
@@ -129,7 +137,7 @@ void ActionDialog::actionTypeChanged(int index)
   ui->comboSwitchToScreen->setVisible(index == ActionTypes::SwitchTo);
   ui->comboSwitchInDirection->setVisible(index == ActionTypes::SwitchInDirection);
   ui->comboLockCursorToScreen->setVisible(index == ActionTypes::ModifyCursorLock);
-  QTimer::singleShot(1, this, &ActionDialog::adjustSize);
+  QTimer::singleShot(1, this, &ActionDialog::updateSize);
 }
 
 bool ActionDialog::isKeyAction(int index)

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -30,9 +30,9 @@
 ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::ActionDialog>()},
-      m_Hotkey(hotkey),
-      m_Action(action),
-      m_pButtonGroupType(new QButtonGroup(this))
+      m_hotkey(hotkey),
+      m_action(action),
+      m_buttonGroupType(new QButtonGroup(this))
 {
   ui->setupUi(this);
 
@@ -49,55 +49,55 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
   };
 
   for (unsigned int i = 0; i < sizeof(typeButtons) / sizeof(typeButtons[0]); i++)
-    m_pButtonGroupType->addButton(typeButtons[i], i);
+    m_buttonGroupType->addButton(typeButtons[i], i);
 
-  ui->m_pKeySequenceWidgetHotkey->setText(m_Action.keySequence().toString());
-  ui->m_pKeySequenceWidgetHotkey->setKeySequence(m_Action.keySequence());
-  m_pButtonGroupType->button(m_Action.type())->setChecked(true);
-  ui->m_pComboSwitchInDirection->setCurrentIndex(m_Action.switchDirection());
-  ui->m_pComboLockCursorToScreen->setCurrentIndex(m_Action.lockCursorMode());
+  ui->m_pKeySequenceWidgetHotkey->setText(m_action.keySequence().toString());
+  ui->m_pKeySequenceWidgetHotkey->setKeySequence(m_action.keySequence());
+  m_buttonGroupType->button(m_action.type())->setChecked(true);
+  ui->m_pComboSwitchInDirection->setCurrentIndex(m_action.switchDirection());
+  ui->m_pComboLockCursorToScreen->setCurrentIndex(m_action.lockCursorMode());
 
-  if (m_Action.activeOnRelease())
+  if (m_action.activeOnRelease())
     ui->m_pRadioHotkeyReleased->setChecked(true);
   else
     ui->m_pRadioHotkeyPressed->setChecked(true);
 
-  ui->m_pGroupBoxScreens->setChecked(m_Action.haveScreens());
+  ui->m_pGroupBoxScreens->setChecked(m_action.haveScreens());
 
   for (const Screen &screen : config.screens()) {
     if (screen.isNull())
       continue;
     QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
     ui->m_pListScreens->addItem(pListItem);
-    if (m_Action.typeScreenNames().indexOf(screen.name()) != -1)
+    if (m_action.typeScreenNames().indexOf(screen.name()) != -1)
       ui->m_pListScreens->setCurrentItem(pListItem);
 
     ui->m_pComboSwitchToScreen->addItem(screen.name());
-    if (screen.name() == m_Action.switchScreenName())
+    if (screen.name() == m_action.switchScreenName())
       ui->m_pComboSwitchToScreen->setCurrentIndex(ui->m_pComboSwitchToScreen->count() - 1);
   }
 }
 
 void ActionDialog::accept()
 {
-  if (!sequenceWidget()->valid() && m_pButtonGroupType->checkedId() >= 0 && m_pButtonGroupType->checkedId() < 3)
+  if (!sequenceWidget()->valid() && m_buttonGroupType->checkedId() >= 0 && m_buttonGroupType->checkedId() < 3)
     return;
 
-  m_Action.setKeySequence(sequenceWidget()->keySequence());
-  m_Action.setType(m_pButtonGroupType->checkedId());
-  m_Action.setHaveScreens(ui->m_pGroupBoxScreens->isChecked());
+  m_action.setKeySequence(sequenceWidget()->keySequence());
+  m_action.setType(m_buttonGroupType->checkedId());
+  m_action.setHaveScreens(ui->m_pGroupBoxScreens->isChecked());
 
-  m_Action.typeScreenNames().clear();
+  m_action.typeScreenNames().clear();
 
   const auto &selection = ui->m_pListScreens->selectedItems();
   for (const QListWidgetItem *pItem : selection)
-    m_Action.typeScreenNames().append(pItem->text());
+    m_action.typeScreenNames().append(pItem->text());
 
-  m_Action.setSwitchScreenName(ui->m_pComboSwitchToScreen->currentText());
-  m_Action.setSwitchDirection(ui->m_pComboSwitchInDirection->currentIndex());
-  m_Action.setLockCursorMode(ui->m_pComboLockCursorToScreen->currentIndex());
-  m_Action.setActiveOnRelease(ui->m_pRadioHotkeyReleased->isChecked());
-  m_Action.setRestartServer(ui->m_pRadioRestartAllConnections->isChecked());
+  m_action.setSwitchScreenName(ui->m_pComboSwitchToScreen->currentText());
+  m_action.setSwitchDirection(ui->m_pComboSwitchInDirection->currentIndex());
+  m_action.setLockCursorMode(ui->m_pComboLockCursorToScreen->currentIndex());
+  m_action.setActiveOnRelease(ui->m_pRadioHotkeyReleased->isChecked());
+  m_action.setRestartServer(ui->m_pRadioRestartAllConnections->isChecked());
 
   QDialog::accept();
 }

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -66,18 +66,18 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 
   int idx = 0;
   for (const Screen &screen : config.screens()) {
-    if (!screen.isNull()) {
-      QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
-      ui->m_pListScreens->addItem(pListItem);
-      if (m_Action.typeScreenNames().indexOf(screen.name()) != -1)
-        ui->m_pListScreens->setCurrentItem(pListItem);
+    if (screen.isNull())
+      continue;
+    QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
+    ui->m_pListScreens->addItem(pListItem);
+    if (m_Action.typeScreenNames().indexOf(screen.name()) != -1)
+      ui->m_pListScreens->setCurrentItem(pListItem);
 
-      ui->m_pComboSwitchToScreen->addItem(screen.name());
-      if (screen.name() == m_Action.switchScreenName())
-        ui->m_pComboSwitchToScreen->setCurrentIndex(idx);
+    ui->m_pComboSwitchToScreen->addItem(screen.name());
+    if (screen.name() == m_Action.switchScreenName())
+      ui->m_pComboSwitchToScreen->setCurrentIndex(idx);
 
-      idx++;
-    }
+    idx++;
   }
 }
 

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * Copyright (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *
@@ -26,10 +27,9 @@
 
 #include <QButtonGroup>
 
-ActionDialog::ActionDialog(QWidget *parent, ServerConfig &config, Hotkey &hotkey, Action &action)
+ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::ActionDialog>()},
-      m_ServerConfig(config),
       m_Hotkey(hotkey),
       m_Action(action),
       m_pButtonGroupType(new QButtonGroup(this))
@@ -65,7 +65,7 @@ ActionDialog::ActionDialog(QWidget *parent, ServerConfig &config, Hotkey &hotkey
   ui->m_pGroupBoxScreens->setChecked(m_Action.haveScreens());
 
   int idx = 0;
-  for (const Screen &screen : serverConfig().screens()) {
+  for (const Screen &screen : config.screens()) {
     if (!screen.isNull()) {
       QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
       ui->m_pListScreens->addItem(pListItem);

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -48,8 +48,8 @@ protected:
 
 private:
   std::unique_ptr<Ui::ActionDialog> ui;
-  Hotkey &m_Hotkey;
-  Action &m_Action;
+  Hotkey &m_hotkey;
+  Action &m_action;
 
-  QButtonGroup *m_pButtonGroupType;
+  QButtonGroup *m_buttonGroupType;
 };

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -41,12 +41,10 @@ public:
 
 protected slots:
   void accept() override;
-  void on_m_pKeySequenceWidgetHotkey_keySequenceChanged();
-
-protected:
-  const KeySequenceWidget *sequenceWidget() const;
 
 private:
+  void keySequenceChanged();
+
   std::unique_ptr<Ui::ActionDialog> ui;
   Hotkey &m_hotkey;
   Action &m_action;

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -23,7 +23,6 @@
 
 class Hotkey;
 class Action;
-class QButtonGroup;
 class ServerConfig;
 class KeySequenceWidget;
 
@@ -36,6 +35,17 @@ class ActionDialog : public QDialog
   Q_OBJECT
 
 public:
+  enum ActionTypes
+  {
+    PressKey,
+    ReleaseKey,
+    ToggleKey,
+    SwitchTo,
+    SwitchInDirection,
+    ModifyCursorLock,
+    RestartServer
+  };
+
   ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action);
   ~ActionDialog() override;
 
@@ -44,10 +54,10 @@ protected slots:
 
 private:
   void keySequenceChanged();
+  void actionTypeChanged(int index);
+  bool isKeyAction(int index);
 
   std::unique_ptr<Ui::ActionDialog> ui;
   Hotkey &m_hotkey;
   Action &m_action;
-
-  QButtonGroup *m_buttonGroupType;
 };

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -53,6 +53,7 @@ protected slots:
   void accept() override;
 
 private:
+  void updateSize();
   void keySequenceChanged();
   void actionTypeChanged(int index);
   bool isKeyAction(int index);

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * Copyright (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
  *
@@ -36,7 +37,7 @@ class ActionDialog : public QDialog
   Q_OBJECT
 
 public:
-  ActionDialog(QWidget *parent, ServerConfig &config, Hotkey &hotkey, Action &action);
+  ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action);
   ~ActionDialog() override;
 
 protected slots:
@@ -45,14 +46,9 @@ protected slots:
 
 protected:
   const KeySequenceWidget *sequenceWidget() const;
-  const ServerConfig &serverConfig() const
-  {
-    return m_ServerConfig;
-  }
 
 private:
   std::unique_ptr<Ui::ActionDialog> ui;
-  const ServerConfig &m_ServerConfig;
   Hotkey &m_Hotkey;
   Action &m_Action;
 

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -23,7 +23,6 @@
 
 class Hotkey;
 class Action;
-class QRadioButton;
 class QButtonGroup;
 class ServerConfig;
 class KeySequenceWidget;

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.h
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.h
@@ -56,6 +56,7 @@ private:
   void keySequenceChanged();
   void actionTypeChanged(int index);
   bool isKeyAction(int index);
+  bool canSave();
 
   std::unique_ptr<Ui::ActionDialog> ui;
   Hotkey &m_hotkey;

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -13,7 +13,21 @@
   <property name="windowTitle">
    <string>Configure Action</string>
   </property>
-  <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QComboBox" name="comboTriggerOn">
+     <item>
+      <property name="text">
+       <string>When the hotkey is pressed</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>When the hotkey is released</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="m_pGroupType">
      <property name="font">
@@ -259,37 +273,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="font">
-      <font>
-       <kerning>false</kerning>
-      </font>
-     </property>
-     <property name="title">
-      <string>This action is performed when</string>
-     </property>
-     <layout class="QHBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="m_pRadioHotkeyPressed">
-        <property name="text">
-         <string>the hotkey is pressed</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioHotkeyReleased">
-        <property name="text">
-         <string>the hotkey is released</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -310,118 +293,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>m_pGroupType</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>104</x>
-     <y>194</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>110</x>
-     <y>132</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>118</x>
-     <y>322</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>81</x>
-     <y>129</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>101</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>68</x>
-     <y>126</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRestartAllConnections</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>101</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>68</x>
-     <y>126</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPress</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>48</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>45</x>
-     <y>129</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>135</x>
-     <y>70</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>148</x>
-     <y>125</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPressAndRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>194</x>
-     <y>100</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>201</x>
-     <y>125</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>m_pRadioSwitchToScreen</sender>
    <signal>toggled(bool)</signal>
@@ -579,22 +450,6 @@
     <hint type="destinationlabel">
      <x>79</x>
      <y>234</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keySequenceWidget</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>84</x>
-     <y>280</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>185</x>
-     <y>123</y>
     </hint>
    </hints>
   </connection>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -50,7 +50,7 @@
        </widget>
       </item>
       <item>
-       <widget class="KeySequenceWidget" name="m_pKeySequenceWidgetHotkey">
+       <widget class="KeySequenceWidget" name="keySequenceWidget">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>1</horstretch>
@@ -345,7 +345,7 @@
   <connection>
    <sender>m_pGroupType</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -361,7 +361,7 @@
   <connection>
    <sender>m_pRadioSwitchInDirection</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -377,7 +377,7 @@
   <connection>
    <sender>m_pRadioLockCursorToScreen</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -393,7 +393,7 @@
   <connection>
    <sender>m_pRadioRestartAllConnections</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -409,7 +409,7 @@
   <connection>
    <sender>m_pRadioPress</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -425,7 +425,7 @@
   <connection>
    <sender>m_pRadioRelease</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -441,7 +441,7 @@
   <connection>
    <sender>m_pRadioPressAndRelease</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -617,7 +617,7 @@
   <connection>
    <sender>m_pRadioSwitchToScreen</sender>
    <signal>toggled(bool)</signal>
-   <receiver>m_pKeySequenceWidgetHotkey</receiver>
+   <receiver>keySequenceWidget</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>375</width>
-    <height>528</height>
+    <width>521</width>
+    <height>428</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,40 +97,18 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="m_pGroupBoxScreens">
+       <widget class="QGroupBox" name="group_screens">
         <property name="title">
-         <string>only on these screens</string>
+         <string>Computers to recieve this event</string>
         </property>
-        <property name="flat">
-         <bool>true</bool>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <layout class="QHBoxLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QListWidget" name="m_pListScreens">
-           <property name="minimumSize">
-            <size>
-             <width>128</width>
-             <height>64</height>
-            </size>
+          <widget class="QListWidget" name="listScreens">
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustToContents</enum>
            </property>
            <property name="selectionMode">
-            <enum>QAbstractItemView::ExtendedSelection</enum>
+            <enum>QAbstractItemView::NoSelection</enum>
            </property>
           </widget>
          </item>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>0</width>
-    <height>0</height>
+    <width>706</width>
+    <height>256</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,20 +19,11 @@
   <property name="windowTitle">
    <string>Configure Action</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
+  <layout class="QVBoxLayout" name="_2">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QComboBox" name="comboTriggerOn">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <item>
         <property name="text">
          <string>When the hotkey is pressed</string>
@@ -47,12 +38,6 @@
      </item>
      <item>
       <widget class="QComboBox" name="comboActionType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <item>
         <property name="text">
          <string>Press key(s)</string>
@@ -106,12 +91,6 @@
        <property name="enabled">
         <bool>true</bool>
        </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <item>
         <property name="text">
          <string>Move to the screen on the left</string>
@@ -139,12 +118,6 @@
        <property name="enabled">
         <bool>true</bool>
        </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <item>
         <property name="text">
          <string>Toggle the cursor lock</string>
@@ -163,17 +136,7 @@
       </widget>
      </item>
      <item>
-      <widget class="KeySequenceWidget" name="keySequenceWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      <widget class="KeySequenceWidget" name="keySequenceWidget"/>
      </item>
     </layout>
    </item>
@@ -188,17 +151,11 @@
      <property name="title">
       <string>Computers to recieve this event</string>
      </property>
-     <layout class="QHBoxLayout">
+     <layout class="QHBoxLayout" name="_3">
       <item>
        <widget class="QListWidget" name="listScreens">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="sizeAdjustPolicy">
-         <enum>QAbstractScrollArea::AdjustToContents</enum>
+         <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContentsOnFirstShow</enum>
         </property>
        </widget>
       </item>
@@ -207,11 +164,8 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -6,18 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>521</width>
-    <height>428</height>
+    <width>0</width>
+    <height>0</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Configure Action</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QComboBox" name="comboTriggerOn">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
          <string>When the hotkey is pressed</string>
@@ -32,6 +47,12 @@
      </item>
      <item>
       <widget class="QComboBox" name="comboActionType">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
          <string>Press key(s)</string>
@@ -44,7 +65,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Toggle key(s)</string>
+         <string>Press and release key(s)</string>
         </property>
        </item>
        <item>
@@ -72,183 +93,114 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="m_pGroupType">
-     <property name="title">
-      <string/>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QComboBox" name="comboSwitchToScreen">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboSwitchInDirection">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Move to the screen on the left</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen on the right</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen above</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Move to the screen below</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboLockCursorToScreen">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Toggle the cursor lock</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Enable the cursor lock</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Disable the cursor lock</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="KeySequenceWidget" name="keySequenceWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupScreens">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QVBoxLayout">
+     <property name="title">
+      <string>Computers to recieve this event</string>
+     </property>
+     <layout class="QHBoxLayout">
       <item>
-       <widget class="KeySequenceWidget" name="keySequenceWidget">
+       <widget class="QListWidget" name="listScreens">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>1</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>256</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
         </property>
        </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="group_screens">
-        <property name="title">
-         <string>Computers to recieve this event</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="QListWidget" name="listScreens">
-           <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContents</enum>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::NoSelection</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Switch to</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboSwitchToScreen">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Direction to move</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboSwitchInDirection">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <item>
-           <property name="text">
-            <string>left</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>right</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>up</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>down</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Cursor lock will</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="m_pComboLockCursorToScreen">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <item>
-           <property name="text">
-            <string>toggle</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>on</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>off</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -55,12 +55,12 @@
        </item>
        <item>
         <property name="text">
-         <string>Switch to a screen</string>
+         <string>Switch to a computer</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Switch to the screen in a direction</string>
+         <string>Switch in a direction</string>
         </property>
        </item>
        <item>
@@ -93,22 +93,22 @@
        </property>
        <item>
         <property name="text">
-         <string>Move to the screen on the left</string>
+         <string>Switch to the computer on the left</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Move to the screen on the right</string>
+         <string>Switch to the computer on the right</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Move to the screen above</string>
+         <string>Switch to the computer above</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Move to the screen below</string>
+         <string>Switch to the computer below</string>
         </property>
        </item>
       </widget>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -311,38 +311,6 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ActionDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>245</x>
-     <y>474</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>ActionDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>313</x>
-     <y>474</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>m_pGroupType</sender>
    <signal>toggled(bool)</signal>
    <receiver>keySequenceWidget</receiver>

--- a/src/apps/deskflow-gui/dialogs/ActionDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ActionDialog.ui
@@ -15,54 +15,68 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QComboBox" name="comboTriggerOn">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
-      <property name="text">
-       <string>When the hotkey is pressed</string>
-      </property>
+      <widget class="QComboBox" name="comboTriggerOn">
+       <item>
+        <property name="text">
+         <string>When the hotkey is pressed</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>When the hotkey is released</string>
+        </property>
+       </item>
+      </widget>
      </item>
      <item>
-      <property name="text">
-       <string>When the hotkey is released</string>
-      </property>
+      <widget class="QComboBox" name="comboActionType">
+       <item>
+        <property name="text">
+         <string>Press key(s)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Release key(s)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Toggle key(s)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Switch to a screen</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Switch to the screen in a direction</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Modify the cursor lock</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Restart the server</string>
+        </property>
+       </item>
+      </widget>
      </item>
-    </widget>
+    </layout>
    </item>
    <item>
     <widget class="QGroupBox" name="m_pGroupType">
-     <property name="font">
-      <font>
-       <kerning>true</kerning>
-      </font>
-     </property>
      <property name="title">
-      <string>Choose the action to perform</string>
+      <string/>
      </property>
      <layout class="QVBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="m_pRadioPress">
-        <property name="text">
-         <string>Press a hotkey</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioRelease">
-        <property name="text">
-         <string>Release a hotkey</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="m_pRadioPressAndRelease">
-        <property name="text">
-         <string>Press and release a hotkey</string>
-        </property>
-       </widget>
-      </item>
       <item>
        <widget class="KeySequenceWidget" name="keySequenceWidget">
         <property name="sizePolicy">
@@ -133,9 +147,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioSwitchToScreen">
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>Switch to screen</string>
+           <string>Switch to</string>
           </property>
          </widget>
         </item>
@@ -164,9 +178,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioSwitchInDirection">
+         <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Switch in direction</string>
+           <string>Direction to move</string>
           </property>
          </widget>
         </item>
@@ -215,9 +229,9 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QRadioButton" name="m_pRadioLockCursorToScreen">
+         <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>Lock cursor to screen</string>
+           <string>Cursor lock will</string>
           </property>
          </widget>
         </item>
@@ -258,17 +272,6 @@
         </item>
        </layout>
       </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QRadioButton" name="m_pRadioRestartAllConnections">
-          <property name="text">
-           <string>Restart server</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
      </layout>
     </widget>
    </item>
@@ -292,166 +295,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboSwitchToScreen</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>148</x>
-     <y>291</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>290</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboSwitchInDirection</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>158</x>
-     <y>322</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>321</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pComboLockCursorToScreen</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>180</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>352</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPress</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>25</x>
-     <y>47</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>33</x>
-     <y>155</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>278</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>98</x>
-     <y>153</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>264</x>
-     <y>67</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>241</x>
-     <y>158</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioPressAndRelease</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>286</x>
-     <y>98</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>290</x>
-     <y>156</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioSwitchInDirection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>38</x>
-     <y>313</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>64</x>
-     <y>195</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioLockCursorToScreen</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>339</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>79</x>
-     <y>234</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_pRadioRestartAllConnections</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>m_pGroupBoxScreens</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>48</x>
-     <y>339</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>79</x>
-     <y>234</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/apps/deskflow-gui/dialogs/ServerConfigDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ServerConfigDialog.ui
@@ -59,7 +59,7 @@
             <bool>true</bool>
            </property>
            <property name="toolTip">
-            <string>Drag a screen from the grid to the trashcan to remove it.</string>
+            <string>Drag a computer from the grid to the trashcan to remove it.</string>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
@@ -461,7 +461,7 @@
           <item>
            <widget class="QCheckBox" name="m_pCheckBoxDisableLockToScreen">
             <property name="text">
-             <string>Disable lock to screen (scroll lock key)</string>
+             <string>Disable lock to computer (scroll lock key)</string>
             </property>
            </widget>
           </item>
@@ -902,7 +902,7 @@
        <item>
         <widget class="QLabel" name="label_6">
          <property name="text">
-          <string>Use a server config file to create complex screen layouts that are not possible with the simple grid-based screen layout editor.
+          <string>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</string>
          </property>

--- a/src/apps/deskflow-gui/widgets/KeySequenceWidget.cpp
+++ b/src/apps/deskflow-gui/widgets/KeySequenceWidget.cpp
@@ -37,8 +37,8 @@ KeySequenceWidget::KeySequenceWidget(QWidget *parent, const KeySequence &seq)
 
 void KeySequenceWidget::setKeySequence(const KeySequence &seq)
 {
-  keySequence() = seq;
-  backupSequence() = seq;
+  m_KeySequence = seq;
+  m_BackupSequence = seq;
 
   setStatus(Stopped);
   updateOutput();
@@ -61,7 +61,7 @@ void KeySequenceWidget::mousePressEvent(QMouseEvent *event)
 
 void KeySequenceWidget::startRecording()
 {
-  keySequence() = KeySequence();
+  m_KeySequence = KeySequence();
   setDown(true);
   setFocus();
   grabKeyboard();
@@ -71,7 +71,7 @@ void KeySequenceWidget::startRecording()
 void KeySequenceWidget::stopRecording()
 {
   if (!keySequence().valid()) {
-    keySequence() = backupSequence();
+    m_KeySequence = backupSequence();
     updateOutput();
   }
 
@@ -101,7 +101,7 @@ bool KeySequenceWidget::event(QEvent *event)
     case QEvent::FocusOut:
       stopRecording();
       if (!valid()) {
-        keySequence() = backupSequence();
+        m_KeySequence = backupSequence();
         updateOutput();
       }
       break;

--- a/src/apps/deskflow-gui/widgets/KeySequenceWidget.h
+++ b/src/apps/deskflow-gui/widgets/KeySequenceWidget.h
@@ -89,14 +89,6 @@ protected:
   void updateOutput();
   void startRecording();
   void stopRecording();
-  KeySequence &keySequence()
-  {
-    return m_KeySequence;
-  }
-  KeySequence &backupSequence()
-  {
-    return m_BackupSequence;
-  }
 
 private:
   enum Status


### PR DESCRIPTION
a Modified port the updates i made to the Action Dialog in Input Leap
 
- Replace user facing string of `screen` -> `computer`

https://github.com/input-leap/input-leap/pull/1837
https://github.com/input-leap/input-leap/pull/1838
https://github.com/input-leap/input-leap/pull/1830

(FROM IL PR)

This Pr will be used to Improve the UX for the Action Dialog

 Before: 
<img alt="" width="350" src="https://github.com/user-attachments/assets/b7ebb4f3-ac4d-425b-b050-8f4452f4a101">

After Ui:

Key press, toggle and release look the same but different action strings

<img alt="" width="350" src="https://github.com/user-attachments/assets/53936382-5a23-4e96-a4a4-6fe321a034bd">

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/e0e5d03c-7c6e-4e1f-b352-ac35b7fdc3b5">

<img alt="" width="350" src="https://github.com/user-attachments/assets/99aa4c0c-76f4-4099-8ed7-8ac94dbae5c7">

<img alt="" width="350" src="https://github.com/input-leap/input-leap/assets/7450820/98b015be-54fc-4d92-be91-b8e73f9b2869">
