### PR TITLE
chore: add icon credit to about box

### DIFF
--- a/src/apps/deskflow-gui/dialogs/AboutDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.cpp
@@ -49,8 +49,8 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent), ui{std::make_unique
   ui->btnOk->setDefault(true);
   connect(ui->btnOk, &QPushButton::clicked, this, [this] { close(); });
 
+  setFixedWidth(600);
   adjustSize();
-  resize(QSize(parent->width() * 0.65, height()));
   setMinimumSize(size());
 }
 

--- a/src/apps/deskflow-gui/dialogs/AboutDialog.h
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.h
@@ -25,8 +25,6 @@ private:
   std::unique_ptr<Ui::AboutDialog> ui;
   void copyVersionText();
 
-  inline static const auto s_lightCopy = QStringLiteral(":/icons/64x64/copy-light.png");
-  inline static const auto s_darkCopy = QStringLiteral(":/icons/64x64/copy-dark.png");
   inline static const auto s_awesomeDevs = QStringList{
       // Chris is the ultimate creator, and the one who started it all in 2001.
       QStringLiteral("Chris Schoeneman"),

--- a/src/apps/deskflow-gui/dialogs/AboutDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.ui
@@ -3,7 +3,7 @@
  <class>AboutDialog</class>
  <widget class="QDialog" name="AboutDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModality::ApplicationModal</enum>
+   <enum>Qt::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -67,7 +67,7 @@ p, li { white-space: pre-wrap; }
       <item row="6" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+         <enum>Qt::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -80,7 +80,7 @@ p, li { white-space: pre-wrap; }
       <item row="0" column="1">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
+         <enum>Qt::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -105,7 +105,7 @@ p, li { white-space: pre-wrap; }
          <bool>false</bool>
         </property>
         <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
+         <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
         </property>
         <property name="indent">
          <number>0</number>
@@ -158,7 +158,7 @@ p, li { white-space: pre-wrap; }
             <string>Version: </string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
            <property name="indent">
             <number>0</number>
@@ -182,7 +182,7 @@ p, li { white-space: pre-wrap; }
             <string>lbl_version</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
            <property name="smaller_text" stdset="0">
             <bool>true</bool>
@@ -224,7 +224,7 @@ p, li { white-space: pre-wrap; }
             </sizepolicy>
            </property>
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -272,7 +272,7 @@ p, li { white-space: pre-wrap; }
       <string>lblDescription</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
     </widget>
    </item>
@@ -292,10 +292,10 @@ p, li { white-space: pre-wrap; }
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Policy::Fixed</enum>
+      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -308,7 +308,7 @@ p, li { white-space: pre-wrap; }
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
+      <enum>QAbstractScrollArea::AdjustIgnored</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -318,8 +318,8 @@ p, li { white-space: pre-wrap; }
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>580</width>
-        <height>157</height>
+        <width>574</width>
+        <height>191</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -329,6 +329,9 @@ p, li { white-space: pre-wrap; }
        </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>6</number>
+       </property>
        <property name="leftMargin">
         <number>3</number>
        </property>
@@ -343,15 +346,24 @@ p, li { white-space: pre-wrap; }
        </property>
        <item>
         <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;KDE Breeze&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/src/apps/deskflow-gui/dialogs/AboutDialog.ui
+++ b/src/apps/deskflow-gui/dialogs/AboutDialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
+    <width>600</width>
     <height>475</height>
    </rect>
   </property>
@@ -207,7 +207,7 @@ p, li { white-space: pre-wrap; }
             <string>Copy version info</string>
            </property>
            <property name="icon">
-            <iconset resource="../../res/deskflow.qrc">
+            <iconset>
              <normaloff>:/icons/64x64/copy-dark.png</normaloff>:/icons/64x64/copy-dark.png</iconset>
            </property>
            <property name="flat">
@@ -306,49 +306,93 @@ p, li { white-space: pre-wrap; }
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_17">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
      </property>
-     <property name="title">
-      <string>Important developers</string>
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0">
-      <property name="spacing">
-       <number>6</number>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>580</width>
+        <height>157</height>
+       </rect>
       </property>
-      <property name="leftMargin">
-       <number>6</number>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
-       <number>6</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="lblImportantDevs">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>lblImportantDevs</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>3</number>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <property name="rightMargin">
+        <number>3</number>
+       </property>
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;KDE Breeze&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Important Developers</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="lblImportantDevs">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>lblImportantDevs</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -375,8 +419,6 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../res/deskflow.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
 - Remove unused icon path string const variables 
 - Update about box to have icon credit and a scrollarea to allow for future explanation to talk about important devs

![Screenshot_20250226_184556](https://github.com/user-attachments/assets/6529b82a-0460-43fd-adb6-7be427d08d0e)
