### PR TITLE
Post peer base clean

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -734,13 +734,11 @@ void MainWindow::checkFingerprint(const QString &line)
       deskflow::string::fromHex(match.captured(2).toStdString())
   };
 
-  // Only Save the sha256
   const bool isClient = m_coreProcess.mode() == CoreMode::Client;
-  const auto trustFile = isClient ? kFingerprintTrustedServersFilename : kFingerprintTrustedClientsFilename;
-  const auto localPath = QStringLiteral("%1/%2").arg(getTlsPath(), trustFile).toStdString();
 
+  // Only Save the sha256
   deskflow::FingerprintDatabase db;
-  db.read(localPath);
+  db.read(trustedFingerprintDb().toStdString());
   if (db.isTrusted(sha256)) {
     return;
   }
@@ -755,7 +753,7 @@ void MainWindow::checkFingerprint(const QString &line)
   );
   if (fingerprintDialog.exec() == QDialog::Accepted) {
     db.addTrusted(sha256);
-    db.write(localPath);
+    db.write(trustedFingerprintDb().toStdString());
     m_coreProcess.start();
   }
 }
@@ -1076,6 +1074,13 @@ QString MainWindow::getTlsPath()
 QString MainWindow::localFingerPrintDb()
 {
   return QStringLiteral("%1/%2").arg(getTlsPath(), kFingerprintLocalFilename);
+}
+
+QString MainWindow::trustedFingerprintDb()
+{
+  const bool isClient = m_coreProcess.mode() == CoreMode::Client;
+  const auto trustFile = isClient ? kFingerprintTrustedServersFilename : kFingerprintTrustedClientsFilename;
+  return QStringLiteral("%1/%2").arg(getTlsPath(), trustFile);
 }
 
 bool MainWindow::regenerateLocalFingerprints()

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -734,8 +734,6 @@ void MainWindow::checkFingerprint(const QString &line)
       deskflow::string::fromHex(match.captured(2).toStdString())
   };
 
-  const bool isClient = m_coreProcess.mode() == CoreMode::Client;
-
   // Only Save the sha256
   deskflow::FingerprintDatabase db;
   db.read(trustedFingerprintDb().toStdString());
@@ -744,13 +742,13 @@ void MainWindow::checkFingerprint(const QString &line)
   }
 
   m_coreProcess.stop();
-  const QList<deskflow::FingerprintData> fingerprints{sha1, sha256};
+
+  const bool isClient = m_coreProcess.mode() == CoreMode::Client;
   auto dialogMode = isClient ? FingerprintDialogMode::Client : FingerprintDialogMode::Server;
-  FingerprintDialog fingerprintDialog(this, fingerprints, dialogMode);
-  connect(
-      &fingerprintDialog, &FingerprintDialog::requestLocalPrintsDialog, this, &MainWindow::showMyFingerprint,
-      Qt::UniqueConnection
-  );
+
+  FingerprintDialog fingerprintDialog(this, {sha1, sha256}, dialogMode);
+  connect(&fingerprintDialog, &FingerprintDialog::requestLocalPrintsDialog, this, &MainWindow::showMyFingerprint);
+
   if (fingerprintDialog.exec() == QDialog::Accepted) {
     db.addTrusted(sha256);
     db.write(trustedFingerprintDb().toStdString());

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -156,13 +156,13 @@ MainWindow::MainWindow(ConfigScopes &configScopes, AppConfig &appConfig)
 
   // Force generation of SHA256 for the localhost
   if (m_appConfig.tlsEnabled()) {
-    if (!QFile::exists(localFingerPrintDb())) {
+    if (!QFile::exists(localFingerprintDb())) {
       regenerateLocalFingerprints();
       return;
     }
 
     deskflow::FingerprintDatabase db;
-    db.read(localFingerPrintDb().toStdString());
+    db.read(localFingerprintDb().toStdString());
     if (db.fingerprints().size() != kTlsDbSize) {
       regenerateLocalFingerprints();
     }
@@ -482,14 +482,14 @@ void MainWindow::updateSize()
 
 void MainWindow::showMyFingerprint()
 {
-  if (!QFile::exists(localFingerPrintDb())) {
+  if (!QFile::exists(localFingerprintDb())) {
     if (regenerateLocalFingerprints())
       showMyFingerprint();
     return;
   }
 
   deskflow::FingerprintDatabase db;
-  db.read(localFingerPrintDb().toStdString());
+  db.read(localFingerprintDb().toStdString());
   if (db.fingerprints().size() != kTlsDbSize) {
     if (regenerateLocalFingerprints())
       showMyFingerprint();
@@ -950,7 +950,7 @@ QString MainWindow::getIPAddresses() const
 
 void MainWindow::updateLocalFingerprint()
 {
-  ui->lblMyFingerprint->setVisible(m_appConfig.tlsEnabled() && QFile::exists(localFingerPrintDb()));
+  ui->lblMyFingerprint->setVisible(m_appConfig.tlsEnabled() && QFile::exists(localFingerprintDb()));
 }
 
 void MainWindow::autoAddScreen(const QString name)
@@ -1071,7 +1071,7 @@ QString MainWindow::getTlsPath()
   return QStringLiteral("%1/%2").arg(coreTool.getProfileDir(), kSslDir);
 }
 
-QString MainWindow::localFingerPrintDb()
+QString MainWindow::localFingerprintDb()
 {
   return QStringLiteral("%1/%2").arg(getTlsPath(), kFingerprintLocalFilename);
 }

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -168,6 +168,12 @@ private:
   QString getTlsPath();
   QString localFingerPrintDb();
 
+  /**
+   * @brief trustedFingerprintDb get the fingerprintDb for the trusted clients or trusted servers.
+   * @return The path to the trusted fingerprint file
+   */
+  QString trustedFingerprintDb();
+
   // Generate prints if they are missing
   // Returns true if successful
   bool regenerateLocalFingerprints();

--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -166,7 +166,12 @@ private:
   void showAndActivate();
 
   QString getTlsPath();
-  QString localFingerPrintDb();
+
+  /**
+   * @brief localFingerprintDb
+   * @return The path to the local fingerprint file
+   */
+  QString localFingerprintDb();
 
   /**
    * @brief trustedFingerprintDb get the fingerprintDb for the trusted clients or trusted servers.

--- a/src/lib/gui/core/ServerConnection.cpp
+++ b/src/lib/gui/core/ServerConnection.cpp
@@ -19,10 +19,11 @@ namespace deskflow::gui {
 // ServerConnection::Deps
 //
 
-messages::NewClientPromptResult
-ServerConnection::Deps::showNewClientPrompt(QWidget *parent, const QString &clientName, bool previouslyAccepted) const
+messages::NewClientPromptResult ServerConnection::Deps::showNewClientPrompt(
+    QWidget *parent, const QString &clientName, bool serverRequiresPeerAuth
+) const
 {
-  return messages::showNewClientPrompt(parent, clientName, previouslyAccepted);
+  return messages::showNewClientPrompt(parent, clientName, serverRequiresPeerAuth);
 }
 
 //

--- a/src/lib/gui/core/ServerConnection.h
+++ b/src/lib/gui/core/ServerConnection.h
@@ -26,7 +26,7 @@ public:
   {
     virtual ~Deps() = default;
     virtual messages::NewClientPromptResult
-    showNewClientPrompt(QWidget *parent, const QString &clientName, bool previouslyAccepted = false) const;
+    showNewClientPrompt(QWidget *parent, const QString &clientName, bool serverRequiresPeerAuth = false) const;
   };
 
   explicit ServerConnection(

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -205,12 +205,12 @@ void showClientConnectError(QWidget *parent, ClientError error, const QString &a
   dialog.exec();
 }
 
-NewClientPromptResult showNewClientPrompt(QWidget *parent, const QString &clientName, bool tlsAcceptedClient)
+NewClientPromptResult showNewClientPrompt(QWidget *parent, const QString &clientName, bool serverRequiresPeerAuth)
 {
   using enum NewClientPromptResult;
 
-  if (tlsAcceptedClient) {
-    // When peer checking is enabled you will be prompted to allow the connection before seeing this dialog.
+  if (serverRequiresPeerAuth) {
+    // When peer auth is enabled you will be prompted to allow the connection before seeing this dialog.
     // This is why we do not show a dialog with an option to ignore the new client
     QMessageBox::information(
         parent, QString("New Client"),

--- a/src/lib/gui/messages.h
+++ b/src/lib/gui/messages.h
@@ -38,7 +38,8 @@ void showCloseReminder(QWidget *parent);
 
 void showClientConnectError(QWidget *parent, ClientError error, const QString &address);
 
-NewClientPromptResult showNewClientPrompt(QWidget *parent, const QString &clientName, bool tlsAcceptedClient = false);
+NewClientPromptResult
+showNewClientPrompt(QWidget *parent, const QString &clientName, bool serverRequiresPeerAuth = false);
 
 bool showClearSettings(QWidget *parent);
 


### PR DESCRIPTION
 Some small cleanups we missed on peerbase. 

 - Add a method to get the `MainWindow::trustedFingerprintDb`
 - Adjust the message box bool (yet again) to even better name `serverRequiresPeerAuth`
 - Simplify `MainWindow::checkFingerprints`
 - rename `MainWindow::localFingerPrintDb` => `MainWindow::localFingerprintDb`