### PR TITLE
docs: Update README.md to raise awareness of bounties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 ![Deskflow](https://github.com/user-attachments/assets/f005b958-24df-4f4a-9bfd-4f834dae59d6)
 
-> [!NOTE]
-> **Deskflow** is the official upstream project for [Synergy](https://symless.com/synergy).
+> [!TIP]
+> [Synergy](https://symless.com/synergy) sponsors the Deskflow project by contributing code and providing financial support.
+> 
+> - [**Bounties**](https://github.com/deskflow/deskflow/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%92%8E%20bounty%22) - Earn while contributing to open source
+> - [**Rewarded**](https://github.com/deskflow/deskflow/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%92%B0%20rewarded%22) - Issues with a rewarded bounty
+> 
+> **Deskflow** is the official upstream project for Synergy.
 > Purchasing a Synergy license is one way to support Deskflow’s growth and sustainability.
->
-> The Deskflow project was established to cultivate community-driven development where everyone can collaborate.
-> Synergy sponsors the Deskflow project by contributing code and providing financial support.
->
-> More info: [Relationship with Synergy](https://github.com/deskflow/deskflow/wiki/Relationship-with-Synergy)
+> Learn more: [Relationship with Synergy](https://github.com/deskflow/deskflow/wiki/Relationship-with-Synergy)
 
 **Deskflow** is a free and open source keyboard and mouse sharing app.
 Use the keyboard, mouse, or trackpad of one computer to control nearby computers,


### PR DESCRIPTION
Right now we're only seeing bounty interest through Algora's network of developers.

We can increase the number of potential contributors aware of bounties by making this prominent on our README.