### PR TITLE
fix: missing reuse info for SECURITY.md file

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -49,6 +49,12 @@ SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
+path = "SECURITY.md"
+precedence = "override"
+SPDX-FileCopyrightText = "Deskflow Developers"
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
 path = "sonar-project.properties"
 precedence = "override"
 SPDX-FileCopyrightText = "Deskflow Developers"


### PR DESCRIPTION
 I though the file was going in to .github/ so i didn't check the spdx info.. ive added the file to the REUSE.toml This will fix the reuse lint failure