### PR TITLE
Tray menu include show hide

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -877,23 +877,6 @@ void MainWindow::onCoreConnectionStateChanged(CoreConnectionState state)
   }
 }
 
-void MainWindow::setVisible(bool visible)
-{
-  QMainWindow::setVisible(visible);
-#ifdef Q_OS_MAC
-  // dock hide only supported on lion :(
-  ProcessSerialNumber psn = {0, kCurrentProcess};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  GetCurrentProcess(&psn);
-#pragma GCC diagnostic pop
-  if (visible)
-    TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-  else
-    TransformProcessType(&psn, kProcessTransformToBackgroundApplication);
-#endif
-}
-
 QString MainWindow::getIPAddresses() const
 {
   QStringList result;

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -98,12 +98,7 @@ public:
   }
   void autoAddScreen(const QString name);
 
-#ifdef Q_OS_MAC
-  void hide()
-  {
-    macOSNativeHide();
-  }
-#endif
+  void hide();
 
 signals:
   void shown();
@@ -212,6 +207,7 @@ private:
   QAction *m_actionHelp = nullptr;
   QAction *m_actionMinimize = nullptr;
   QAction *m_actionQuit = nullptr;
+  QAction *m_actionTrayQuit = nullptr;
   QAction *m_actionRestore = nullptr;
   QAction *m_actionSave = nullptr;
   QAction *m_actionSettings = nullptr;

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -85,7 +85,6 @@ public:
   explicit MainWindow(deskflow::gui::ConfigScopes &configScopes, AppConfig &appConfig);
   ~MainWindow() override;
 
-  void setVisible(bool visible) override;
   CoreMode coreMode() const
   {
     return m_CoreProcess.mode();


### PR DESCRIPTION
When testing XFCE i noticed that their tray impl blocks the "activated" state of the tray so its not possible to hide / show by clicking on it (like mac os). This PR fixes this by

 - Add `Open Deskflow` and `Minimize to tray` to the tray menu
 - Added a second action for the tray's Quit action (mac os will move the first and this is incase others do too)
 - Remove the window menu (the hide show happens on window close or via the tray icon now)
 - Remove old code used on mac os to hide the dock icon when the window is not visible (it does not work and our new native code is less code and works) 

fixes: #8095  (it seams not all GNOME Tray exts allow you "activate" either) 