### PR TITLE
Clean up a few items missed when removing the legacy tray

### DIFF
--- a/src/lib/base/log_outputters.cpp
+++ b/src/lib/base/log_outputters.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -148,55 +149,6 @@ SystemLogger::~SystemLogger()
     CLOG->remove(m_stop);
     delete m_stop;
   }
-}
-
-//
-// BufferedLogOutputter
-//
-
-BufferedLogOutputter::BufferedLogOutputter(uint32_t maxBufferSize) : m_maxBufferSize(maxBufferSize)
-{
-  // do nothing
-}
-
-BufferedLogOutputter::~BufferedLogOutputter()
-{
-  // do nothing
-}
-
-BufferedLogOutputter::const_iterator BufferedLogOutputter::begin() const
-{
-  return m_buffer.begin();
-}
-
-BufferedLogOutputter::const_iterator BufferedLogOutputter::end() const
-{
-  return m_buffer.end();
-}
-
-void BufferedLogOutputter::open(const char *)
-{
-  // do nothing
-}
-
-void BufferedLogOutputter::close()
-{
-  // remove all elements from the buffer
-  m_buffer.clear();
-}
-
-void BufferedLogOutputter::show(bool)
-{
-  // do nothing
-}
-
-bool BufferedLogOutputter::write(ELevel, const char *message)
-{
-  while (m_buffer.size() >= m_maxBufferSize) {
-    m_buffer.pop_front();
-  }
-  m_buffer.push_back(std::string(message));
-  return true;
 }
 
 //

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -117,41 +118,4 @@ public:
 private:
   ILogOutputter *m_syslog;
   ILogOutputter *m_stop;
-};
-
-//! Save log history
-/*!
-This outputter records the last N log messages.
-*/
-class BufferedLogOutputter : public ILogOutputter
-{
-private:
-  using Buffer = std::deque<std::string>;
-
-public:
-  using const_iterator = Buffer::const_iterator;
-
-  BufferedLogOutputter(uint32_t maxBufferSize);
-  virtual ~BufferedLogOutputter();
-
-  //! @name accessors
-  //@{
-
-  //! Get start of buffer
-  const_iterator begin() const;
-
-  //! Get end of buffer
-  const_iterator end() const;
-
-  //@}
-
-  // ILogOutputter overrides
-  virtual void open(const char *title);
-  virtual void close();
-  virtual void show(bool showIfEmpty);
-  virtual bool write(ELevel level, const char *message);
-
-private:
-  uint32_t m_maxBufferSize;
-  Buffer m_buffer;
 };

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -206,14 +206,6 @@ void App::initApp(int argc, const char **argv)
 
   // load configuration
   loadConfig();
-
-  if (!argsBase().m_disableTray && m_createTaskBarReceiver) {
-
-    // create a log buffer so we can show the latest message
-    // as a tray icon tooltip
-    BufferedLogOutputter *logBuffer = new BufferedLogOutputter(1000);
-    CLOG->insert(logBuffer, true);
-  }
 }
 
 void App::initIpcClient()

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -21,8 +21,6 @@
 
 #include <stdexcept>
 
-class IArchTaskBarReceiver;
-class BufferedLogOutputter;
 class ILogOutputter;
 class FileLogOutputter;
 namespace deskflow {
@@ -30,8 +28,6 @@ class Screen;
 }
 class IEventQueue;
 class SocketMultiplexer;
-
-typedef IArchTaskBarReceiver *(*CreateTaskBarReceiverFunc)(const BufferedLogOutputter *, IEventQueue *events);
 
 class App : public IApp
 {
@@ -127,7 +123,6 @@ private:
   deskflow::ArgsBase *m_args;
   static App *s_instance;
   FileLogOutputter *m_fileLog;
-  CreateTaskBarReceiverFunc m_createTaskBarReceiver;
   ARCH_APP_UTIL m_appUtil;
   IpcClient *m_ipcClient;
   SocketMultiplexer *m_socketMultiplexer;

--- a/src/lib/deskflow/ArgsBase.h
+++ b/src/lib/deskflow/ArgsBase.h
@@ -56,9 +56,6 @@ public:
   /// @brief The name of the current computer
   std::string m_name;
 
-  /// @brief Should the app add a tray icon
-  bool m_disableTray = false;
-
   /// @brief Tell the client to talk through IPC to the daemon
   bool m_enableIpc = false;
 


### PR DESCRIPTION
 As noted in https://github.com/deskflow/deskflow/issues/8107#issuecomment-2678563921

 - Removed the mentioned item
 - Remove the BufferlogOutputter as its not unused but did so in its own commit incase we need it back later. 