### PR TITLE
fix: Remove mutex locking in Windows daemon watchdog (solves access violation bug)

### DIFF
--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 
 configure_file(constants.h.in constants.h @ONLY)
 
-add_library(common INTERFACE
+add_library(common
   common.h
   version.h
   IInterface.h

--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -41,11 +41,12 @@ enum
   kExitArgs = 3,       // bad arguments
   kExitConfig = 4,     // cannot read configuration
 };
+namespace deskflow::common {
 
 #if WINAPI_MSWINDOWS
-namespace deskflow::common {
 
 const auto kCloseEventName = "Global\\DeskflowClose";
 
-}
 #endif
+
+} // namespace deskflow::common

--- a/src/lib/common/version.cpp
+++ b/src/lib/common/version.cpp
@@ -1,0 +1,24 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Symless Ltd.
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "common/version.h"
+
+#include "common/constants.h"
+
+namespace deskflow::common {
+
+QString versionNumber()
+{
+  auto versionString = QString(kVersion);
+  if (versionString.endsWith(QStringLiteral(".0"))) {
+    versionString.chop(2);
+  } else {
+    versionString.append(QStringLiteral(" (%1)").arg(kVersionGitSha));
+  }
+  return versionString;
+}
+
+} // namespace deskflow::common

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -135,7 +135,7 @@ void DaemonApp::clearWatchdogCommand()
 #endif
 }
 
-void DaemonApp::clearSettings()
+void DaemonApp::clearSettings() const
 {
   LOG_INFO("clearing daemon settings");
   ARCH->clearSettings();

--- a/src/lib/deskflow/DaemonApp.h
+++ b/src/lib/deskflow/DaemonApp.h
@@ -52,7 +52,7 @@ public:
   void setCommand(const QString &command);
   void applyWatchdogCommand() const;
   void clearWatchdogCommand();
-  void clearSettings();
+  void clearSettings() const;
   std::string logFilename();
 
   static DaemonApp &instance()

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -171,8 +171,6 @@ void MSWindowsWatchdog::mainLoop(void *)
 
   LOG_DEBUG("starting watchdog main loop");
   while (m_running) {
-    std::unique_lock lock(m_processStateMutex);
-
     if (!m_command.empty() && !m_foreground && m_session.hasChanged()) {
       LOG_DEBUG("session changed, queueing process start");
       m_processState = ProcessState::StartPending;
@@ -229,8 +227,6 @@ void MSWindowsWatchdog::mainLoop(void *)
       m_processState = Idle;
     } break;
     }
-
-    lock.unlock();
 
     // TODO: This seems like a hack, why would we need to send the SAS function every loop iteration?
     // This slows down both the process relaunch speed and the watchdog thread loop shut down time.
@@ -333,8 +329,6 @@ void MSWindowsWatchdog::startProcess()
 void MSWindowsWatchdog::setProcessConfig(const std::string_view &command, bool elevate)
 {
   LOG_DEBUG("updating watchdog process config");
-  std::unique_lock lock(m_processStateMutex);
-
   m_command = command;
   m_elevateProcess = elevate;
 

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -162,5 +162,4 @@ private:
   ProcessState m_processState = ProcessState::Idle;
   std::string m_command = "";
   SendSas m_sendSasFunc = nullptr;
-  std::mutex m_processStateMutex;
 };


### PR DESCRIPTION
⚠️ **Draft** (not ready for review)

Fixes: #8288

Blocked by: 
- #8303
- #8305

~~This is a bit of a backward step, but for some reason the C++11 mutex was causing an access violation in the release build on some computers.~~

Use of either C++11 mutex or native Win32 mutex causes access violation. The mutex was added as it looked safe to do so but perhaps we can live without it.

This probably a symptom of a much bigger problem like stack or heap corruption, making this more of a workaround than a proper fix.

Note: I tried using `QMutex`, but linking `platform` against Qt causes many things to break, so we should do this some other time.