### PR TITLE
Add Arch conflict package and update linux readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Windows 10 or higher is required.
 
 macOS 12 or higher is required.
 
-All Linux distributions are supported, primarily focusing on: 
-Debian, Ubuntu, Linux Mint, Fedora, RHEL, AlmaLinux, Rocky Linux, Arch Linux, openSUSE, Gentoo.
+Linux requires libei 1.3+ and libportal 0.8+ for the server/client. Additionally, Qt 6.7+ is required for the GUI.
+Linux users with systems not meeting these requirements should use flatpak in place of a native package.
 
 We officially support FreeBSD, and would also like to support: OpenBSD, NetBSD, DragonFly, Solaris.
 

--- a/deploy/linux/arch/PKGBUILD.in
+++ b/deploy/linux/arch/PKGBUILD.in
@@ -5,8 +5,10 @@ pkgver=@DESKFLOW_VERSION@
 pkgrel=1
 pkgdesc="Mouse and keyboard sharing utility"
 url='https://deskflow.org'
-arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')
-license=('GPL-2.0-only')
+arch=('i686' 'x86_64' 'armv7h' 'aarch64')
+license=(LicenseRef-GPL-2.0-only-WITH-OpenSSL-Exception)
+conflicts=('synergy-git' 'synergy-1.6' 'synergy1-bin' 'synergy2-bin' 'synergy3-bin' 'synergy3-beta-bin' 'synergy3-stable-bin' 'barrier' 'barrier-git' 'barrier-headless' 'barrier-headless-git' 'input-leap' 'input-leap-git' 'input-leap-headless-git' 'input-leap-headless' 'waynergy' 'waynergy-git' 'qsynergy' 'slim-synergy' 'quicksynergy' 'deskflow')
+provides=("deskflow-git${pkgver}")
 depends=(
   'gcc-libs'
   'glibc'
@@ -28,7 +30,6 @@ depends=(
   'tomlplusplus'
   'cli11'
 )
-conflicts=('synergy-git' 'synergy1-bin' 'synergy2-bin' 'synergy3-bin')
 options=('!debug')
 
 package() {


### PR DESCRIPTION
 - Update linux info on the readme to not say specific distros but instead the need for ei / portal and Qt(for the gui) 
 
 -Add conflicts to the pkgbuild for arch , license is updated to w/ ssl exception string and do not install extra copy of the license