### PR TITLE
chore: enable cpack as DEB for deepin|uos

### DIFF
--- a/deploy/linux/deploy.cmake
+++ b/deploy/linux/deploy.cmake
@@ -67,7 +67,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   # Check if Debian-link
   string(REGEX MATCH debian|buntu DEBTYPE "${DISTRO_LIKE}")
-  if((NOT ("${DEBTYPE}" STREQUAL "")) OR ("${DISTRO_NAME}" STREQUAL "debian"))
+  string(REGEX MATCH debian|deepin|uos DEBNAME "${DISTRO_NAME}")
+  if((NOT ("${DEBTYPE}" STREQUAL "")) OR (NOT ("${DEBNAME}" STREQUAL "")))
     set(CPACK_GENERATOR "DEB")
   endif()
 


### PR DESCRIPTION
The deepin and uos are debian liked OS, but they do define "ID_LIKE".

Log: enable cpack as DEB for deepin|uos.