### PR TITLE
fix: Do stop the client on fingerprint dialog

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -809,18 +809,19 @@ void MainWindow::checkFingerprint(const QString &line)
     return;
   }
 
-  if (isClient) {
-    m_checkedServers.append(sha256Text);
-  } else {
-    m_checkedClients.append(sha256Text);
-  }
-
   deskflow::FingerprintDatabase db;
   db.read(trustedFingerprintDb().toStdString());
 
   if (db.isTrusted(sha256)) {
     qDebug("fingerprint is trusted");
     return;
+  }
+
+  if (isClient) {
+    m_checkedServers.append(sha256Text);
+    m_coreProcess.stop();
+  } else {
+    m_checkedClients.append(sha256Text);
   }
 
   auto dialogMode = isClient ? FingerprintDialogMode::Client : FingerprintDialogMode::Server;
@@ -833,6 +834,7 @@ void MainWindow::checkFingerprint(const QString &line)
     db.write(trustedFingerprintDb().toStdString());
     if (isClient) {
       m_checkedServers.removeAll(sha256Text);
+      m_coreProcess.start();
     } else {
       m_checkedClients.removeAll(sha256Text);
     }


### PR DESCRIPTION
Stops the core process in client mode while the client it validating fingerprints of the server, this has two benefits
 1. The Client no longer repeatably try to connect while the user is looking at the fingerprints of the server. So the Connection failed message mentioned in #8267 is no longer spawned.
 2. The Server will not be spammed with connection attempts at this time from the connecting client.

I fail to see any downside to this since the any client may only be connected to a single server.  I tested this on the with a client using auto connect to a name with two servers using the same name one accepted and one not and the client only talks to the proper one the fingerprint dialog is not even show, so it does not look like a rouge server can use this as a DDOS of the client.

fixes #8267  