### PR TITLE
fix: messages read into vector are cut off by 4 bytes

### DIFF
--- a/src/lib/deskflow/ProtocolUtil.h
+++ b/src/lib/deskflow/ProtocolUtil.h
@@ -95,6 +95,7 @@ private:
   static void readVector1ByteInt(deskflow::IStream *, std::vector<UInt8> &);
   static void readVector2BytesInt(deskflow::IStream *, std::vector<UInt16> &);
   static void readVector4BytesInt(deskflow::IStream *, std::vector<UInt32> &);
+  static UInt32 readVectorSize(deskflow::IStream *stream);
 
   /**
    * @brief Handles an array of bytes


### PR DESCRIPTION
This is a candidate fix for https://github.com/deskflow/deskflow/issues/8016.

[This line](https://github.com/deskflow/deskflow/commit/ab44559df6ebcd18c4a7fa088dbc608c75981d6e#diff-4ada4360f34addf3e4ad4389e49967a9617ba8b22b9da1c1fc682370e0062a24R180): `UInt32 n = read4BytesInt(stream);` added to `ProtocolUtil::vreadf` in commit https://github.com/deskflow/deskflow/commit/ab44559df6ebcd18c4a7fa088dbc608c75981d6e reads the length of a vector that is then re-read again in `readVector4BytesInt` (or `readVector1BytesInt` or `readVector2BytesInt`.) That second read eats the first 4 bytes of the content, interprets them as a length, and reads the shortest of that misinterpreted length and what's available on the stream. The read buffer is offset by the 4 missing bytes from the original.

https://github.com/deskflow/deskflow/issues/8016 is caused by this issue occurring in `ServerProxy::setOptions()` during startup. Machines experiencing this issue see a `recv set options size=31` log, corresponding to a `send set options to "..." size=32` from the server. ~As options are interpreted one at a time, most of them are still received and interpreted correctly (I think -- I didn't check.) The missing int, however, seems to account for the missing mapping config~. Most options are parsed as a key-value pair of ints. The modifier mappings definitely are. The off-by-one offset introduced by the extra read makes option values get read as keys and thus prevents correct parsing.

In my affected Mac machine, the first int of the option was interpreted as some huge number. However, reading stopped after the remaining 31 ints were read from the stream. I assume that was because there wasn't anything left on it. Needless to say, this affects all vector reads, and so the impact of the bug goes beyond just the missing mappings.

This change is just a proposal -- it moves the length sanity check to the functions that read into a vector. The code is duplicated, but it's not a whole lot. I didn't see a peek or pushback method that would let me read non-destructively from the stream, and didn't want to modify the method signatures to accept a size -- but doing any of that could be an option.