### PR TITLE
ci: Fix missing screenshots in CI generated flatpaks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -370,10 +370,9 @@ jobs:
           cache-key: flatpak-builder-${{matrix.flatpak.arch}}-2.0
           arch: ${{matrix.flatpak.arch}}
           upload-artifact: false
-          mirror-screenshots-url: https://dl.flathub.org/media
 
       - name: Validate build
-        run: flatpak-builder-lint repo repo
+        run: flatpak-builder-lint --exceptions --user-exceptions deploy/linux/flatpak/ci-build-lint-exceptions.json repo repo
 
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -97,7 +97,7 @@ SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "GPL-2.0-only"
 
 [[annotations]]
-path = "deploy/linux/flatpak/org.deskflow.deskflow.yml"
+path = "deploy/linux/flatpak/**"
 precedence = "override"
 SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "MIT"

--- a/deploy/linux/flatpak/ci-build-lint-exceptions.json
+++ b/deploy/linux/flatpak/ci-build-lint-exceptions.json
@@ -1,0 +1,6 @@
+{
+    "org.deskflow.deskflow": [
+        "appstream-external-screenshot-url",
+        "appstream-screenshots-not-mirrored-in-ostree"
+    ]
+}


### PR DESCRIPTION
Images are broken in our CI build flatpaks

 By default the linter for the flathub flatpak builder wants you to upload the screenshots to flathub, since our CI does not the images are blank in the resluting flatref , this skips the builder from remaking the screen shot links and tells the linter to not fail us because we did not upload the image to flathub. 