### PR TITLE
Speed up the windows CI action build time

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -9,8 +9,12 @@ inputs:
     description: "Used only on linux distro type: debian, fedora, suse, arch"
     required: false
 
-  mac-qt-version:
-    description: "The verison of Qt to install on mac os"
+  qt-version:
+    description: "The version of Qt to install (Windows & macOS)"
+    required: false
+
+  qt-install-dir:
+    description: "The path to install Qt into (Windows & macOS)"
     required: false
 
 outputs:
@@ -67,13 +71,13 @@ runs:
       shell: bash
 
     - name: Install Qt
-      if: ${{runner.os == 'macOS' }}
+      if: ${{runner.os != 'Linux' }}
       uses: jurplel/install-qt-action@v4
       with:
-        dir: "/Users/runner"
-        version: ${{inputs.mac-qt-version}}
+        dir: ${{inputs.qt-install-dir}}
+        version: ${{inputs.qt-version}}
         cache: true
-        cache-key-prefix: ${{matrix.target.os}}-${{env.qt-version}}
+        cache-key-prefix: ${{matrix.target.os}}-${{inputs.qt-version}}
 
     # Install Ninja with an action instead of using Chocolatey, as it's more
     # reliable and faster. The Ninja install action is pretty good as it

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -91,7 +91,8 @@ runs:
       id: vcpkg
       uses: johnwason/vcpkg-action@v6
       with:
-        manifest-dir: ${{ github.workspace }}
+        pkgs: wintoast gtest pkgconf openssl
+        extra-args: --classic
         triplet: x64-windows-release
         token: ${{ github.token }}
         github-binarycache: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,17 +133,20 @@ jobs:
             runs-on: "windows-2022"
             timeout: 120 #Windows can take while if it has to build vcpkg cache
             config-args: "-G Ninja"
+            qt-install-dir: "C:"
 
           - name: "macos-14-arm64"
             runs-on: "macos-14"
             timeout: 10
             arch: arm64
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64\""
+            qt-install-dir: "/Users/runner"
 
           - name: "macos-13-x64"
             runs-on: macos-13
             timeout: 20
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"x86_64\""
+            qt-install-dir: "/Users/runner"
 
           - name: "debian-13-x86_64"
             runs-on: ubuntu-latest
@@ -255,7 +258,8 @@ jobs:
         id: get-deps
         uses: ./.github/actions/install-dependencies
         with:
-          mac-qt-version: 6.8.2
+          qt-version: 6.8.2
+          qt-install-dir: ${{matrix.target.qt-install-dir}}
           like: ${{ matrix.target.like }}
 
       - name: Get version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -255,7 +255,7 @@ jobs:
         id: get-deps
         uses: ./.github/actions/install-dependencies
         with:
-          mac-qt-version: 6.7.3
+          mac-qt-version: 6.8.2
           like: ${{ matrix.target.like }}
 
       - name: Get version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,7 +131,7 @@ jobs:
         target:
           - name: "windows-2022-x64"
             runs-on: "windows-2022"
-            timeout: 120 #Windows can take while if it has to build vcpkg cache
+            timeout: 30
             config-args: "-G Ninja"
             qt-install-dir: "C:"
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4e08971f3ddc13018ca858a692efe92d3b6b9fce",
+    "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,11 +5,6 @@
     "wintoast",
     "gtest",
     "pkgconf",
-    {
-      "name": "openssl",
-      "features": [
-        "tools"
-      ]
-    }
+    "openssl"
   ]
 }


### PR DESCRIPTION
Speed up the windows CI
- bump qt install action to install qt 6.8.2
- use Qt action for windows
- do not use the vcpkg classic mode for CI builds, this prevents the `vcpkg.json` from not installing Qt for local builds.
- fixes https://github.com/deskflow/deskflow/issues/7976