### PR TITLE
chore: add missing String methods

### DIFF
--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "base/String.h"
-#include "arch/Arch.h"
 #include "common/stdvector.h"
 
 #include <algorithm>
@@ -132,7 +131,7 @@ std::string sprintf(const char *fmt, ...)
     // try printing into the buffer
     va_list args;
     va_start(args, fmt);
-    int n = ARCH->vsnprintf(buffer, len, fmt, args);
+    int n = vsnprintf(buffer, len, fmt, args);
     va_end(args);
 
     // if the buffer wasn't big enough then make it bigger and try again

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -219,6 +219,33 @@ int fromHexChar(char c)
 }
 // clang-format on
 
+std::vector<uint8_t> fromHex(const std::string &hexString)
+{
+  std::vector<uint8_t> result;
+  result.reserve(hexString.size() / 2);
+
+  size_t i = 0;
+  while (i < hexString.size()) {
+    if (hexString[i] == ':') {
+      i++;
+      continue;
+    }
+
+    if (i + 2 > hexString.size()) {
+      return {}; // uneven character count follows, it's unclear how to interpret it
+    }
+
+    auto high = fromHexChar(hexString[i]);
+    auto low = fromHexChar(hexString[i + 1]);
+    if (high < 0 || low < 0) {
+      return {};
+    }
+    result.push_back(high * 16 + low);
+    i += 2;
+  }
+  return result;
+}
+
 void uppercase(std::string &subject)
 {
   std::transform(subject.begin(), subject.end(), subject.begin(), ::toupper);

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -187,6 +187,38 @@ std::string toHex(const std::string &subject, int width, const char fill)
   return ss.str();
 }
 
+// clang-format off
+int fromHexChar(char c)
+{
+  switch (c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a':
+    case 'A': return 10;
+    case 'b':
+    case 'B': return 11;
+    case 'c':
+    case 'C': return 12;
+    case 'd':
+    case 'D': return 13;
+    case 'e':
+    case 'E': return 14;
+    case 'f':
+    case 'F': return 15;
+    default:  return -1;
+  }
+  return -1;
+}
+// clang-format on
+
 void uppercase(std::string &subject)
 {
   std::transform(subject.begin(), subject.end(), subject.begin(), ::toupper);

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -176,7 +176,7 @@ std::string removeFileExt(std::string filename)
   return filename.substr(0, dot);
 }
 
-void toHex(std::string &subject, int width, const char fill)
+std::string toHex(const std::string &subject, int width, const char fill)
 {
   std::stringstream ss;
   ss << std::hex;
@@ -184,7 +184,7 @@ void toHex(std::string &subject, int width, const char fill)
     ss << std::setw(width) << std::setfill(fill) << (int)(unsigned char)subject[i];
   }
 
-  subject = ss.str();
+  return ss.str();
 }
 
 void uppercase(std::string &subject)

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -1,18 +1,9 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * Copyright (C) 2014-2016 Symless Ltd.
- *
- * This package is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * found in the file LICENSE that should have accompanied this file.
- *
- * This package is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
 #include "base/String.h"

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -1,19 +1,9 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * Copyright (C) 2012-2016 Symless Ltd.
- * Copyright (C) 2002 Chris Schoeneman
- *
- * This package is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * found in the file LICENSE that should have accompanied this file.
- *
- * This package is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
 #pragma once

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -75,6 +75,13 @@ Return a new hexString
 */
 std::string toHex(const std::string &subject, int width, const char fill = '0');
 
+/**
+ * @brief fromHexChar Convert a single char to its hexidecmal value
+ * @param c input char 0-F
+ * @return The value of c in Hex or -1 for invalid hex chars
+ */
+int fromHexChar(char c);
+
 //! Convert to all uppercase
 /*!
 Convert each character in \c subject to uppercase

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -71,8 +71,9 @@ std::string removeFileExt(std::string filename);
 //! Convert into hexdecimal
 /*!
 Convert each character in \c subject into hexdecimal form with \c width
+Return a new hexString
 */
-void toHex(std::string &subject, int width, const char fill = '0');
+std::string toHex(const std::string &subject, int width, const char fill = '0');
 
 //! Convert to all uppercase
 /*!

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -82,6 +82,13 @@ std::string toHex(const std::string &subject, int width, const char fill = '0');
  */
 int fromHexChar(char c);
 
+/**
+ * @brief fromHex Turn the string into a std::vector<uint8_t>
+ * @param hexString a Hexidecimal string
+ * @return std::vector<uint8_t> version of the hex chars
+ */
+std::vector<uint8_t> fromHex(const std::string &hexString);
+
 //! Convert to all uppercase
 /*!
 Convert each character in \c subject to uppercase

--- a/src/lib/net/InverseSockets/SslApi.cpp
+++ b/src/lib/net/InverseSockets/SslApi.cpp
@@ -221,7 +221,7 @@ int SslApi::getErrorCode(int status) const
 void SslApi::formatFingerprint(std::string &fingerprint) const
 {
   // to hexidecimal
-  deskflow::string::toHex(fingerprint, 2);
+  fingerprint = deskflow::string::toHex(fingerprint, 2);
   // all uppercase
   deskflow::string::uppercase(fingerprint);
   // add colon to separate each 2 charactors

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -625,7 +625,7 @@ void SecureSocket::formatFingerprint(std::string &fingerprint, bool hex, bool se
 {
   if (hex) {
     // to hexidecimal
-    deskflow::string::toHex(fingerprint, 2);
+    fingerprint = deskflow::string::toHex(fingerprint, 2);
   }
 
   // all uppercase

--- a/src/test/unittests/base/StringTests.cpp
+++ b/src/test/unittests/base/StringTests.cpp
@@ -59,6 +59,33 @@ TEST(StringTests, toHex_plaintext_hexString)
   EXPECT_EQ("666f6f626172", string::toHex("foobar", 2));
 }
 
+TEST(StringTests, fromHexChar_plaintext_hexString)
+{
+  EXPECT_EQ(-1, string::fromHexChar('z'));
+  EXPECT_EQ(0, string::fromHexChar('0'));
+  EXPECT_EQ(1, string::fromHexChar('1'));
+  EXPECT_EQ(2, string::fromHexChar('2'));
+  EXPECT_EQ(3, string::fromHexChar('3'));
+  EXPECT_EQ(4, string::fromHexChar('4'));
+  EXPECT_EQ(5, string::fromHexChar('5'));
+  EXPECT_EQ(6, string::fromHexChar('6'));
+  EXPECT_EQ(7, string::fromHexChar('7'));
+  EXPECT_EQ(8, string::fromHexChar('8'));
+  EXPECT_EQ(9, string::fromHexChar('9'));
+  EXPECT_EQ(10, string::fromHexChar('a'));
+  EXPECT_EQ(10, string::fromHexChar('A'));
+  EXPECT_EQ(11, string::fromHexChar('b'));
+  EXPECT_EQ(11, string::fromHexChar('B'));
+  EXPECT_EQ(12, string::fromHexChar('c'));
+  EXPECT_EQ(12, string::fromHexChar('C'));
+  EXPECT_EQ(13, string::fromHexChar('d'));
+  EXPECT_EQ(13, string::fromHexChar('D'));
+  EXPECT_EQ(14, string::fromHexChar('e'));
+  EXPECT_EQ(14, string::fromHexChar('E'));
+  EXPECT_EQ(15, string::fromHexChar('f'));
+  EXPECT_EQ(15, string::fromHexChar('F'));
+}
+
 TEST(StringTests, uppercase_lowercaseInput_uppercaseOutput)
 {
   std::string subject = "12foo3BaR";

--- a/src/test/unittests/base/StringTests.cpp
+++ b/src/test/unittests/base/StringTests.cpp
@@ -56,12 +56,7 @@ TEST(StringTests, sprintf_formatWithArgument_formatedString)
 
 TEST(StringTests, toHex_plaintext_hexString)
 {
-  std::string subject = "foobar";
-  int width = 2;
-
-  string::toHex(subject, width);
-
-  EXPECT_EQ("666f6f626172", subject);
+  EXPECT_EQ("666f6f626172", string::toHex("foobar", 2));
 }
 
 TEST(StringTests, uppercase_lowercaseInput_uppercaseOutput)

--- a/src/test/unittests/base/StringTests.cpp
+++ b/src/test/unittests/base/StringTests.cpp
@@ -86,6 +86,13 @@ TEST(StringTests, fromHexChar_plaintext_hexString)
   EXPECT_EQ(15, string::fromHexChar('F'));
 }
 
+TEST(StringTests, fromHex_plaintext_hexString)
+{
+  EXPECT_EQ(255, string::fromHex("FF")[0]);
+  EXPECT_EQ(255, string::fromHex(":FF:EE")[0]);
+  EXPECT_EQ(238, string::fromHex(":FF:EE")[1]);
+}
+
 TEST(StringTests, uppercase_lowercaseInput_uppercaseOutput)
 {
   std::string subject = "12foo3BaR";


### PR DESCRIPTION
Clean up some of our String methods
 

- `String.cpp` does not need the access to `ARCH` 
- modified `void String::toHex(...)` -> `std::string String::toHex(...)` will now return a std::string;
- added `int String::fromHexChar(char c)`
- added `std::vector<uint8_t> string::fromHex(const std::string&)`
- Update copyright to SPDX format

#8098  Should base upon this and remove modifications to the `String` Class