### PR TITLE
fix: #8119, by adding missing BSD checks for installing deskflow binaries

### DIFF
--- a/src/apps/deskflow-client/CMakeLists.txt
+++ b/src/apps/deskflow-client/CMakeLists.txt
@@ -113,11 +113,11 @@ target_link_libraries(
   app
   ${libs})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_BUNDLE_CONTENT_DIR:${CMAKE_PROJECT_PROPER_NAME}>/MacOS)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+elseif(UNIX)
   install(TARGETS ${target} DESTINATION bin)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+elseif(WIN32)
   install(
     TARGETS ${target}
     RUNTIME_DEPENDENCY_SET clientDeps

--- a/src/apps/deskflow-core/CMakeLists.txt
+++ b/src/apps/deskflow-core/CMakeLists.txt
@@ -43,11 +43,11 @@ target_link_libraries(
   app
   ${libs})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_BUNDLE_CONTENT_DIR:${CMAKE_PROJECT_PROPER_NAME}>/MacOS)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+elseif(UNIX)
   install(TARGETS ${target} DESTINATION bin)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+elseif(WIN32)
   install(
     TARGETS ${target}
     RUNTIME_DEPENDENCY_SET coreDeps

--- a/src/apps/deskflow-server/CMakeLists.txt
+++ b/src/apps/deskflow-server/CMakeLists.txt
@@ -117,11 +117,11 @@ target_link_libraries(
   app
   ${libs})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_BUNDLE_CONTENT_DIR:${CMAKE_PROJECT_PROPER_NAME}>/MacOS)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+elseif(UNIX)
   install(TARGETS ${target} DESTINATION bin)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+elseif(WIN32)
   install(
     TARGETS ${target}
     RUNTIME_DEPENDENCY_SET serverDeps


### PR DESCRIPTION
Fixes #8119 (using the same method as pr #6649)