### PR TITLE
fix: Restore active desktop name check in Windows daemon

### DIFF
--- a/src/apps/deskflow-server/deskflow-server.cpp
+++ b/src/apps/deskflow-server/deskflow-server.cpp
@@ -28,6 +28,30 @@ int main(int argc, char **argv)
   Log log;
   EventQueue events;
 
+  // HACK: the `--active-desktop` arg actually belongs in the `deskflow-core` binary,
+  // but we are placing it here in the server binary temporarily until we are ready to
+  // ship the `deskflow-core` binary. we are deliberately not integrating `--active-desktop`
+  // into the existing `ServerApp` arg parsing code as that would be a waste of time.
+#if SYSAPI_WIN32
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    // This is called by the daemon (running in session 0) when it needs to know the name of the
+    // interactive desktop.
+    // It is necessary to run a utility process because the daemon runs in session 0, which does not
+    // have access to the active desktop, and so cannot query it's name.
+    if (arg == "--active-desktop") {
+      const auto name = ArchMiscWindows::getActiveDesktopName();
+      if (name.empty()) {
+        LOG((CLOG_CRIT "failed to get active desktop name"));
+        return kExitFailed;
+      }
+
+      LOG((CLOG_PRINT "%s", name.c_str()));
+      return kExitSuccess;
+    }
+  }
+#endif
+
   ServerApp app(&events);
   return app.run(argc, argv);
 }

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -7,6 +7,7 @@
 
 #include "arch/win32/ArchMiscWindows.h"
 #include "arch/win32/ArchDaemonWindows.h"
+#include "arch/win32/XArchWindows.h"
 #include "base/Log.h"
 #include "common/constants.h"
 
@@ -456,4 +457,20 @@ void ArchMiscWindows::setInstanceWin32(HINSTANCE instance)
 {
   assert(instance != NULL);
   s_instanceWin32 = instance;
+}
+
+std::string ArchMiscWindows::getActiveDesktopName()
+{
+  HDESK desk = OpenInputDesktop(0, TRUE, GENERIC_READ);
+  if (desk == nullptr) {
+    LOG((CLOG_ERR "could not open input desktop"));
+    throw XArch(new XArchEvalWindows());
+  }
+
+  DWORD size;
+  GetUserObjectInformation(desk, UOI_NAME, nullptr, 0, &size);
+  auto *name = (TCHAR *)alloca(size + sizeof(TCHAR));
+  GetUserObjectInformation(desk, UOI_NAME, name, size, &size);
+  CloseDesktop(desk);
+  return name;
 }

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -155,12 +155,11 @@ public:
   static bool getParentProcessName(std::string &name);
 
   static HINSTANCE instanceWin32();
-
   static void setInstanceWin32(HINSTANCE instance);
-
   static BOOL WINAPI getProcessEntry(PROCESSENTRY32 &entry, DWORD processID);
   static BOOL WINAPI getSelfProcessEntry(PROCESSENTRY32 &entry);
   static BOOL WINAPI getParentProcessEntry(PROCESSENTRY32 &entry);
+  static std::string getActiveDesktopName();
 
 private:
   //! Open and return a registry key, closing the parent key

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -129,8 +129,6 @@ int App::run(int argc, char **argv)
     LOG((CLOG_CRIT "an unknown error occurred\n"));
   }
 
-  appUtil().beforeAppExit();
-
   return result;
 }
 

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -209,16 +209,14 @@ private:
 #elif SYSAPI_WIN32
 
 // windows args
-#define HELP_SYS_ARGS " [--service <action>] [--relaunch] [--exit-pause]"
+#define HELP_SYS_ARGS " [--service <action>] [--relaunch]"
 #define HELP_SYS_INFO                                                                                                  \
   "      --service <action>   manage the windows service, valid options "                                              \
   "are:\n"                                                                                                             \
   "                             install/uninstall/start/stop\n"                                                        \
   "      --relaunch           persistently relaunches process in current "                                             \
   "user \n"                                                                                                            \
-  "                             session (useful for vista and upward).\n"                                              \
-  "      --exit-pause         wait for key press on exit, can be useful for\n"                                         \
-  "                             reading error messages that occur on exit.\n"
+  "                             session (useful for vista and upward).\n"
 #endif
 
 #if !defined(WINAPI_LIBEI) && WINAPI_XWINDOWS

--- a/src/lib/deskflow/AppUtil.h
+++ b/src/lib/deskflow/AppUtil.h
@@ -28,9 +28,6 @@ public:
   {
     instance().exitApp(code);
   }
-  virtual void beforeAppExit()
-  {
-  }
 
 private:
   IApp *m_app;

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -121,9 +121,7 @@ bool ArgParser::parsePlatformArgs(
 )
 {
 #if WINAPI_MSWINDOWS
-  if (isArg(i, argc, argv, nullptr, "--exit-pause")) {
-    argsBase.m_pauseOnExit = true;
-  } else if (isArg(i, argc, argv, nullptr, "--stop-on-desk-switch")) {
+  if (isArg(i, argc, argv, nullptr, "--stop-on-desk-switch")) {
     argsBase.m_stopOnDeskSwitch = true;
   } else {
     // option not supported here

--- a/src/lib/deskflow/ArgsBase.h
+++ b/src/lib/deskflow/ArgsBase.h
@@ -91,7 +91,6 @@ public:
 
 #if SYSAPI_WIN32
   bool m_debugServiceWait = false;
-  bool m_pauseOnExit = false;
   bool m_stopOnDeskSwitch = false;
 #endif
 

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -376,7 +376,7 @@ void DaemonApp::handleIpcMessage(const Event &e, void *)
     }
 
 #if SYSAPI_WIN32
-    std::string watchdogStatus = m_watchdog->isProcessActive() ? "active" : "idle";
+    std::string watchdogStatus = m_watchdog->isProcessRunning() ? "active" : "idle";
     LOG((CLOG_INFO "service status: %s", watchdogStatus.c_str()));
 #endif
 

--- a/src/lib/deskflow/IAppUtil.h
+++ b/src/lib/deskflow/IAppUtil.h
@@ -19,7 +19,6 @@ public:
   virtual void adoptApp(IApp *app) = 0;
   virtual IApp &app() const = 0;
   virtual int run(int argc, char **argv) = 0;
-  virtual void beforeAppExit() = 0;
   virtual void startNode() = 0;
   virtual std::vector<std::string> getKeyboardLayoutList() = 0;
   virtual std::string getCurrentLanguageCode() = 0;

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -99,17 +99,6 @@ static int foregroundStartupStatic(int argc, char **argv)
   return AppUtil::instance().app().foregroundStartup(argc, argv);
 }
 
-void AppUtilWindows::beforeAppExit()
-{
-  // this can be handy for debugging, since the application is launched in
-  // a new console window, and will normally close on exit (making it so
-  // that we can't see error messages).
-  if (app().argsBase().m_pauseOnExit) {
-    std::cout << std::endl << "press any key to exit..." << std::endl;
-    int c = _getch();
-  }
-}
-
 int AppUtilWindows::run(int argc, char **argv)
 {
   if (!IsWindowsXPSP3OrGreater()) {

--- a/src/lib/deskflow/win32/AppUtilWindows.h
+++ b/src/lib/deskflow/win32/AppUtilWindows.h
@@ -35,7 +35,6 @@ public:
   void debugServiceWait();
   int run(int argc, char **argv) override;
   void exitApp(int code) override;
-  void beforeAppExit() override;
   void startNode() override;
   std::vector<std::string> getKeyboardLayoutList() override;
   std::string getCurrentLanguageCode() override;

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -43,6 +43,8 @@ if(WIN32)
     MSWindowsKeyState.h
     MSWindowsPowerManager.cpp
     MSWindowsPowerManager.h
+    MSWindowsProcess.cpp
+    MSWindowsProcess.h
     MSWindowsScreen.cpp
     MSWindowsScreen.h
     MSWindowsScreenSaver.cpp

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -760,7 +760,11 @@ void MSWindowsDesks::checkDesk()
   // if we are told to shut down on desk switch, and this is not the
   // first switch, then shut down.
   if (m_stopOnDeskSwitch && m_activeDesk != NULL && name != m_activeDeskName) {
-    LOG((CLOG_DEBUG "shutting down because of desk switch to \"%s\"", name.c_str()));
+    if (name.empty()) {
+      LOG_DEBUG("shutting down because of desk switch, desktop name unknown");
+    } else {
+      LOG_DEBUG("shutting down because of desk switch to: %s", name.c_str());
+    }
     m_events->addEvent(Event(Event::kQuit));
     return;
   }

--- a/src/lib/platform/MSWindowsProcess.cpp
+++ b/src/lib/platform/MSWindowsProcess.cpp
@@ -1,0 +1,225 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Symless Ltd.
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "MSWindowsProcess.h"
+
+#include "arch/win32/XArchWindows.h"
+#include "base/Log.h"
+#include "ipc/IpcMessage.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <UserEnv.h>
+
+#include <string>
+
+namespace deskflow::platform {
+
+MSWindowsProcess::MSWindowsProcess(const std::string &command, HANDLE stdOutput, HANDLE stdError)
+    : m_command(command),
+      m_stdOutput(stdOutput),
+      m_stdError(stdError)
+{
+}
+
+MSWindowsProcess::~MSWindowsProcess()
+{
+  if (m_createProcessResult) {
+    CloseHandle(m_info.hProcess);
+    CloseHandle(m_info.hThread);
+  }
+}
+
+BOOL MSWindowsProcess::startInForeground()
+{
+  // clear, as we're reusing process info struct
+  ZeroMemory(&m_info, sizeof(PROCESS_INFORMATION));
+
+  // show the console window when in foreground mode,
+  // so we can close it gracefully, but minimize it
+  // so it doesn't get in the way.
+  STARTUPINFO si;
+  setStartupInfo(si);
+  si.dwFlags |= STARTF_USESHOWWINDOW;
+  si.wShowWindow = SW_MINIMIZE;
+
+  m_createProcessResult =
+      CreateProcess(nullptr, LPSTR(m_command.c_str()), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si, &m_info);
+  return m_createProcessResult;
+}
+
+BOOL MSWindowsProcess::startAsUser(HANDLE userToken, LPSECURITY_ATTRIBUTES sa)
+{
+  STARTUPINFO si;
+  setStartupInfo(si);
+
+  LPVOID environment;
+  if (!CreateEnvironmentBlock(&environment, userToken, FALSE)) {
+    LOG((CLOG_ERR "could not create environment block"));
+    throw XArch(new XArchEvalWindows);
+  }
+
+  ZeroMemory(&m_info, sizeof(PROCESS_INFORMATION));
+  const DWORD creationFlags = NORMAL_PRIORITY_CLASS | CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT;
+  m_createProcessResult = CreateProcessAsUser(
+      userToken, nullptr, LPSTR(m_command.c_str()), sa, nullptr, TRUE, creationFlags, environment, nullptr, &si, &m_info
+  );
+
+  DestroyEnvironmentBlock(environment);
+  CloseHandle(userToken);
+
+  return m_createProcessResult;
+}
+
+void MSWindowsProcess::setStartupInfo(STARTUPINFO &si)
+{
+  static char g_desktopName[] = "winsta0\\Default"; // NOSONAR -- Idiomatic Win32
+
+  ZeroMemory(&si, sizeof(STARTUPINFO));
+  si.cb = sizeof(STARTUPINFO);
+  si.lpDesktop = g_desktopName;
+  si.hStdOutput = m_stdOutput;
+  si.hStdError = m_stdError;
+  si.dwFlags |= STARTF_USESTDHANDLES;
+}
+
+DWORD MSWindowsProcess::waitForExit()
+{
+  const auto kMaxWaitMilliseconds = 10000;
+
+  LOG_INFO("waiting for process to exit, pid: %lu", m_info.dwProcessId);
+  if (WaitForSingleObject(m_info.hProcess, kMaxWaitMilliseconds) != WAIT_OBJECT_0) {
+    LOG_ERR("process did not exit within the expected time");
+    TerminateProcess(m_info.hProcess, 1);
+    throw XArch(new XArchEvalWindows());
+  }
+
+  DWORD exitCode = 0;
+  if (!GetExitCodeProcess(m_info.hProcess, &exitCode)) {
+    LOG_ERR("failed to get exit code, error: %lu", GetLastError());
+    throw XArch(new XArchEvalWindows());
+  }
+
+  if (exitCode != 0) {
+    LOG_WARN("process failed with exit code: %lu", exitCode);
+  } else {
+    LOG_DEBUG("process exited with code: %lu", exitCode);
+  }
+
+  return exitCode;
+}
+
+void MSWindowsProcess::shutdown(IpcServer &ipcServer, int timeout)
+{
+  shutdown(m_info.hProcess, m_info.dwProcessId, ipcServer, timeout);
+}
+
+void MSWindowsProcess::shutdown(HANDLE handle, DWORD pid, IpcServer &ipcServer, int timeout)
+{
+  LOG_DEBUG("shutting down process %d", pid);
+
+  DWORD exitCode;
+  GetExitCodeProcess(handle, &exitCode);
+  if (exitCode != STILL_ACTIVE) {
+    LOG_DEBUG("process %d is already shutdown", pid);
+    return;
+  }
+
+  IpcShutdownMessage shutdown;
+  ipcServer.send(shutdown, IpcClientType::Node);
+
+  // wait for process to exit gracefully.
+  double start = ARCH->time();
+  while (true) { // NOSONAR -- Multiple breaks necessary
+
+    GetExitCodeProcess(handle, &exitCode);
+    if (exitCode != STILL_ACTIVE) {
+      // yay, we got a graceful shutdown. there should be no hook in use errors!
+      LOG((CLOG_DEBUG "process %d was shutdown gracefully", pid));
+      break;
+    }
+
+    if (double elapsed = (ARCH->time() - start); elapsed > timeout) {
+      // if timeout reached, kill forcefully.
+      // calling TerminateProcess on deskflow is very bad!
+      // it causes the hook DLL to stay loaded in some apps,
+      // making it impossible to start deskflow again.
+      LOG((CLOG_WARN "shutdown timed out after %d secs, forcefully terminating", (int)elapsed));
+      TerminateProcess(handle, kExitSuccess);
+      break;
+    }
+
+    ARCH->sleep(1);
+  }
+}
+
+void MSWindowsProcess::createPipes()
+{
+  SECURITY_ATTRIBUTES saAttr;
+  saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+  saAttr.bInheritHandle = TRUE;
+  saAttr.lpSecurityDescriptor = nullptr;
+
+  if (!CreatePipe(&m_outputPipe, &m_stdOutput, &saAttr, 0)) {
+    LOG_ERR("could not create output pipe");
+    throw XArch(new XArchEvalWindows());
+  }
+
+  if (!CreatePipe(&m_errorPipe, &m_stdError, &saAttr, 0)) {
+    LOG_ERR("could not create error pipe");
+    throw XArch(new XArchEvalWindows());
+  }
+
+  // Set the pipes to non-blocking mode
+  DWORD mode = PIPE_NOWAIT;
+  if (!SetNamedPipeHandleState(m_outputPipe, &mode, nullptr, nullptr)) {
+    throw XArch(new XArchEvalWindows());
+  }
+
+  if (!SetNamedPipeHandleState(m_errorPipe, &mode, nullptr, nullptr)) {
+    throw XArch(new XArchEvalWindows());
+  }
+}
+
+std::string MSWindowsProcess::readStdOutput()
+{
+  return readOutput(m_outputPipe);
+}
+
+std::string MSWindowsProcess::readStdError()
+{
+  return readOutput(m_errorPipe);
+}
+
+std::string MSWindowsProcess::readOutput(HANDLE handle)
+{
+  const auto kOutputBufferSize = 4096;
+  char buffer[kOutputBufferSize]; // NOSONAR -- Idiomatic Win32
+
+  DWORD bytesRead;
+  DWORD totalBytesAvail;
+  DWORD bytesLeftThisMessage;
+
+  // Check if there is data available in the pipe, which prevents `ReadFile` from freezing execution.
+  if (!PeekNamedPipe(handle, nullptr, 0, nullptr, &totalBytesAvail, &bytesLeftThisMessage)) {
+    LOG_ERR("could not peek into pipe");
+    throw XArch(new XArchEvalWindows());
+  }
+
+  if (totalBytesAvail == 0) {
+    return "";
+  }
+
+  if (!ReadFile(handle, buffer, kOutputBufferSize, &bytesRead, nullptr)) {
+    LOG_ERR("could not read from pipe");
+    throw XArch(new XArchEvalWindows());
+  }
+
+  return std::string(buffer, bytesRead);
+}
+
+} // namespace deskflow::platform

--- a/src/lib/platform/MSWindowsProcess.h
+++ b/src/lib/platform/MSWindowsProcess.h
@@ -1,0 +1,57 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Symless Ltd.
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include "ipc/IpcServer.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <string>
+
+namespace deskflow::platform {
+
+namespace { // NOSONAR -- Deliberate anonymous
+const auto kDefaultShutdownTimeout = 10;
+}
+
+class MSWindowsProcess
+{
+public:
+  explicit MSWindowsProcess(const std::string &command, HANDLE stdOutput = nullptr, HANDLE stdError = nullptr);
+  ~MSWindowsProcess();
+
+  BOOL startInForeground();
+  BOOL startAsUser(HANDLE userToken, LPSECURITY_ATTRIBUTES sa);
+  void shutdown(IpcServer &ipcServer, int timeout = kDefaultShutdownTimeout);
+  DWORD waitForExit();
+  void createPipes();
+  std::string readStdOutput();
+  std::string readStdError();
+
+  PROCESS_INFORMATION info() const
+  {
+    return m_info;
+  }
+
+  static void shutdown(HANDLE handle, DWORD pid, IpcServer &ipcServer, int timeout = kDefaultShutdownTimeout);
+
+private:
+  void setStartupInfo(STARTUPINFO &si);
+
+  static std::string readOutput(HANDLE handle);
+
+  std::string m_command;
+  HANDLE m_stdOutput;
+  HANDLE m_stdError;
+  HANDLE m_outputPipe = nullptr;
+  HANDLE m_errorPipe = nullptr;
+  PROCESS_INFORMATION m_info;
+  BOOL m_createProcessResult = FALSE;
+};
+
+} // namespace deskflow::platform

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -308,10 +308,9 @@ bool MSWindowsScreen::canLeave()
 {
   POINT pos;
   if (!getThisCursorPos(&pos)) {
-    LOG((CLOG_DEBUG "unable to leave screen as windows security has disabled "
-                    "critical functions"));
-    // unable to get position this means deskflow will break if the cursor
-    // leaves the screen
+    // prevent screen leave when cursor position is not available; if unable to get cursor position,
+    // screen will become inaccessible if the cursor leaves the screen.
+    LOG_DEBUG("unable to leave screen, cursor position not available");
     return false;
   }
 

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -158,23 +158,3 @@ BOOL MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
 
   return gotEntry;
 }
-
-std::string MSWindowsSession::getActiveDesktopName()
-{
-  std::string result;
-  try {
-    HDESK hd = OpenInputDesktop(0, TRUE, GENERIC_READ);
-    if (hd != NULL) {
-      DWORD size;
-      GetUserObjectInformation(hd, UOI_NAME, NULL, 0, &size);
-      TCHAR *name = (TCHAR *)alloca(size + sizeof(TCHAR));
-      GetUserObjectInformation(hd, UOI_NAME, name, size, &size);
-      result = name;
-      CloseDesktop(hd);
-    }
-  } catch (std::exception &error) {
-    LOG((CLOG_ERR "failed to get active desktop name: %s", error.what()));
-  }
-
-  return result;
-}

--- a/src/lib/platform/MSWindowsSession.h
+++ b/src/lib/platform/MSWindowsSession.h
@@ -19,7 +19,6 @@ public:
   MSWindowsSession();
   ~MSWindowsSession();
 
-  //!
   /*!
   Returns true if the session ID has changed since updateActiveSession was
   called.
@@ -27,17 +26,13 @@ public:
   BOOL hasChanged();
 
   bool isProcessInSession(const char *name, PHANDLE process);
-
   HANDLE getUserToken(LPSECURITY_ATTRIBUTES security);
+  void updateActiveSession();
 
   DWORD getActiveSessionId()
   {
     return m_activeSessionId;
   }
-
-  void updateActiveSession();
-
-  std::string getActiveDesktopName();
 
 private:
   BOOL nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry);

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -198,10 +198,12 @@ void MSWindowsWatchdog::mainLoop(void *)
         continue;
       }
 
-      if (m_processFailures != 0) {
+      if (m_processFailures > 1) {
         // increasing backoff period, maximum of 10 seconds.
-        int timeout = (m_processFailures * 2) < 10 ? (m_processFailures * 2) : 10;
-        LOG((CLOG_WARN "backing off, wait=%ds, failures=%d", timeout, m_processFailures));
+        // only start sleeping at 1 second to avoid unnecessary delay when the process stops
+        // for the first failure (i.e. when the process just stopped running).
+        int timeout = m_processFailures < 10 ? m_processFailures : 10;
+        LOG_WARN("backing off, wait=%ds, failures=%d", timeout, m_processFailures);
         ARCH->sleep(timeout);
       }
 
@@ -428,7 +430,7 @@ void MSWindowsWatchdog::outputLoop(void *)
 
 void MSWindowsWatchdog::shutdownExistingProcesses()
 {
-  LOG_INFO("deamon shutting down existing processes");
+  LOG_INFO("daemon shutting down existing processes");
 
   if (m_process != nullptr) {
     m_process->shutdown(m_ipcServer);

--- a/src/test/unittests/deskflow/ArgParserTests.cpp
+++ b/src/test/unittests/deskflow/ArgParserTests.cpp
@@ -207,10 +207,7 @@ TEST(ArgParserTests, parseServerArgs_parses_each_category)
   args.m_daemon = false;
   char const *argv[] = {
       "deskflow", "--help"
-#if WINAPI_MSWINDOWS
-      ,
-      "--exit-pause"
-#elif WINAPI_XWINDOWS
+#if WINAPI_XWINDOWS
       ,
       "--no-xinitthreads"
 #endif
@@ -229,10 +226,7 @@ TEST(ArgParserTests, parseClientArgs_parses_single_help)
   char const *argv[] = {
       kAppId,
       "--help"
-#if WINAPI_MSWINDOWS
-      ,
-      "--exit-pause"
-#elif WINAPI_XWINDOWS
+#if WINAPI_XWINDOWS
       ,
       "--no-xinitthreads"
 #endif


### PR DESCRIPTION
Fixes: #8183

Blocks: 
- #8180
- #7804

Restores some of the code deleted in fb686ede21413eee5e9f92fce917438388bdc9ce (#7827) which is needed to run the core process in secure desktops (UAC prompts, login, lock screen, etc). I thought I tested PR #7827 pretty thoroughly (https://github.com/deskflow/deskflow/pull/7827#issuecomment-2447209735) but it looks like I made a mistake and wasn't thorough enough.

This time we're using ~~deskflow-core.exe~~ `deskflow-server.exe` (temporarily until core bin ships) instead of `deskflow-legacy.exe` to find the active desktop name (which is not accessible to processes running in session 0).

- [x] Test with UAC dialog 
- [x] Test with lock screen
- [x] Test with login screen
- [x] Test local built package
- [x] Test CI package

# Testing

Use 'Automatic' elevation:
![image](https://github.com/user-attachments/assets/9170eaac-8702-4a14-9907-af2540ad73f0)

Right click any app and click 'Run as administrator' to show the UAC dialog.

Expect: Mouse should work on client