### PR TITLE
Fix: Screen icons not showing on the screen setup tab

### DIFF
--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -96,6 +96,8 @@ add_executable(${target} WIN32 MACOSX_BUNDLE
   widgets/ClientStateLabel.h
   widgets/KeySequenceWidget.cpp
   widgets/KeySequenceWidget.h
+  widgets/NewScreenWidget.h
+  widgets/NewScreenWidget.cpp
   widgets/ScreenSetupView.cpp
   widgets/ScreenSetupView.h
   widgets/ServerStateLabel.cpp

--- a/src/apps/deskflow-gui/ScreenSetupModel.cpp
+++ b/src/apps/deskflow-gui/ScreenSetupModel.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -37,28 +38,26 @@ ScreenSetupModel::ScreenSetupModel(ScreenList &screens, int numColumns, int numR
 
 QVariant ScreenSetupModel::data(const QModelIndex &index, int role) const
 {
-  if (index.isValid() && index.row() < m_NumRows && index.column() < m_NumColumns) {
-    switch (role) {
-    case Qt::DecorationRole:
-      if (screen(index).isNull())
-        break;
-      return QIcon(screen(index).pixmap());
+  if (!index.isValid() || index.row() > m_NumRows || index.row() < 0 || index.column() < 0 ||
+      index.column() > m_NumColumns)
+    return QVariant();
 
-    case Qt::ToolTipRole:
-      if (screen(index).isNull())
-        break;
-      return QString(tr("<center>Screen: <b>%1</b></center>"
-                        "<br>Double click to edit settings"
-                        "<br>Drag screen to the trashcan to remove it"))
-          .arg(screen(index).name());
+  if (screen(index).isNull())
+    return QVariant();
 
-    case Qt::DisplayRole:
-      if (screen(index).isNull())
-        break;
-      return screen(index).name();
-    }
+  switch (role) {
+  case Qt::DecorationRole:
+    return screen(index).pixmap();
+
+  case Qt::ToolTipRole:
+    return QString(tr("<center>Screen: <b>%1</b></center>"
+                      "<br>Double click to edit settings"
+                      "<br>Drag screen to the trashcan to remove it"))
+        .arg(screen(index).name());
+
+  case Qt::DisplayRole:
+    return screen(index).name();
   }
-
   return QVariant();
 }
 

--- a/src/apps/deskflow-gui/ServerConfig.cpp
+++ b/src/apps/deskflow-gui/ServerConfig.cpp
@@ -239,7 +239,7 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 
   for (const Screen &s : config.screens()) {
     if (!s.isNull())
-      s.writeScreensSection(outStream);
+      outStream << s.screensSection();
   }
 
   outStream << "end" << Qt::endl << Qt::endl;
@@ -248,7 +248,7 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 
   for (const Screen &s : config.screens()) {
     if (!s.isNull())
-      s.writeAliasesSection(outStream);
+      outStream << s.aliasesSection();
   }
 
   outStream << "end" << Qt::endl << Qt::endl;

--- a/src/apps/deskflow-gui/dialogs/ServerConfigDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/ServerConfigDialog.cpp
@@ -36,6 +36,8 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config, Ap
 
   ui->m_pButtonBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
   ui->m_pTrashScreenWidget->setPixmap(QIcon::fromTheme("user-trash").pixmap(QSize(64, 64)));
+  ui->lblNewScreen->setPixmap(QIcon::fromTheme("video-display").pixmap(QSize(64, 64)));
+  ui->lblNewScreen->setToolTip(tr("Drag to the grid to add a new computer."));
 
   // force the first tab, since qt creator sets the active tab as the last one
   // the developer was looking at, and it's easy to accidentally save that.
@@ -87,7 +89,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config, Ap
     server->markAsServer();
   }
 
-  ui->m_pButtonAddComputer->setEnabled(!model().isFull());
+  ui->lblNewScreen->setEnabled(!model().isFull());
   connect(ui->m_pTrashScreenWidget, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
 
   onChange();
@@ -418,7 +420,7 @@ void ServerConfigDialog::on_m_pButtonAddComputer_clicked()
 
 void ServerConfigDialog::onScreenRemoved()
 {
-  ui->m_pButtonAddComputer->setEnabled(true);
+  ui->lblNewScreen->setEnabled(true);
   onChange();
 }
 
@@ -464,7 +466,7 @@ bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
     isAccepted = true;
   }
 
-  ui->m_pButtonAddComputer->setEnabled(!model().isFull());
+  ui->lblNewScreen->setEnabled(!model().isFull());
   return isAccepted;
 }
 

--- a/src/apps/deskflow-gui/dialogs/ServerConfigDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/ServerConfigDialog.ui
@@ -62,10 +62,10 @@
             <string>Drag a computer from the grid to the trashcan to remove it.</string>
            </property>
            <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
+            <enum>QFrame::Shape::StyledPanel</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Shadow::Raised</enum>
            </property>
            <property name="text">
             <string/>
@@ -75,7 +75,7 @@
          <item>
           <spacer name="horizontalSpacer_21">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -103,7 +103,7 @@
             <string>Configure the layout of your computer displays by dragging to where you want.</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -116,7 +116,7 @@
          <item>
           <spacer name="horizontalSpacer_22">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -127,6 +127,13 @@
           </spacer>
          </item>
          <item>
+          <widget class="NewScreenWidget" name="lblNewScreen">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QVBoxLayout" name="m_pLayoutAddComputer">
            <property name="spacing">
             <number>0</number>
@@ -134,16 +141,6 @@
            <property name="leftMargin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QPushButton" name="m_pButtonAddComputer">
-             <property name="text">
-              <string>Add computer</string>
-             </property>
-             <property name="default">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
           </layout>
          </item>
         </layout>
@@ -151,10 +148,10 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -191,10 +188,10 @@
           <bool>false</bool>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
+          <enum>QFrame::Shadow::Sunken</enum>
          </property>
         </widget>
        </item>
@@ -252,7 +249,7 @@
           <item row="3" column="1">
            <spacer>
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -312,7 +309,7 @@
           <item row="3" column="1">
            <spacer>
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -396,7 +393,7 @@
             <item>
              <spacer name="horizontalSpacer_7">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -431,7 +428,7 @@
           <item>
            <spacer name="verticalSpacer_7">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -506,7 +503,7 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -548,7 +545,7 @@
           <item>
            <spacer name="verticalSpacer_6">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -591,7 +588,7 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -655,7 +652,7 @@
             <item>
              <spacer name="horizontalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -687,7 +684,7 @@
           <item>
            <spacer name="verticalSpacer_3">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -735,7 +732,7 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -788,7 +785,7 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -829,7 +826,7 @@
           <item>
            <spacer name="verticalSpacer_5">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -845,7 +842,7 @@
        <item row="2" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -880,7 +877,7 @@
        <property name="rightMargin">
         <number>120</number>
        </property>
-       <item alignment="Qt::AlignHCenter">
+       <item alignment="Qt::AlignmentFlag::AlignHCenter">
         <widget class="QLabel" name="label_5">
          <property name="font">
           <font>
@@ -892,7 +889,7 @@
           <string>Core server config file</string>
          </property>
          <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+          <enum>Qt::TextFormat::PlainText</enum>
          </property>
         </widget>
        </item>
@@ -904,10 +901,10 @@
 Enabling this setting will disable the server config GUI.</string>
          </property>
          <property name="textFormat">
-          <enum>Qt::MarkdownText</enum>
+          <enum>Qt::TextFormat::MarkdownText</enum>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -917,10 +914,10 @@ Enabling this setting will disable the server config GUI.</string>
        <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Maximum</enum>
+          <enum>QSizePolicy::Policy::Maximum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -941,10 +938,10 @@ Enabling this setting will disable the server config GUI.</string>
          <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -976,10 +973,10 @@ Enabling this setting will disable the server config GUI.</string>
          <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1002,10 +999,10 @@ Enabling this setting will disable the server config GUI.</string>
          <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1040,10 +1037,10 @@ Enabling this setting will disable the server config GUI.</string>
          <item>
           <spacer name="horizontalSpacer_6">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
+            <enum>QSizePolicy::Policy::Fixed</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1103,10 +1100,10 @@ Enabling this setting will disable the server config GUI.</string>
          <item>
           <spacer name="horizontalSpacer_5">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
+            <enum>QSizePolicy::Policy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1121,7 +1118,7 @@ Enabling this setting will disable the server config GUI.</string>
        <item>
         <spacer name="verticalSpacer_1">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1138,10 +1135,10 @@ Enabling this setting will disable the server config GUI.</string>
    <item>
     <widget class="QDialogButtonBox" name="m_pButtonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -1159,10 +1156,14 @@ Enabling this setting will disable the server config GUI.</string>
    <extends>QLabel</extends>
    <header>widgets/TrashScreenWidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>NewScreenWidget</class>
+   <extends>QLabel</extends>
+   <header>widgets/NewScreenWidget.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>m_pButtonBrowseConfigFile</tabstop>
-  <tabstop>m_pButtonAddComputer</tabstop>
   <tabstop>m_pScreenSetupView</tabstop>
   <tabstop>m_pListHotkeys</tabstop>
   <tabstop>m_pButtonNewHotkey</tabstop>

--- a/src/apps/deskflow-gui/widgets/NewScreenWidget.cpp
+++ b/src/apps/deskflow-gui/widgets/NewScreenWidget.cpp
@@ -1,0 +1,37 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "NewScreenWidget.h"
+#include "ScreenSetupModel.h"
+
+#include <QDrag>
+#include <QLabel>
+#include <QMimeData>
+#include <QMouseEvent>
+
+NewScreenWidget::NewScreenWidget(QWidget *parent) : QLabel(parent)
+{
+}
+
+void NewScreenWidget::mousePressEvent(QMouseEvent *event)
+{
+  Screen newScreen(tr("Unnamed"));
+
+  QByteArray itemData;
+  QDataStream dataStream(&itemData, QIODevice::WriteOnly);
+  dataStream << -1 << -1 << newScreen;
+
+  QMimeData *pMimeData = new QMimeData;
+  pMimeData->setData(ScreenSetupModel::mimeType(), itemData);
+
+  QDrag *pDrag = new QDrag(this);
+  pDrag->setMimeData(pMimeData);
+  pDrag->setPixmap(pixmap());
+  pDrag->setHotSpot(event->pos());
+  pDrag->exec(Qt::CopyAction, Qt::CopyAction);
+}

--- a/src/apps/deskflow-gui/widgets/NewScreenWidget.h
+++ b/src/apps/deskflow-gui/widgets/NewScreenWidget.h
@@ -1,0 +1,24 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QLabel>
+
+class QMouseEvent;
+class QWidget;
+
+class NewScreenWidget : public QLabel
+{
+  Q_OBJECT
+
+public:
+  NewScreenWidget(QWidget *parent);
+
+protected:
+  void mousePressEvent(QMouseEvent *event) override;
+};

--- a/src/apps/deskflow-gui/widgets/ScreenSetupView.cpp
+++ b/src/apps/deskflow-gui/widgets/ScreenSetupView.cpp
@@ -44,6 +44,13 @@ ScreenSetupModel *ScreenSetupView::model() const
   return qobject_cast<ScreenSetupModel *>(QTableView::model());
 }
 
+void ScreenSetupView::showScreenConfig(int col, int row)
+{
+  ScreenSettingsDialog dlg(this, &model()->screen(col, row), &model()->m_Screens);
+  dlg.exec();
+  Q_EMIT model()->screensChanged();
+}
+
 void ScreenSetupView::setTableSize()
 {
   for (int i = 0; i < model()->columnCount(); i++)
@@ -66,9 +73,7 @@ void ScreenSetupView::mouseDoubleClickEvent(QMouseEvent *event)
     int row = rowAt(event->pos().y());
 
     if (!model()->screen(col, row).isNull()) {
-      ScreenSettingsDialog dlg(this, &model()->screen(col, row), &model()->m_Screens);
-      dlg.exec();
-      Q_EMIT model()->screensChanged();
+      showScreenConfig(col, row);
     }
   } else
     event->ignore();
@@ -100,8 +105,9 @@ void ScreenSetupView::dragMoveEvent(QDragMoveEvent *event)
       // a drop from outside is not allowed if there's a screen already there.
       if (!model()->screen(col, row).isNull())
         event->ignore();
-      else
+      else {
         event->acceptProposedAction();
+      }
     }
   } else
     event->ignore();

--- a/src/apps/deskflow-gui/widgets/ScreenSetupView.cpp
+++ b/src/apps/deskflow-gui/widgets/ScreenSetupView.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -27,7 +28,7 @@ ScreenSetupView::ScreenSetupView(QWidget *parent) : QTableView(parent)
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-  setIconSize(QSize(64, 64));
+  setIconSize(QSize(96, 96));
   horizontalHeader()->hide();
   verticalHeader()->hide();
 }
@@ -140,8 +141,16 @@ void ScreenSetupView::startDrag(Qt::DropActions)
 
 void ScreenSetupView::initViewItemOption(QStyleOptionViewItem *option) const
 {
+  // HACK make a basic widget and init from it
+  auto w = new QWidget();
+  option->initFrom(w);
+  w->deleteLater();
+  delete w;
+
+  option->decorationSize = QSize(96, 96);
   option->showDecorationSelected = true;
   option->decorationPosition = QStyleOptionViewItem::Top;
-  option->displayAlignment = Qt::AlignCenter;
+  option->decorationAlignment = Qt::AlignHCenter | Qt::AlignVCenter;
+  option->displayAlignment = Qt::AlignTop | Qt::AlignHCenter;
   option->textElideMode = Qt::ElideMiddle;
 }

--- a/src/apps/deskflow-gui/widgets/ScreenSetupView.h
+++ b/src/apps/deskflow-gui/widgets/ScreenSetupView.h
@@ -29,6 +29,9 @@ public:
   void setModel(QAbstractItemModel *model) override;
   ScreenSetupModel *model() const;
 
+private:
+  void showScreenConfig(int col, int row);
+
 protected:
   void mouseDoubleClickEvent(QMouseEvent *) override;
   void setTableSize();

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -76,40 +77,40 @@ void Screen::saveSettings(QSettingsProxy &settings) const
   writeSettings(settings, fixes(), "fix");
 }
 
-QTextStream &Screen::writeScreensSection(QTextStream &outStream) const
+QString Screen::screensSection() const
 {
-  outStream << "\t" << name() << ":" << Qt::endl;
+  const QString lineTemplate = QStringLiteral("\t\t%1 = %2\n");
 
-  for (int i = 0; i < modifiers().size(); i++)
+  QString out = QStringLiteral("\t%1:\n").arg(name());
+  for (int i = 0; i < modifiers().size(); i++) {
     if (modifier(i) != i)
-      outStream << "\t\t" << modifierName(i) << " = " << modifierName(modifier(i)) << Qt::endl;
-
-  for (int i = 0; i < fixes().size(); i++)
-    outStream << "\t\t" << fixName(i) << " = " << (fixes()[i] ? "true" : "false") << Qt::endl;
-
-  outStream << "\t\t"
-            << "switchCorners = none ";
-  for (int i = 0; i < switchCorners().size(); i++)
-    if (switchCorners()[i])
-      outStream << "+" << switchCornerName(i) << " ";
-  outStream << Qt::endl;
-
-  outStream << "\t\t"
-            << "switchCornerSize = " << switchCornerSize() << Qt::endl;
-
-  return outStream;
-}
-
-QTextStream &Screen::writeAliasesSection(QTextStream &outStream) const
-{
-  if (!aliases().isEmpty()) {
-    outStream << "\t" << name() << ":" << Qt::endl;
-
-    for (const QString &alias : aliases())
-      outStream << "\t\t" << alias << Qt::endl;
+      out.append(lineTemplate.arg(modifierName(i), modifierName(modifier(i))));
   }
 
-  return outStream;
+  for (int i = 0; i < fixes().size(); i++)
+    out.append(lineTemplate.arg(fixName(i), fixes().at(i) ? QStringLiteral("true") : QStringLiteral("false")));
+
+  out.append(QStringLiteral("\t\tswitchCorners = none"));
+  for (int i = 0; i < switchCorners().size(); i++)
+    if (switchCorners()[i])
+      out.append(QStringLiteral("+%1 ").arg(switchCornerName(i)));
+
+  out.append("\n");
+  out.append(lineTemplate.arg(QStringLiteral("switchCornerSize"), QString::number(switchCornerSize())));
+
+  return out;
+}
+
+QString Screen::aliasesSection() const
+{
+  QString out;
+  if (!aliases().isEmpty()) {
+    out = QStringLiteral("\t%1:\n").arg(name());
+
+    for (const QString &alias : aliases())
+      out.append(QStringLiteral("\t\t%1\n").arg(alias));
+  }
+  return out;
 }
 
 bool Screen::operator==(const Screen &screen) const

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -164,7 +165,7 @@ protected:
   }
 
 private:
-  QPixmap m_Pixmap = QIcon::fromTheme("video-display").pixmap(QSize(64, 64));
+  QPixmap m_Pixmap = QIcon::fromTheme("video-display").pixmap(QSize(96, 96));
   QString m_Name;
   QStringList m_Aliases;
   QList<int> m_Modifiers;

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -94,8 +94,8 @@ public:
 
   void loadSettings(QSettingsProxy &settings);
   void saveSettings(QSettingsProxy &settings) const;
-  QTextStream &writeScreensSection(QTextStream &outStream) const;
-  QTextStream &writeAliasesSection(QTextStream &outStream) const;
+  QString screensSection() const;
+  QString aliasesSection() const;
 
   bool swapped() const
   {


### PR DESCRIPTION
 - Fix #8155 
 - "Return Early Return Often"  in `ScreenSetupModel::data method`
 -  Bring back the `NewScreenWidget`
 -  `QTextStream& screen::writeScreensSection(QTextStream&)` -> `QString Screen::screenSection()`
 -  `QTextStream& screen::writeAliasSection(QTextStream&)` -> `QString Screen::aliasSection()`