### PR TITLE
build: run macdeployqt on package

### DIFF
--- a/deploy/mac/deploy.cmake
+++ b/deploy/mac/deploy.cmake
@@ -6,7 +6,7 @@
 set(MY_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 install(CODE "execute_process(COMMAND
-  ${DEPLOYQT_BIN}
+  ${DEPLOYQT}
   \"\${CMAKE_INSTALL_PREFIX}/Deskflow.app\"
   -timestamp -codesign=-
 )")


### PR DESCRIPTION
Hotfix, typo in the name of the mac deploy tool prevents it from running on package.