### PR TITLE
fixes 8106, by adjusting the spacing of the about dialog

### DIFF
--- a/src/apps/deskflow-gui/dialogs/AboutDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.ui
@@ -29,6 +29,9 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>12</number>
+   </property>
    <item>
     <widget class="QWidget" name="frameLogo" native="true">
      <property name="sizePolicy">
@@ -285,6 +288,22 @@ p, li { white-space: pre-wrap; }
       <string notr="true">lblCopyright</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>6</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox_17">


### PR DESCRIPTION
Fix 8106 adjust vertical spacing. 
<img width="440" alt="Screenshot 2025-01-19 at 11 20 56 PM" src="https://github.com/user-attachments/assets/9ed420af-0643-46fe-b694-2d112073354e" />
