### PR TITLE
fix: correctly mask symbolic icon on mac os

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -651,11 +651,12 @@ void MainWindow::setIcon()
   }
   m_trayIcon->setIcon(QIcon(iconString));
 #else
-  if (m_AppConfig.colorfulTrayIcon())
+  if (m_AppConfig.colorfulTrayIcon()) {
     m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
-  else
-    m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
-  m_trayIcon->icon().setIsMask(true);
+  } else {
+    m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow-symbolic")));
+    m_trayIcon->icon().setIsMask(true);
+  }
 #endif
 }
 


### PR DESCRIPTION
use symbolic tray icon on mac os and mask it properly