### PR TITLE
fix: mac os tray icon not showing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -244,7 +244,7 @@ jobs:
         id: get-deps
         uses: ./.github/actions/install-dependencies
         with:
-          mac-qt-version: 6.7.2
+          mac-qt-version: 6.7.3
           like: ${{ matrix.target.like }}
 
       - name: Get version

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -644,14 +644,18 @@ void MainWindow::setIcon()
   // Using a theme icon that is packed in exe renders an invisible icon
   // Instead use the resource path of the packed icon
   // TODO Report to Qt ref the bug here
+#ifndef Q_OS_MAC
   QString iconString = QStringLiteral(":/icons/deskflow-%1/apps/64/deskflow").arg(iconMode());
   if (!appConfig().colorfulTrayIcon()) {
     iconString.append(QStringLiteral("-symbolic"));
   }
   m_trayIcon->setIcon(QIcon(iconString));
-#ifdef Q_OS_MAC
-  if (!appConfig().colorfulTrayIcon())
-    m_trayIcon->icon().setIsMask(true);
+#else
+  if (m_AppConfig.colorfulTrayIcon())
+    m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
+  else
+    m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
+  m_trayIcon->icon().setIsMask(true);
 #endif
 }
 

--- a/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
@@ -55,8 +55,8 @@ SettingsDialog::SettingsDialog(
   ui->m_pPushButtonTlsCertPath->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
   ui->m_pButtonBrowseLog->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
 
-  ui->rb_icon_mono->setIcon(QIcon(QStringLiteral(":/icons/deskflow-%1/apps/64/deskflow-symbolic").arg(iconMode())));
-  ui->rb_icon_colorful->setIcon(QIcon(QStringLiteral(":/icons/deskflow-%1/apps/64/deskflow").arg(iconMode())));
+  ui->rb_icon_mono->setIcon(QIcon::fromTheme(QStringLiteral("deskflow-symbolic")));
+  ui->rb_icon_colorful->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
 
   // force the first tab, since qt creator sets the active tab as the last one
   // the developer was looking at, and it's easy to accidentally save that.


### PR DESCRIPTION
For some reason when the CI builds the mac os don't show the "deskflow" or "deskflow-symbolic" icons.

 - bump mac os qt to 6.7.3
 - Attempt to force the icons on mac os