### PR TITLE
Parts of #8180 that are easy to land first

### DIFF
--- a/src/apps/deskflow-core/CMakeLists.txt
+++ b/src/apps/deskflow-core/CMakeLists.txt
@@ -9,10 +9,12 @@ add_executable(${target} "${target}.cpp")
 if(WIN32)
   # Generate rc file
   set(EXE_DESCRIPTION "${CMAKE_PROJECT_DESCRIPTION}\\n CLI combined server and client")
+  set(EXE_ICON "IDI_DESKFLOW ICON DISCARDABLE \"${CMAKE_SOURCE_DIR}/src/apps/res/deskflow.ico\"")
   configure_file(${CMAKE_SOURCE_DIR}/src/apps/res/windows.rc.in ${target}.rc)
 
   target_sources(${target} PRIVATE
-    "${target}.exe.manifest"
+    ${target}.exe.manifest
+    ${CMAKE_SOURCE_DIR}/src/apps/res/deskflow.ico
     ${CMAKE_CURRENT_BINARY_DIR}/${target}.rc
   )
 endif()

--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -11,17 +11,18 @@
 #include "base/Log.h"
 #include "deskflow/ClientApp.h"
 #include "deskflow/ServerApp.h"
-#include <iostream>
 
 #if SYSAPI_WIN32
 #include "arch/win32/ArchMiscWindows.h"
 #endif
 
+#include <iostream>
+
 void showHelp()
 {
-  std::cout << "Usage: " CORE_BINARY_NAME " <server | client> [...options]" << std::endl;
-  std::cout << "server - start as a server ( deskflow-server)" << std::endl;
-  std::cout << "client - start as a client ( deslflow-client)" << std::endl;
+  std::cout << "Usage: deskflow-core <server | client> [...options]" << std::endl;
+  std::cout << "server - start as a server (deskflow-server)" << std::endl;
+  std::cout << "client - start as a client (deskflow-client)" << std::endl;
   std::cout << "use deskflow-core <server|client> --help for more information." << std::endl;
 }
 

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -230,7 +230,6 @@ void MainWindow::setupControls()
 // signal is emitted from the thread that owns the receiver's object.
 void MainWindow::connectSlots()
 {
-
   connect(&Logger::instance(), &Logger::newLine, this, &MainWindow::handleLogLine);
 
   connect(this, &MainWindow::shown, this, &MainWindow::firstShown, Qt::QueuedConnection);
@@ -238,21 +237,14 @@ void MainWindow::connectSlots()
   connect(&m_configScopes, &ConfigScopes::saving, this, &MainWindow::configScopesSaving, Qt::DirectConnection);
 
   connect(&m_appConfig, &AppConfig::tlsChanged, this, &MainWindow::appConfigTlsChanged);
-
   connect(&m_appConfig, &AppConfig::screenNameChanged, this, &MainWindow::appConfigScreenNameChanged);
-
   connect(&m_appConfig, &AppConfig::invertConnectionChanged, this, &MainWindow::appConfigInvertConnection);
 
   connect(&m_coreProcess, &CoreProcess::starting, this, &MainWindow::coreProcessStarting, Qt::DirectConnection);
-
   connect(&m_coreProcess, &CoreProcess::error, this, &MainWindow::coreProcessError);
-
   connect(&m_coreProcess, &CoreProcess::logLine, this, &MainWindow::handleLogLine);
-
   connect(&m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged);
-
   connect(&m_coreProcess, &CoreProcess::connectionStateChanged, this, &MainWindow::coreConnectionStateChanged);
-
   connect(&m_coreProcess, &CoreProcess::secureSocket, this, &MainWindow::coreProcessSecureSocket);
 
   connect(m_actionAbout, &QAction::triggered, this, &MainWindow::openAboutDialog);

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -237,15 +237,15 @@ void MainWindow::connectSlots()
   connect(&m_configScopes, &ConfigScopes::saving, this, &MainWindow::configScopesSaving, Qt::DirectConnection);
 
   connect(&m_appConfig, &AppConfig::tlsChanged, this, &MainWindow::appConfigTlsChanged);
-  connect(&m_appConfig, &AppConfig::screenNameChanged, this, &MainWindow::appConfigScreenNameChanged);
-  connect(&m_appConfig, &AppConfig::invertConnectionChanged, this, &MainWindow::appConfigInvertConnection);
+  connect(&m_appConfig, &AppConfig::screenNameChanged, this, &MainWindow::updateScreenName);
+  connect(&m_appConfig, &AppConfig::invertConnectionChanged, this, &MainWindow::applyConfig);
 
   connect(&m_coreProcess, &CoreProcess::starting, this, &MainWindow::coreProcessStarting, Qt::DirectConnection);
   connect(&m_coreProcess, &CoreProcess::error, this, &MainWindow::coreProcessError);
   connect(&m_coreProcess, &CoreProcess::logLine, this, &MainWindow::handleLogLine);
   connect(&m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged);
   connect(&m_coreProcess, &CoreProcess::connectionStateChanged, this, &MainWindow::coreConnectionStateChanged);
-  connect(&m_coreProcess, &CoreProcess::secureSocket, this, &MainWindow::coreProcessSecureSocket);
+  connect(&m_coreProcess, &CoreProcess::secureSocket, this, &MainWindow::secureSocket);
 
   connect(m_actionAbout, &QAction::triggered, this, &MainWindow::openAboutDialog);
   connect(m_actionClearSettings, &QAction::triggered, this, &MainWindow::clearSettings);
@@ -352,16 +352,6 @@ void MainWindow::versionCheckerUpdateFound(const QString &version)
 
   ui->lblUpdate->show();
   ui->lblUpdate->setText(text);
-}
-
-void MainWindow::appConfigScreenNameChanged()
-{
-  updateScreenName();
-}
-
-void MainWindow::appConfigInvertConnection()
-{
-  applyConfig();
 }
 
 void MainWindow::coreProcessError(CoreProcess::Error error)
@@ -759,11 +749,6 @@ void MainWindow::showFirstConnectedMessage()
 
   const auto isServer = m_coreProcess.mode() == CoreMode::Server;
   messages::showFirstConnectedMessage(this, m_appConfig.closeToTray(), m_appConfig.enableService(), isServer);
-}
-
-void MainWindow::coreProcessSecureSocket(bool enabled)
-{
-  secureSocket(enabled);
 }
 
 void MainWindow::updateStatus()

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -165,8 +165,6 @@ private:
   void showAndActivate();
 
   VersionChecker m_versionChecker;
-  QSystemTrayIcon *m_trayIcon = nullptr;
-  QAbstractButton *m_btnCancel = nullptr;
   bool m_secureSocket = false;
   deskflow::gui::config::ServerConfigDialogState m_serverConfigDialogState;
   bool m_saveOnExit = true;
@@ -181,6 +179,7 @@ private:
   deskflow::gui::TlsUtility m_tlsUtility;
   QSize m_expandedSize = QSize();
 
+  QSystemTrayIcon *m_trayIcon = nullptr;
   QLocalServer *m_guiDupeChecker = nullptr;
   inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
 

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -98,13 +98,10 @@ private:
 
   void configScopesSaving();
   void appConfigTlsChanged();
-  void appConfigScreenNameChanged();
-  void appConfigInvertConnection();
   void coreProcessStarting();
   void coreProcessError(CoreProcess::Error error);
   void coreConnectionStateChanged(CoreProcess::ConnectionState state);
   void coreProcessStateChanged(CoreProcess::ProcessState state);
-  void coreProcessSecureSocket(bool enabled);
   void versionCheckerUpdateFound(const QString &version);
   void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
   void serverConnectionConfigureClient(const QString &clientName);

--- a/src/lib/deskflow/CMakeLists.txt
+++ b/src/lib/deskflow/CMakeLists.txt
@@ -67,7 +67,7 @@ elseif(UNIX)
   )
 endif()
 
-add_library(${lib_name} STATIC  ${PLATFORM_CODE}
+add_library(${lib_name} STATIC ${PLATFORM_CODE}
   App.cpp
   App.h
   AppUtil.cpp

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -259,7 +259,7 @@ void CoreProcess::onProcessFinished(int exitCode, QProcess::ExitStatus)
   }
 }
 
-void CoreProcess::startDesktop(const QString &app, const QStringList &args)
+void CoreProcess::startForegroundProcess(const QString &app, const QStringList &args)
 {
   using enum ProcessState;
 
@@ -282,7 +282,7 @@ void CoreProcess::startDesktop(const QString &app, const QStringList &args)
   }
 }
 
-void CoreProcess::startService(const QString &app, const QStringList &args)
+void CoreProcess::startProcessFromDaemon(const QString &app, const QStringList &args)
 {
   using enum ProcessState;
 
@@ -304,7 +304,7 @@ void CoreProcess::startService(const QString &app, const QStringList &args)
   setProcessState(Started);
 }
 
-void CoreProcess::stopDesktop() const
+void CoreProcess::stopForegroundProcess() const
 {
   if (m_processState != ProcessState::Stopping) {
     qFatal("core process must be in stopping state");
@@ -324,7 +324,7 @@ void CoreProcess::stopDesktop() const
   }
 }
 
-void CoreProcess::stopService()
+void CoreProcess::stopProcessFromDaemon()
 {
   if (m_processState != ProcessState::Stopping) {
     qFatal("core process must be in stopping state");
@@ -409,9 +409,9 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
     qInfo("log file: %s", qPrintable(m_appConfig.logFilename()));
 
   if (processMode == ProcessMode::kDesktop) {
-    startDesktop(app, args);
+    startForegroundProcess(app, args);
   } else if (processMode == ProcessMode::kService) {
-    startService(app, args);
+    startProcessFromDaemon(app, args);
   }
 
   m_lastProcessMode = processMode;
@@ -432,9 +432,9 @@ void CoreProcess::stop(std::optional<ProcessMode> processModeOption)
     setProcessState(ProcessState::Stopping);
 
     if (processMode == ProcessMode::kService) {
-      stopService();
+      stopProcessFromDaemon();
     } else if (processMode == ProcessMode::kDesktop) {
-      stopDesktop();
+      stopForegroundProcess();
     }
 
   } else {

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -136,10 +136,10 @@ private slots:
   void onProcessReadyReadStandardError();
 
 private:
-  void startDesktop(const QString &app, const QStringList &args);
-  void startService(const QString &app, const QStringList &args);
-  void stopDesktop() const;
-  void stopService();
+  void startForegroundProcess(const QString &app, const QStringList &args);
+  void startProcessFromDaemon(const QString &app, const QStringList &args);
+  void stopForegroundProcess() const;
+  void stopProcessFromDaemon();
   bool addGenericArgs(QStringList &args, const ProcessMode processMode) const;
   bool addServerArgs(QStringList &args, QString &app);
   bool addClientArgs(QStringList &args, QString &app);

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -40,7 +40,6 @@ void raiseCriticalDialog()
 
 void showErrorDialog(const QString &message, const QString &fileLine, QtMsgType type)
 {
-
   auto title = type == QtFatalMsg ? "Fatal error" : "Critical error";
   QString text;
   if (type == QtFatalMsg) {
@@ -96,7 +95,6 @@ QString fileLine(const QMessageLogContext &context)
 
 void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message)
 {
-
   const auto fileLine = messages::fileLine(context);
   Logger::instance().handleMessage(type, fileLine, message);
 

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -183,7 +183,7 @@ if(UNIX)
     ${libs})
 
   if(NOT APPLE)
-    find_package(Qt6 COMPONENTS DBus)
+    find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS DBus)
     target_link_libraries(platform Qt6::DBus)
 
     link_wayland_libs()

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -596,10 +596,9 @@ void MSWindowsWatchdog::getActiveDesktop(LPSECURITY_ATTRIBUTES security)
     MSWindowsSession session;
     std::string name = session.getActiveDesktopName();
     if (name.empty()) {
-      LOG((CLOG_CRIT "failed to get active desktop name"));
+      LOG((CLOG_DEBUG "no active desktop in current session"));
     } else {
-      std::string output = deskflow::string::sprintf("activeDesktop:%s", name.c_str());
-      LOG((CLOG_INFO "%s", output.c_str()));
+      LOG((CLOG_INFO "active desktop name: %s", name.c_str()));
     }
   }
 }


### PR DESCRIPTION
Parts of #8180 that are easier to land first.

 - Clean up of white space
    - `src/apps/deskflow-gui/MainWindow.cpp`
    - `lib/deskflow/CMakeLists.txt`
    - `src/lib/gui/messages.cpp`
 - MainWindow Remove some unneeded intermediary methods (one was renamed in https://github.com/deskflow/deskflow/pull/8180/commits/eaf6326e90da1f20a69b40121091dd9cd6cac514)
 - Set the icon for deskflow-core
 - [fix: Out of order m_trayIcon in ctor init](https://github.com/deskflow/deskflow/pull/8180/commits/1e32c2efaf92c6042238981af76749996d4f2293)
    - modified to remove unused m_btnCancel
 - [Rename core process start/stop function names](https://github.com/deskflow/deskflow/pull/8180/commits/e236f17d749d1cfbc7e7557a0c085a71b96c7d46)
 - [Cleanup core binary help text](https://github.com/deskflow/deskflow/pull/8180/commits/b88b5f87833d46910b71ef9c94000f267f0a20aa)
 - [Change log level for active desktop query to debug](https://github.com/deskflow/deskflow/pull/8180/commits/de31673ce054e3afad9b54965b5f93a6fb8dd25d)