### PR TITLE
refactor: Use correct log level for failure messages

### DIFF
--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -321,7 +321,7 @@ void ClientApp::handleClientFailed(const Event &e, void *)
     std::unique_ptr<Client::FailInfo> info(static_cast<Client::FailInfo *>(e.getData()));
 
     updateStatus(std::string("Failed to connect to server: ") + info->m_what + " Trying next address...");
-    LOG((CLOG_NOTE "failed to connect to server=%s, trying next address", info->m_what.c_str()));
+    LOG((CLOG_WARN "failed to connect to server=%s, trying next address", info->m_what.c_str()));
     if (!m_suspended) {
       scheduleClientRestart(nextRestartTimeout());
     }

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -558,7 +558,7 @@ const KeyMap::KeyItem *KeyMap::mapCommandKey(
 
   // add keystrokes to restore modifier keys
   if (!keysToRestoreModifiers(*keyItem, group, newModifiers, newState, activeModifiers, keys)) {
-    LOG((CLOG_DEBUG1 "failed to restore modifiers"));
+    LOG((CLOG_DEBUG1 "modifiers were not restored"));
     keys.clear();
     return NULL;
   }
@@ -629,7 +629,7 @@ const KeyMap::KeyItem *KeyMap::mapCharacterKey(
 
   // add keystrokes to restore modifier keys
   if (!keysToRestoreModifiers(keyItem, group, newModifiers, newState, activeModifiers, keys)) {
-    LOG((CLOG_DEBUG1 "failed to restore modifiers"));
+    LOG((CLOG_DEBUG1 "modifiers were not restored"));
     keys.clear();
     return NULL;
   }

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -170,19 +170,19 @@ void AppUtilUnix::showNotification(const std::string &title, const std::string &
 #if HAVE_LIBNOTIFY
   LOG((CLOG_INFO "showing notification, title=\"%s\", text=\"%s\"", title.c_str(), text.c_str()));
   if (!notify_init(kAppName)) {
-    LOG((CLOG_INFO "failed to initialize libnotify"));
+    LOG((CLOG_WARN "failed to initialize libnotify"));
     return;
   }
 
   auto notification = notify_notification_new(title.c_str(), text.c_str(), nullptr);
   if (notification == nullptr) {
-    LOG((CLOG_INFO "failed to create notification"));
+    LOG((CLOG_WARN "failed to create notification"));
     return;
   }
   notify_notification_set_timeout(notification, 10000);
 
   if (!notify_notification_show(notification, nullptr)) {
-    LOG((CLOG_INFO "failed to show notification"));
+    LOG((CLOG_WARN "failed to show notification"));
   }
 
   g_object_unref(G_OBJECT(notification));

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -266,7 +266,7 @@ void AppUtilWindows::showNotification(const std::string &title, const std::strin
     WinToastLib::WinToast::instance()->setAppUserModelId(aumi);
 
     if (!WinToastLib::WinToast::instance()->initialize()) {
-      LOG((CLOG_DEBUG "failed to initialize toast notifications"));
+      LOG((CLOG_WARN "failed to initialize toast notifications"));
       return;
     }
   }
@@ -279,7 +279,7 @@ void AppUtilWindows::showNotification(const std::string &title, const std::strin
 
   const bool launched = WinToastLib::WinToast::instance()->showToast(templ, handler.get(), &error);
   if (!launched) {
-    LOG((CLOG_DEBUG "failed to show toast notification, error code: %d", error));
+    LOG((CLOG_WARN "failed to show toast notification, error code: %d", error));
     return;
   }
 #else

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -22,6 +22,7 @@
 #include "gui/core/CoreTool.h"
 #include "gui/paths.h"
 #include "tls/TlsUtility.h"
+#include <qlogging.h>
 
 #if defined(Q_OS_MAC)
 #include "OSXHelpers.h"
@@ -406,10 +407,10 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
   addGenericArgs(args, processMode);
 
   if (mode() == Mode::Server && !addServerArgs(args, app)) {
-    qDebug("failed to add server args for core process, aborting start");
+    qWarning("failed to add server args for core process, aborting start");
     return;
   } else if (mode() == Mode::Client && !addClientArgs(args, app)) {
-    qDebug("failed to add client args for core process, aborting start");
+    qWarning("failed to add client args for core process, aborting start");
     return;
   }
 

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -64,7 +64,7 @@ void EiKeyState::init(int fd, size_t len)
   auto sz = read(fd, buffer.get(), len);
 
   if ((size_t)sz < len) {
-    LOG_DEBUG("failed to create xkb context: %s", strerror(errno));
+    LOG_WARN("failed to create xkb context: %s", strerror(errno));
     return;
   }
 
@@ -76,7 +76,7 @@ void EiKeyState::init(int fd, size_t len)
   buffer[len] = '\0'; // guarantee null-termination
   auto keymap = xkb_keymap_new_from_string(xkb_, buffer.get(), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
   if (!keymap) {
-    LOG_NOTE("failed to compile keymap, falling back to defaults");
+    LOG_WARN("failed to compile keymap, falling back to defaults");
     // Falling back to layout "us" is a lot more useful than segfaulting
     init_default_keymap();
     return;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -712,7 +712,7 @@ void EiScreen::handle_connected_to_eis_event(const Event &event, void *)
 
   auto rc = ei_setup_backend_fd(ei_, fd);
   if (rc != 0) {
-    LOG_NOTE("failed to set up ei: %s", strerror(-rc));
+    LOG_WARN("failed to set up ei: %s", strerror(-rc));
   }
 }
 

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -70,7 +70,7 @@ bool MSWindowsClipboard::emptyUnowned()
   if (!EmptyClipboard()) {
     // unable to cause this in integ tests, but this error has never
     // actually been reported by users.
-    LOG((CLOG_DEBUG "failed to grab clipboard"));
+    LOG((CLOG_WARN "failed to grab clipboard"));
     return false;
   }
 
@@ -86,7 +86,7 @@ bool MSWindowsClipboard::empty()
   // mark clipboard as being owned by deskflow
   HGLOBAL data = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, 1);
   if (NULL == SetClipboardData(getOwnershipFormat(), data)) {
-    LOG((CLOG_DEBUG "failed to set clipboard data"));
+    LOG((CLOG_WARN "failed to set clipboard data"));
     GlobalFree(data);
     return false;
   }

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -237,7 +237,7 @@ void MSWindowsScreen::enable()
 
   // install our clipboard snooper
   if (!AddClipboardFormatListener(m_window)) {
-    LOG((CLOG_DEBUG "failed to add the clipboard format listener: %d", GetLastError()));
+    LOG((CLOG_WARN "failed to add the clipboard format listener: %d", GetLastError()));
   }
 
   // track the active desk and (re)install the hooks
@@ -270,7 +270,7 @@ void MSWindowsScreen::disable()
 
   // stop snooping the clipboard
   if (!RemoveClipboardFormatListener(m_window)) {
-    LOG((CLOG_DEBUG "failed to remove the clipboard format listener: %d", GetLastError()));
+    LOG((CLOG_WARN "failed to remove the clipboard format listener: %d", GetLastError()));
   }
 
   // uninstall fix timer
@@ -554,7 +554,7 @@ bool MSWindowsScreen::setThisCursorPos(int x, int y)
 
 void MSWindowsScreen::updateDesktopThread()
 {
-  LOG((CLOG_DEBUG3 "failed to set cursor while attempting to switch desktop"));
+  LOG((CLOG_WARN "failed to set cursor while attempting to switch desktop"));
   SetLastError(0);
   HDESK cur_hdesk = OpenInputDesktop(0, true, GENERIC_ALL);
 
@@ -1818,7 +1818,7 @@ std::string &MSWindowsScreen::getDraggingFilename()
     }
 
     if (m_draggingFilename.empty()) {
-      LOG((CLOG_DEBUG "failed to get drag file name from OLE"));
+      LOG((CLOG_WARN "failed to get drag file name from OLE"));
     }
   }
   return m_draggingFilename;

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -41,7 +41,7 @@ OSXClipboard::OSXClipboard() : m_time(0), m_pboard(NULL)
 
   OSStatus createErr = PasteboardCreate(kPasteboardClipboard, &m_pboard);
   if (createErr != noErr) {
-    LOG((CLOG_DEBUG "failed to create clipboard reference: error %i", createErr));
+    LOG((CLOG_WARN "failed to create clipboard reference: error %i", createErr));
     LOG((CLOG_ERR "unable to connect to pasteboard, clipboard sharing disabled", createErr));
     m_pboard = NULL;
     return;
@@ -49,7 +49,7 @@ OSXClipboard::OSXClipboard() : m_time(0), m_pboard(NULL)
 
   OSStatus syncErr = PasteboardSynchronize(m_pboard);
   if (syncErr != noErr) {
-    LOG((CLOG_DEBUG "failed to syncronize clipboard: error %i", syncErr));
+    LOG((CLOG_WARN "failed to syncronize clipboard: error %i", syncErr));
   }
 }
 
@@ -66,7 +66,7 @@ bool OSXClipboard::empty()
 
   OSStatus err = PasteboardClear(m_pboard);
   if (err != noErr) {
-    LOG((CLOG_DEBUG "failed to clear clipboard: error %i", err));
+    LOG((CLOG_WARN "failed to clear clipboard: error %i", err));
     return false;
   }
 

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -129,13 +129,13 @@ void XWindowsClipboard::addRequest(Window owner, Window requestor, Atom target, 
         success = true;
       }
     } else {
-      LOG((CLOG_DEBUG1 "failed, not owned at time %d", time));
+      LOG((CLOG_DEBUG1 "clipboard not owned at time %d", time));
     }
   }
 
   if (!success) {
     // send failure
-    LOG((CLOG_DEBUG1 "failed"));
+    LOG((CLOG_DEBUG1 "clipboard request was not added"));
     insertReply(new Reply(requestor, target, time));
   }
 
@@ -179,12 +179,12 @@ bool XWindowsClipboard::addSimpleRequest(Window requestor, Atom target, ::Time t
 
   if (type != None) {
     // success
-    LOG((CLOG_DEBUG1 "success"));
+    LOG((CLOG_DEBUG1 "clipboard request added"));
     insertReply(new Reply(requestor, target, time, property, data, type, format));
     return true;
   } else {
     // failure
-    LOG((CLOG_DEBUG1 "failed"));
+    LOG((CLOG_DEBUG1 "clipboard request not added"));
     insertReply(new Reply(requestor, target, time));
     return false;
   }
@@ -255,7 +255,7 @@ bool XWindowsClipboard::empty()
   // assert ownership of clipboard
   XSetSelectionOwner(m_display, m_selection, m_window, m_time);
   if (XGetSelectionOwner(m_display, m_selection) != m_window) {
-    LOG((CLOG_DEBUG "failed to grab clipboard %d", m_id));
+    LOG((CLOG_WARN "failed to grab clipboard %d", m_id));
     return false;
   }
 
@@ -294,7 +294,7 @@ void XWindowsClipboard::add(EFormat format, const std::string &data)
 bool XWindowsClipboard::open(Time time) const
 {
   if (m_open) {
-    LOG((CLOG_DEBUG "failed to open clipboard: already opened"));
+    LOG((CLOG_WARN "failed to open clipboard: already opened"));
     return false;
   }
 

--- a/src/lib/platform/XWindowsPowerManager.cpp
+++ b/src/lib/platform/XWindowsPowerManager.cpp
@@ -44,7 +44,7 @@ void XWindowsPowerManager::disableSleep() const
 {
   if (!sleepInhibitCall(true, ArchSystemUnix::InhibitScreenServices::kScreenSaver) &&
       !sleepInhibitCall(true, ArchSystemUnix::InhibitScreenServices::kSessionManager)) {
-    LOG((CLOG_INFO "failed to prevent system from going to sleep"));
+    LOG((CLOG_WARN "failed to prevent system from going to sleep"));
   }
 }
 
@@ -52,6 +52,6 @@ void XWindowsPowerManager::enableSleep() const
 {
   if (!sleepInhibitCall(false, ArchSystemUnix::InhibitScreenServices::kScreenSaver) &&
       !sleepInhibitCall(false, ArchSystemUnix::InhibitScreenServices::kSessionManager)) {
-    LOG((CLOG_INFO "failed to enable system idle sleep"));
+    LOG((CLOG_WARN "failed to enable system idle sleep"));
   }
 }


### PR DESCRIPTION
This change may help us turn up some everyday problems in the field that get missed due to not using debug log level.

This could also make the log a bit noisier, so at a later date we may need to downgrade anything that is too noisy/not helpful or not actually a failure/warning.