### PR TITLE
Fix keymap not correctly loading for the Ei backend

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -60,6 +60,7 @@ void EiKeyState::init_default_keymap()
 void EiKeyState::init(int fd, size_t len)
 {
   auto buffer = std::make_unique<char[]>(len + 1);
+  lseek(fd, 0, SEEK_SET);
   auto sz = read(fd, buffer.get(), len);
 
   if ((size_t)sz < len) {


### PR DESCRIPTION
On some systems, the keymap file provided by Ei required to create the XKB context is not properly seeked to the start.
This will cause reading the file to fail (or, more accurately, just cause 0 bytes to be read), causing the keymap to just default to a US-keymap.
This PR fixes this, causing the correct keymap to be loaded.
See input-leap/input-leap#2158