### PR TITLE
refactor: MainWindow: Update name change

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.h
+++ b/src/apps/deskflow-gui/MainWindow.h
@@ -11,6 +11,7 @@
 #include <QMainWindow>
 #include <QMutex>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QSystemTrayIcon>
 #include <QThread>
@@ -166,6 +167,8 @@ private:
   void showFirstConnectedMessage();
   void updateStatus();
   void showAndActivate();
+  void showHostNameEditor();
+  void setHostName();
 
   QString getTlsPath();
 
@@ -203,6 +206,7 @@ private:
   QSystemTrayIcon *m_trayIcon = nullptr;
   QLocalServer *m_guiDupeChecker = nullptr;
   inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
+  inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
 
   QLabel *m_lblSecurityStatus = nullptr;
   QLabel *m_lblStatus = nullptr;

--- a/src/apps/deskflow-gui/MainWindow.ui
+++ b/src/apps/deskflow-gui/MainWindow.ui
@@ -25,37 +25,120 @@
      <number>10</number>
     </property>
     <item>
-     <layout class="QHBoxLayout" name="layoutName">
-      <property name="sizeConstraint">
-       <enum>QLayout::SizeConstraint::SetMinAndMaxSize</enum>
+     <widget class="QWidget" name="widget" native="true">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>28</height>
+       </size>
       </property>
-      <item>
-       <widget class="QLabel" name="lblComputerName">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string notr="true">This computer's name:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="m_pSpacerUpdate">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>28</height>
+       </size>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="labelComputerName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true">This computer's name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblComputerName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>lblName</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEditName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Name can't have have spaces or special characters&lt;/p&gt;&lt;p&gt;Use Enter to save the name change.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="maxLength">
+          <number>255</number>
+         </property>
+         <property name="frame">
+          <bool>false</bool>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnEditName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Edit Computer Name</string>
+         </property>
+         <property name="icon">
+          <iconset theme="document-edit"/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </item>
     <item>
      <widget class="QLabel" name="lblIpAddresses">

--- a/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/SettingsDialog.cpp
@@ -55,11 +55,6 @@ SettingsDialog::SettingsDialog(
   m_wasOriginallySystemScope = m_appConfig.isActiveScopeSystem();
   updateControls();
 
-  m_pScreenNameError = new validators::ValidationError(this);
-  ui->m_pLineEditScreenName->setValidator(
-      new validators::ScreenNameValidator(ui->m_pLineEditScreenName, m_pScreenNameError, &serverConfig.screens())
-  );
-
   connect(ui->m_pCheckBoxEnableTls, &QCheckBox::toggled, this, &SettingsDialog::updateTlsControlsEnabled);
 
   connect(
@@ -167,13 +162,7 @@ void SettingsDialog::showReadOnlyMessage()
 
 void SettingsDialog::accept()
 {
-  if (!ui->m_pLineEditScreenName->hasAcceptableInput()) {
-    QMessageBox::warning(this, tr("Invalid screen name"), m_pScreenNameError->message());
-    return;
-  }
-
   m_appConfig.setLoadFromSystemScope(ui->m_pRadioSystemScope->isChecked());
-  m_appConfig.setScreenName(ui->m_pLineEditScreenName->text());
   m_appConfig.setPort(ui->m_pSpinBoxPort->value());
   m_appConfig.setNetworkInterface(ui->m_pLineEditInterface->text());
   m_appConfig.setLogLevel(ui->m_pComboLogLevel->currentIndex());
@@ -209,7 +198,6 @@ void SettingsDialog::reject()
 void SettingsDialog::loadFromConfig()
 {
 
-  ui->m_pLineEditScreenName->setText(m_appConfig.screenName());
   ui->m_pSpinBoxPort->setValue(m_appConfig.port());
   ui->m_pLineEditInterface->setText(m_appConfig.networkInterface());
   ui->m_pComboLogLevel->setCurrentIndex(m_appConfig.logLevel());
@@ -318,7 +306,6 @@ void SettingsDialog::updateControls()
   const bool serviceChecked = ui->m_pCheckBoxServiceEnabled->isChecked();
   const bool logToFile = ui->m_pCheckBoxLogToFile->isChecked();
 
-  ui->m_pLineEditScreenName->setEnabled(writable);
   ui->m_pSpinBoxPort->setEnabled(writable);
   ui->m_pLineEditInterface->setEnabled(writable);
   ui->m_pComboLogLevel->setEnabled(writable);

--- a/src/apps/deskflow-gui/dialogs/SettingsDialog.h
+++ b/src/apps/deskflow-gui/dialogs/SettingsDialog.h
@@ -65,8 +65,6 @@ private:
   /// @brief Enables controls when they should be.
   void updateControls();
 
-  validators::ValidationError *m_pScreenNameError;
-
   /// @brief Stores settings scope at start of settings dialog
   /// This is necessary to restore state if user changes
   /// the scope and doesn't save changes

--- a/src/apps/deskflow-gui/dialogs/SettingsDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/SettingsDialog.ui
@@ -55,55 +55,6 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="m_pLabelComputerName">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>75</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Computer name</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::Maximum</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="m_pLineEditScreenName">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="maxLength">
-               <number>255</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <widget class="QCheckBox" name="m_pCheckBoxPreventSleep">
             <property name="text">
              <string>Prevent this computer from going to sleep</string>
@@ -772,7 +723,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>m_pLineEditScreenName</tabstop>
   <tabstop>m_pSpinBoxPort</tabstop>
   <tabstop>m_pLineEditInterface</tabstop>
   <tabstop>m_pCheckBoxEnableTls</tabstop>

--- a/src/apps/res/deskflow.qrc
+++ b/src/apps/res/deskflow.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>icons/deskflow-dark/actions/16/configure.svg</file>
         <file>icons/deskflow-dark/actions/16/edit-copy.svg</file>
+        <file>icons/deskflow-dark/actions/16/document-edit.svg</file>
         <file>icons/deskflow-dark/actions/16/document-open.svg</file>
         <file>icons/deskflow-dark/actions/16/document-save-as.svg</file>
         <file>icons/deskflow-dark/actions/16/help-about.svg</file>
@@ -11,6 +12,7 @@
         <file>icons/deskflow-dark/actions/16/view-refresh.svg</file>
         <file>icons/deskflow-dark/actions/22/configure.svg</file>
         <file>icons/deskflow-dark/actions/22/edit-copy.svg</file>
+        <file>icons/deskflow-dark/actions/22/document-edit.svg</file>
         <file>icons/deskflow-dark/actions/22/document-open.svg</file>
         <file>icons/deskflow-dark/actions/22/document-save-as.svg</file>
         <file>icons/deskflow-dark/actions/22/fingerprint.svg</file>
@@ -21,6 +23,7 @@
         <file>icons/deskflow-dark/actions/22/view-refresh.svg</file>
         <file>icons/deskflow-dark/actions/24/configure.svg</file>
         <file>icons/deskflow-dark/actions/24/edit-copy.svg</file>
+        <file>icons/deskflow-dark/actions/24/document-edit.svg</file>
         <file>icons/deskflow-dark/actions/24/document-open.svg</file>
         <file>icons/deskflow-dark/actions/24/document-save-as.svg</file>
         <file>icons/deskflow-dark/actions/24/edit-clear-all.svg</file>
@@ -56,6 +59,7 @@
         <file>icons/deskflow-light/actions/16/configure.svg</file>
         <file>icons/deskflow-light/actions/16/edit-clear-all.svg</file>
         <file>icons/deskflow-light/actions/16/edit-copy.svg</file>
+        <file>icons/deskflow-light/actions/16/document-edit.svg</file>
         <file>icons/deskflow-light/actions/16/document-open.svg</file>
         <file>icons/deskflow-light/actions/16/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/16/help-about.svg</file>
@@ -66,6 +70,7 @@
         <file>icons/deskflow-light/actions/22/configure.svg</file>
         <file>icons/deskflow-light/actions/22/edit-clear-all.svg</file>
         <file>icons/deskflow-light/actions/22/edit-copy.svg</file>
+        <file>icons/deskflow-light/actions/22/document-edit.svg</file>
         <file>icons/deskflow-light/actions/22/document-open.svg</file>
         <file>icons/deskflow-light/actions/22/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/22/fingerprint.svg</file>
@@ -78,6 +83,7 @@
         <file>icons/deskflow-light/actions/24/edit-clear-all.svg</file>
         <file>icons/deskflow-light/actions/24/edit-copy.svg</file>
         <file>icons/deskflow-light/actions/24/fingerprint.svg</file>
+        <file>icons/deskflow-light/actions/24/document-edit.svg</file>
         <file>icons/deskflow-light/actions/24/document-open.svg</file>
         <file>icons/deskflow-light/actions/24/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/24/help-about.svg</file>


### PR DESCRIPTION
Allow for rename on the mainwindow

Normal
![Screenshot_20250225_095649](https://github.com/user-attachments/assets/2ebcd845-e339-4a22-9255-168eb1ec12f9)

When Editing, (note the size is the same i had to capture it differently to get the tooltip also, tooltip is normal tooltip not always shown, my cursor was not captured in the image )
![Screenshot_20250225_095751](https://github.com/user-attachments/assets/0bfcb095-108c-4379-99d3-dc409c0a0978)
