### PR TITLE
fix: Enter screen on mac os asap to ensure event hand off

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -803,6 +803,7 @@ void OSXScreen::disable()
 
 void OSXScreen::enter()
 {
+  m_isOnScreen = true;
   showCursor();
 
   if (m_isPrimary) {
@@ -822,9 +823,6 @@ void OSXScreen::enter()
 
     avoidSupression();
   }
-
-  // now on screen
-  m_isOnScreen = true;
 }
 
 bool OSXScreen::canLeave()


### PR DESCRIPTION
based on https://github.com/input-leap/input-leap/pull/2116 by @spottenn 

Entering the screen at the top of enter should ensure new event happen on the screen.
