### PR TITLE
Create GitHub recommended security policy file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+The latest minor release is supported and receives security updates:
+https://github.com/deskflow/deskflow/releases
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities on our issue tracker as bugs:
+https://github.com/deskflow/deskflow/issues


### PR DESCRIPTION
On the [security page](https://github.com/deskflow/deskflow/security), the 'Set up a security policy' button creates a file called `SECURITY.md`:
![image](https://github.com/user-attachments/assets/5df4aa64-01a8-48dc-93e9-35c02fe538da)
