### PR TITLE
fix: mac os icon mask

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -741,8 +741,9 @@ void MainWindow::setIcon()
   if (m_appConfig.colorfulTrayIcon()) {
     m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow")));
   } else {
-    m_trayIcon->setIcon(QIcon::fromTheme(QStringLiteral("deskflow-symbolic")));
-    m_trayIcon->icon().setIsMask(true);
+    auto icon = QIcon::fromTheme(QStringLiteral("deskflow-symbolic"));
+    icon.setIsMask(true);
+    m_trayIcon->setIcon(icon);
   }
 #endif
 }


### PR DESCRIPTION
fixes #8310

Restore the icon mask for our tray icon. 

tldr it was in the wrong order you must mask before applying to the tray 

