### PR TITLE
fix: Guard MSVC runtime version depending on compiler version

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -11,7 +11,7 @@ macro(configure_libs)
     find_package(Python REQUIRED QUIET)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /D _BIND_TO_CURRENT_VCLIBS_VERSION=1")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD /O2 /Ob2")
-    list(APPEND libs Wtsapi32 Userenv Wininet comsuppw Shlwapi)
+    list(APPEND libs Wtsapi32 Userenv Wininet comsuppw Shlwapi version)
     add_definitions(
       /DWIN32
       /D_WINDOWS

--- a/src/apps/deskflow-client/deskflow-client.cpp
+++ b/src/apps/deskflow-client/deskflow-client.cpp
@@ -18,6 +18,8 @@
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  ArchMiscWindows::guardRuntimeVersion();
+
   // record window instance for tray icon, etc
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
 #endif

--- a/src/apps/deskflow-daemon/deskflow-daemon.cpp
+++ b/src/apps/deskflow-daemon/deskflow-daemon.cpp
@@ -32,6 +32,8 @@ void handleError(const char *message);
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  ArchMiscWindows::guardRuntimeVersion();
+
   // Save window instance for later use, e.g. `GetModuleFileName` which is used when installing the daemon.
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif

--- a/src/apps/deskflow-server/deskflow-server.cpp
+++ b/src/apps/deskflow-server/deskflow-server.cpp
@@ -18,6 +18,8 @@
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  ArchMiscWindows::guardRuntimeVersion();
+
   // record window instance for tray icon, etc
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
 #endif

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -157,6 +157,9 @@ public:
   //! Returns true if we got the parent process name.
   static bool getParentProcessName(std::string &name);
 
+  //! Prevent hard to troubleshoot errors, e.g. access violations.
+  static void guardRuntimeVersion();
+
   static HINSTANCE instanceWin32();
   static void setInstanceWin32(HINSTANCE instance);
   static BOOL WINAPI getProcessEntry(PROCESSENTRY32 &entry, DWORD processID);


### PR DESCRIPTION
Fixes: #8311

PR shows an error dialog and exits the program (server, client, and daemon) if the MSVC++ runtime is too old. This avoids silent crashes which are very confusing and waste a lot of time. Windows doesn't tell you when a binary was linked against an older library, it just loads whatever DLL it finds and hopes for the best.

Wrong version:
![image](https://github.com/user-attachments/assets/b193806c-da5d-45bf-84aa-3652f15d06f2)

Missing runtime (default Windows message):
![image](https://github.com/user-attachments/assets/528c48e2-17e1-4919-a5f7-528d84c1a91d)
