### PR TITLE
fix: Delete `HKEY_LOCAL_MACHINE\SOFTWARE\Deskflow` when clearing settings

### DIFF
--- a/src/apps/deskflow-daemon/deskflow-daemon.cpp
+++ b/src/apps/deskflow-daemon/deskflow-daemon.cpp
@@ -99,6 +99,10 @@ int main(int argc, char **argv)
         &ipcServer, &ipc::DaemonIpcServer::stopProcessRequested, &daemon, &DaemonApp::clearWatchdogCommand, //
         Qt::DirectConnection
     );
+    QObject::connect(
+        &ipcServer, &ipc::DaemonIpcServer::clearSettingsRequested, &daemon, &DaemonApp::clearSettings, //
+        Qt::DirectConnection
+    );
 
     daemonThread.start();
     const auto exitCode = QCoreApplication::exec();

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -459,6 +459,7 @@ void MainWindow::clearSettings()
   }
 
   m_coreProcess.stop();
+  m_coreProcess.clearSettings();
 
   m_saveOnExit = false;
   diagnostic::clearSettings(m_configScopes, true);

--- a/src/lib/arch/IArchSystem.h
+++ b/src/lib/arch/IArchSystem.h
@@ -46,4 +46,11 @@ public:
   */
   virtual void setting(const std::string &valueName, const std::string &valueString) const = 0;
   //@}
+
+  //! Delete settings
+  /*!
+  Deletes all Core settings from the system.
+  */
+  virtual void clearSettings() const = 0;
+  //@}
 };

--- a/src/lib/arch/unix/ArchSystemUnix.cpp
+++ b/src/lib/arch/unix/ArchSystemUnix.cpp
@@ -67,6 +67,11 @@ void ArchSystemUnix::setting(const std::string &, const std::string &) const
 {
 }
 
+void ArchSystemUnix::clearSettings() const
+{
+  // Not implemented
+}
+
 std::string ArchSystemUnix::getLibsUsed(void) const
 {
   return "not implemented.\nuse lsof on shell";

--- a/src/lib/arch/unix/ArchSystemUnix.h
+++ b/src/lib/arch/unix/ArchSystemUnix.h
@@ -24,6 +24,7 @@ public:
   virtual std::string setting(const std::string &) const;
   virtual void setting(const std::string &, const std::string &) const;
   virtual std::string getLibsUsed(void) const;
+  virtual void clearSettings() const;
 
 #ifndef __APPLE__
   enum class InhibitScreenServices

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -165,6 +165,15 @@ void ArchMiscWindows::deleteValue(HKEY key, const TCHAR *name)
   RegDeleteValue(key, name);
 }
 
+void ArchMiscWindows::deleteKeyTree(HKEY key, const TCHAR *name)
+{
+  assert(key != NULL);
+  assert(name != NULL);
+  if (key == NULL || name == NULL)
+    return;
+  RegDeleteTree(key, name);
+}
+
 bool ArchMiscWindows::hasValue(HKEY key, const TCHAR *name)
 {
   DWORD type;

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -99,6 +99,9 @@ public:
   //! Delete a value
   static void deleteValue(HKEY parent, const TCHAR *name);
 
+  //! Delete a tree of keys from the registry
+  static void deleteKeyTree(HKEY parent, const TCHAR *name);
+
   //! Test if a value exists
   static bool hasValue(HKEY key, const TCHAR *name);
 

--- a/src/lib/arch/win32/ArchSystemWindows.cpp
+++ b/src/lib/arch/win32/ArchSystemWindows.cpp
@@ -9,6 +9,7 @@
 #include "arch/win32/ArchMiscWindows.h"
 
 #include "arch/XArch.h"
+#include "base/Log.h"
 #include "common/constants.h"
 
 #include "tchar.h"
@@ -17,7 +18,7 @@
 #include <psapi.h>
 #include <windows.h>
 
-static const char *s_settingsKeyNames[] = {_T("SOFTWARE"), _T(kAppName), NULL};
+static const TCHAR *s_settingsKeyNames[] = {_T("SOFTWARE"), _T(kAppName), NULL};
 
 //
 // ArchSystemWindows
@@ -84,6 +85,11 @@ void ArchSystemWindows::setting(const std::string &valueName, const std::string 
   if (key == NULL)
     throw XArch(std::string("could not access registry key: ") + valueName);
   ArchMiscWindows::setValue(key, valueName.c_str(), valueString.c_str());
+}
+
+void ArchSystemWindows::clearSettings() const
+{
+  ArchMiscWindows::deleteKeyTree(HKEY_LOCAL_MACHINE, kWindowsRegistryKey);
 }
 
 bool ArchSystemWindows::isWOW64() const

--- a/src/lib/arch/win32/ArchSystemWindows.h
+++ b/src/lib/arch/win32/ArchSystemWindows.h
@@ -23,6 +23,7 @@ public:
   virtual std::string getPlatformName() const;
   virtual std::string setting(const std::string &valueName) const;
   virtual void setting(const std::string &valueName, const std::string &valueString) const;
+  virtual void clearSettings() const;
 
   bool isWOW64() const;
 };

--- a/src/lib/common/constants.h.in
+++ b/src/lib/common/constants.h.in
@@ -15,6 +15,7 @@ const auto kVersionGitSha = "@GIT_SHA_SHORT@";
 const auto kDaemonBinName = "@CMAKE_PROJECT_NAME@-daemon";
 const auto kDaemonIpcName = "@CMAKE_PROJECT_NAME@-daemon";
 const auto kDaemonLogFilename = "@CMAKE_PROJECT_NAME@-daemon.log";
+const auto kWindowsRegistryKey = "SOFTWARE\\@CMAKE_PROJECT_PROPER_NAME@";
 
 const auto kCopyright = //
     "Copyright @CMAKE_PROJECT_COPYRIGHT@\n"

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -135,6 +135,12 @@ void DaemonApp::clearWatchdogCommand()
 #endif
 }
 
+void DaemonApp::clearSettings()
+{
+  LOG_INFO("clearing daemon settings");
+  ARCH->clearSettings();
+}
+
 DaemonApp::InitResult DaemonApp::init(IEventQueue *events, int argc, char **argv) // NOSONAR - CLI args
 {
   using enum InitResult;

--- a/src/lib/deskflow/DaemonApp.h
+++ b/src/lib/deskflow/DaemonApp.h
@@ -52,6 +52,7 @@ public:
   void setCommand(const QString &command);
   void applyWatchdogCommand() const;
   void clearWatchdogCommand();
+  void clearSettings();
   std::string logFilename();
 
   static DaemonApp &instance()

--- a/src/lib/deskflow/ipc/DaemonIpcServer.cpp
+++ b/src/lib/deskflow/ipc/DaemonIpcServer.cpp
@@ -130,6 +130,10 @@ void DaemonIpcServer::processMessage(QLocalSocket *clientSocket, const QString &
   } else if (command == "logPath") {
     LOG_DEBUG("ipc server got log path request");
     clientSocket->write("logPath=" + m_logFilename.toUtf8());
+  } else if (command == "clearSettings") {
+    LOG_DEBUG("ipc server got clear settings message");
+    Q_EMIT clearSettingsRequested();
+    clientSocket->write(kAckMessage);
   } else {
     LOG_WARN("ipc server got unknown message: %s", message.toUtf8().constData());
   }

--- a/src/lib/deskflow/ipc/DaemonIpcServer.h
+++ b/src/lib/deskflow/ipc/DaemonIpcServer.h
@@ -28,6 +28,7 @@ signals:
   void commandChanged(const QString &command);
   void startProcessRequested();
   void stopProcessRequested();
+  void clearSettingsRequested();
 
 private:
   void processMessage(QLocalSocket *clientSocket, const QString &message);

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -746,4 +746,19 @@ QString CoreProcess::requestDaemonLogPath()
   return logPath;
 }
 
+void CoreProcess::clearSettings()
+{
+  if (m_appConfig.processMode() == ProcessMode::kDesktop) {
+    qDebug("no core settings to clear in desktop mode");
+    return;
+  }
+
+  if (m_appConfig.processMode() != ProcessMode::kService) {
+    qFatal("invalid process mode");
+  }
+
+  qInfo("clearing core settings through daemon");
+  m_daemonIpcClient->sendClearSettings();
+}
+
 } // namespace deskflow::gui

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -87,6 +87,7 @@ public:
   void restart();
   void cleanup();
   void applyLogLevel();
+  void clearSettings();
 
   // getters
   Mode mode() const

--- a/src/lib/gui/ipc/DaemonIpcClient.cpp
+++ b/src/lib/gui/ipc/DaemonIpcClient.cpp
@@ -194,4 +194,9 @@ QString DaemonIpcClient::requestLogPath()
   return parts[1];
 }
 
+bool DaemonIpcClient::sendClearSettings()
+{
+  return sendMessage("clearSettings");
+}
+
 } // namespace deskflow::gui::ipc

--- a/src/lib/gui/ipc/DaemonIpcClient.h
+++ b/src/lib/gui/ipc/DaemonIpcClient.h
@@ -24,6 +24,7 @@ public:
   bool sendLogLevel(const QString &logLevel);
   bool sendStartProcess(const QString &command, ElevateMode elevateMode);
   bool sendStopProcess();
+  bool sendClearSettings();
   QString requestLogPath();
 
   bool isConnected() const


### PR DESCRIPTION
Fixes: #8227

To test: 
1. Use Windows
2. Click 'Help'
3. Click 'Clear settings'

Expect: Registry key does not exist: `HKEY_LOCAL_MACHINE\SOFTWARE\Deskflow`