### PR TITLE
Toolbutton style

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -222,7 +222,7 @@ void MainWindow::setupControls()
   }
 
   // Setup the log toggle, set its initial state to closed
-  ui->btnToggleLog->setStyleSheet(QStringLiteral("background:rgba(0,0,0,0);"));
+  ui->btnToggleLog->setStyleSheet(kStyleFlatButton);
   if (m_appConfig.logExpanded()) {
     ui->btnToggleLog->setArrowType(Qt::DownArrow);
     ui->textLog->setVisible(true);
@@ -247,6 +247,7 @@ void MainWindow::setupControls()
 #endif
 
   const auto trayItemSize = QSize(24, 24);
+  m_btnFingerprint->setStyleSheet(kStyleFlatButtonHoverable);
   m_btnFingerprint->setIcon(QIcon::fromTheme(QStringLiteral("fingerprint")));
   m_btnFingerprint->setFixedSize(trayItemSize);
   m_btnFingerprint->setIconSize(trayItemSize);
@@ -262,12 +263,13 @@ void MainWindow::setupControls()
   ui->statusBar->insertPermanentWidget(2, m_lblStatus, 1);
 
   m_btnUpdate->setVisible(false);
+  m_btnUpdate->setStyleSheet(kStyleFlatButtonHoverable);
+  m_btnUpdate->setFlat(true);
   m_btnUpdate->setText(tr("Update available"));
   m_btnUpdate->setLayoutDirection(Qt::RightToLeft);
   m_btnUpdate->setIcon(QIcon::fromTheme(QStringLiteral("software-updates-release")));
   m_btnUpdate->setFixedHeight(24);
   m_btnUpdate->setIconSize(trayItemSize);
-  m_btnUpdate->setFlat(true);
   ui->statusBar->insertPermanentWidget(3, m_btnUpdate);
 }
 

--- a/src/apps/deskflow-gui/VersionChecker.cpp
+++ b/src/apps/deskflow-gui/VersionChecker.cpp
@@ -47,7 +47,7 @@ void VersionChecker::replyFinished(QNetworkReply *reply)
     return;
   }
 
-  qDebug() << QStringLiteral("version check server success, http status: %1").arg(QString::number(httpStatus));
+  qDebug("version check server success, http status: %d", httpStatus);
 
   const auto newestVersion = QString(reply->readAll());
   qDebug("version check response: %s", qPrintable(newestVersion));

--- a/src/lib/gui/styles.h
+++ b/src/lib/gui/styles.h
@@ -17,18 +17,18 @@ const auto kColorError = "#ec4c47";
 const auto kColorLightGrey = "#666666";
 
 const auto kStyleLink = //
-    QString("color: %1").arg(kColorSecondary);
+    QStringLiteral("color: %1").arg(kColorSecondary);
 
 const auto kStyleLineEditErrorBorder =
-    QString("border: 1px solid %1; border-radius: 2px; padding: 2px;").arg(kColorError);
+    QStringLiteral("border: 1px solid %1; border-radius: 2px; padding: 2px;").arg(kColorError);
 
 const auto kStyleErrorActiveLabel = //
-    QString("padding: 3px 5px; border-radius: 3px; "
-            "background-color: %1; color: %2")
+    QStringLiteral("padding: 3px 5px; border-radius: 3px; "
+                   "background-color: %1; color: %2")
         .arg(kColorError, kColorWhite);
 
 const auto kStyleErrorInactiveLabel = //
-    QString("padding: 3px 5px; border-radius: 3px;"
-            "background-color: none");
+    QStringLiteral("padding: 3px 5px; border-radius: 3px;"
+                   "background-color: none");
 
 } // namespace deskflow::gui

--- a/src/lib/gui/styles.h
+++ b/src/lib/gui/styles.h
@@ -31,4 +31,11 @@ const auto kStyleErrorInactiveLabel = //
     QStringLiteral("padding: 3px 5px; border-radius: 3px;"
                    "background-color: none");
 
+const auto kStyleFlatButton = QStringLiteral("QAbstractButton{background-color: none; border: none;}");
+
+const auto kStyleFlatButtonHoverable = QStringLiteral("%1\n"
+                                                      "QAbstractButton:hover{border: 1px solid palette(highlight);"
+                                                      " border-radius: 6px}")
+                                           .arg(kStyleFlatButton);
+
 } // namespace deskflow::gui


### PR DESCRIPTION
Naturally mac os had to do something with the style for the status buttons... 

-  fixes #8247
- Use `QStringLiteral` for style literal
 - Create a style for flat buttons and those with highlight 
 - use the styles for `btnToggleLog`,`btnUpdate` and `btnFingerprints`
 
The `btnToggleLog` should be flat and look like a label (when hovered the widget style may color it the highlight color, breeze does other don't its upto the style in that case) 

The `btnUpdate` and `btnFingerprints` should look flat and when hovered have a border that is 1px of your highlight color in my case blue on my mac)  The tooltip should look normal

Normal:
![Screenshot_20250225_101349](https://github.com/user-attachments/assets/e431fe2b-ece8-4e34-99fe-b807f5931418)

Hover 
![Screenshot_20250225_101607](https://github.com/user-attachments/assets/64502b38-5a62-4a9a-9f01-67eed5f62272)
