### PR TITLE
chore: update to fancy checkout 1.0.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -243,7 +243,7 @@ jobs:
       # Fancy checkout gets all the tags
       # it also makes sure we can use git --describe correctly
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       # This effectively runs `vcvarsall.bat`, etc. It's not actually installing
       # VC++ as that's already pre-installed on the Windows runner.
@@ -311,7 +311,7 @@ jobs:
       # Fancy checkout gets all the tags
       # it also makes sure we can use git --describe correctly
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - name: Build on FreeBSD
         if: ${{ matrix.distro.name == 'freebsd' }}
@@ -345,7 +345,7 @@ jobs:
       options: --privileged
     steps:
       - name: Check out repository
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - run: git config --global protocol.file.allow always
 
@@ -374,7 +374,7 @@ jobs:
 
     steps:
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - name: Get version
         uses: ./.github/actions/get-version
@@ -419,7 +419,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - name: Get version
         uses: ./.github/actions/get-version

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           apt install -qqq git curl unzip gcovr > /dev/null
 
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - name: Install project dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/valgrind-analysis.yml
+++ b/.github/workflows/valgrind-analysis.yml
@@ -17,7 +17,7 @@ jobs:
           apt install -qqq git valgrind > /dev/null
 
       - name: Fancy Checkout
-        uses: sithlord48/fancy-checkout@v1.0.0
+        uses: sithlord48/fancy-checkout@v1.0.1
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
Update fancy checkout to 1.0.1