### PR TITLE
refactor: force mac os to use the larger security icon for the status area

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -983,13 +983,18 @@ void MainWindow::showConfigureServer(const QString &message)
 void MainWindow::secureSocket(bool secureSocket)
 {
   m_SecureSocket = secureSocket;
-  if (secureSocket) {
-    ui->lblConnectionSecurityStatus->setToolTip(tr("Secure Connection"));
-    ui->lblConnectionSecurityStatus->setPixmap(QIcon::fromTheme(QIcon::ThemeIcon::SecurityHigh).pixmap(QSize(32, 32)));
-  } else {
-    ui->lblConnectionSecurityStatus->setToolTip(tr("Insecure Connection"));
-    ui->lblConnectionSecurityStatus->setPixmap(QIcon::fromTheme(QIcon::ThemeIcon::SecurityLow).pixmap(QSize(32, 32)));
-  }
+  const auto txt = secureSocket ? tr("Secure Connection") : tr("Insecure Connection");
+  ui->lblConnectionSecurityStatus->setToolTip(txt);
+
+// mac os will try to use the 16x16 low detail icon when we use the theme name
+// because of this we manually select the 64x64 icon from our packed in set
+#ifdef Q_OS_MAC
+  const auto icon = QIcon(QStringLiteral(":/icons/deskflow-%1/status/64/security-%2")
+                              .arg(iconMode(), secureSocket ? QStringLiteral("high") : QStringLiteral("low")));
+#else
+  const auto icon = QIcon::fromTheme(secureSocket ? QIcon::ThemeIcon::SecurityHigh : QIcon::ThemeIcon::SecurityLow);
+#endif
+  ui->lblConnectionSecurityStatus->setPixmap(icon.pixmap(QSize(32, 32)));
 }
 
 void MainWindow::updateScreenName()


### PR DESCRIPTION
Fixes.
  - macOs the theme icon falls back to the low detail 16x16 icon instead of the higher detail one.