### PR TITLE
chore: remove unused GUI_HOOK

### DIFF
--- a/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
@@ -76,9 +76,6 @@ SettingsDialog::SettingsDialog(
       Qt::QueuedConnection
   );
 
-#ifdef DESKFLOW_GUI_HOOK_SETTINGS
-  DESKFLOW_GUI_HOOK_SETTINGS
-#endif
   adjustSize();
   QApplication::processEvents();
   setFixedHeight(height());

--- a/src/apps/deskflow-gui/main.cpp
+++ b/src/apps/deskflow-gui/main.cpp
@@ -168,10 +168,6 @@ int main(int argc, char *argv[])
   MainWindow mainWindow(configScopes, appConfig);
   mainWindow.open();
 
-#ifdef DESKFLOW_GUI_HOOK_START
-  DESKFLOW_GUI_HOOK_START
-#endif
-
   return QApplication::exec();
 }
 


### PR DESCRIPTION
 - Remove two more unused `DESKFLOW_GUI` Defines