### PR TITLE
docs: Make Windows MSVC redist requirement stand out

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ For instructions on building Deskflow, use the wiki page: [Building](https://git
 
 We support all major operating systems, including Windows, macOS, Linux, and Unix-like BSD-derived.
 
-Windows 10 or higher is required. You will need to have installed the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version). Download latest: [`vc_redist.x64.exe`](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+> [!NOTE]
+> On Windows, you will need to install the 
+> [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).  
+> Download latest: [`vc_redist.x64.exe`](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
+Windows 10 or higher is required. 
 
 macOS 12 or higher is required.
 


### PR DESCRIPTION
Time machine's broken.

Before:
![image](https://github.com/user-attachments/assets/778028e8-d0dd-45bf-913e-1487bbea3b6d)

After:
![image](https://github.com/user-attachments/assets/277822c4-5278-4abe-aa1b-83dd20ec4e93)