### PR TITLE
Make Windows watchdog more responsive with new SAS thread

### DIFF
--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -46,6 +46,7 @@ enum
 namespace deskflow::common {
 
 const auto kCloseEventName = "Global\\DeskflowClose";
+const auto kSendSasEventName = "Global\\DeskflowSendSAS";
 
-}
+} // namespace deskflow::common
 #endif

--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -41,12 +41,3 @@ enum
   kExitArgs = 3,       // bad arguments
   kExitConfig = 4,     // cannot read configuration
 };
-
-#if WINAPI_MSWINDOWS
-namespace deskflow::common {
-
-const auto kCloseEventName = "Global\\DeskflowClose";
-const auto kSendSasEventName = "Global\\DeskflowSendSAS";
-
-} // namespace deskflow::common
-#endif

--- a/src/lib/common/constants.h.in
+++ b/src/lib/common/constants.h.in
@@ -47,7 +47,7 @@ const auto kWindowsRuntimeMinor = @REQUIRED_MSVC_RUNTIME_MINOR@;
 // clang-format on
 
 const auto kWindowsRegistryKey = "SOFTWARE\\@CMAKE_PROJECT_PROPER_NAME@";
-const auto kCloseEventName = "Global\\DeskflowClose";
-const auto kSendSasEventName = "Global\\DeskflowSendSAS";
+const auto kCloseEventName = "Global\\@CMAKE_PROJECT_PROPER_NAME@Close";
+const auto kSendSasEventName = "Global\\@CMAKE_PROJECT_PROPER_NAME@SendSAS";
 
 #endif

--- a/src/lib/common/constants.h.in
+++ b/src/lib/common/constants.h.in
@@ -15,7 +15,6 @@ const auto kVersionGitSha = "@GIT_SHA_SHORT@";
 const auto kDaemonBinName = "@CMAKE_PROJECT_NAME@-daemon";
 const auto kDaemonIpcName = "@CMAKE_PROJECT_NAME@-daemon";
 const auto kDaemonLogFilename = "@CMAKE_PROJECT_NAME@-daemon.log";
-const auto kWindowsRegistryKey = "SOFTWARE\\@CMAKE_PROJECT_PROPER_NAME@";
 
 // clang-format off
 const auto kDisplayVersion = @CMAKE_PROJECT_VERSION_TWEAK@ ? "@CMAKE_PROJECT_VERSION@ (@GIT_SHA_SHORT@)" : "@CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@.@CMAKE_PROJECT_VERSION_PATCH@";
@@ -46,5 +45,7 @@ const auto kTlsFingerprintTrustedClientsFilename = "trusted-clients";
 const auto kWindowsRuntimeMajor = @REQUIRED_MSVC_RUNTIME_MAJOR@;
 const auto kWindowsRuntimeMinor = @REQUIRED_MSVC_RUNTIME_MINOR@;
 // clang-format on
+
+const auto kWindowsRegistryKey = "SOFTWARE\\@CMAKE_PROJECT_PROPER_NAME@";
 
 #endif

--- a/src/lib/common/constants.h.in
+++ b/src/lib/common/constants.h.in
@@ -47,5 +47,7 @@ const auto kWindowsRuntimeMinor = @REQUIRED_MSVC_RUNTIME_MINOR@;
 // clang-format on
 
 const auto kWindowsRegistryKey = "SOFTWARE\\@CMAKE_PROJECT_PROPER_NAME@";
+const auto kCloseEventName = "Global\\DeskflowClose";
+const auto kSendSasEventName = "Global\\DeskflowSendSAS";
 
 #endif

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -40,7 +40,7 @@ AppUtilWindows::AppUtilWindows(IEventQueue *events) : m_events(events), m_exitMo
   // Waiting for the event loop start prevents race condition in fast fail scenario,
   // where the dtor is called just before the event loop starts.
   LOG_DEBUG("waiting for event thread to start");
-  std::unique_lock<std::mutex> lock(m_eventThreadStartedMutex);
+  std::unique_lock lock(m_eventThreadStartedMutex);
   m_eventThreadStartedCond.wait(lock, [this] { return m_eventThreadRunning; });
   LOG_DEBUG("event thread started");
 }
@@ -269,7 +269,7 @@ void AppUtilWindows::eventLoop()
 
   LOG_DEBUG("windows event loop running");
   {
-    std::lock_guard<std::mutex> lock(m_eventThreadStartedMutex);
+    std::lock_guard lock(m_eventThreadStartedMutex);
     m_eventThreadRunning = true;
   }
   m_eventThreadStartedCond.notify_one();

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -13,7 +13,7 @@
 #include "base/IEventQueue.h"
 #include "base/Log.h"
 #include "base/log_outputters.h"
-#include "common/common.h"
+#include "common/constants.h"
 #include "deskflow/App.h"
 #include "deskflow/ArgsBase.h"
 #include "deskflow/Screen.h"
@@ -261,7 +261,7 @@ void AppUtilWindows::showNotification(const std::string &title, const std::strin
 
 void AppUtilWindows::eventLoop()
 {
-  HANDLE hCloseEvent = CreateEventA(nullptr, TRUE, FALSE, deskflow::common::kCloseEventName);
+  HANDLE hCloseEvent = CreateEventA(nullptr, TRUE, FALSE, kCloseEventName);
   if (!hCloseEvent) {
     LOG_CRIT("failed to create event for windows event loop");
     throw XArch(new XArchEvalWindows());

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -234,7 +234,7 @@ TCPSocket::EJobResult SecureSocket::doWrite()
 
 int SecureSocket::secureRead(void *buffer, int size, int &read)
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   if (m_ssl->m_ssl != NULL) {
     LOG((CLOG_DEBUG2 "reading secure socket"));
@@ -261,7 +261,7 @@ int SecureSocket::secureRead(void *buffer, int size, int &read)
 
 int SecureSocket::secureWrite(const void *buffer, int size, int &wrote)
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   if (m_ssl->m_ssl != NULL) {
     LOG((CLOG_DEBUG2 "writing secure socket: %p", this));
@@ -294,7 +294,7 @@ bool SecureSocket::isSecureReady()
 
 void SecureSocket::initSsl(bool server)
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   m_ssl = new Ssl();
   m_ssl->m_context = NULL;
@@ -305,7 +305,7 @@ void SecureSocket::initSsl(bool server)
 
 bool SecureSocket::loadCertificates(std::string &filename)
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   if (filename.empty()) {
     SslLogger::logError("tls certificate is not specified");
@@ -396,7 +396,7 @@ void SecureSocket::createSSL()
 
 void SecureSocket::freeSSL()
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   isFatal(true);
   // take socket from multiplexer ASAP otherwise the race condition
@@ -421,7 +421,7 @@ void SecureSocket::freeSSL()
 
 int SecureSocket::secureAccept(int socket)
 {
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   createSSL();
 
@@ -489,7 +489,7 @@ int SecureSocket::secureConnect(int socket)
     return -1;
   }
 
-  std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+  std::lock_guard ssl_lock{ssl_mutex_};
 
   createSSL();
 

--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -65,7 +65,7 @@ void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
   int retval = poll(pfds, POLLFD_COUNT, timeout);
   if (retval > 0) {
     if (pfds[EIFD].revents & POLLIN) {
-      std::lock_guard<std::mutex> lock(mutex_);
+      std::lock_guard lock(mutex_);
 
       // libei doesn't allow ei_event_ref() because events are
       // supposed to be short-lived only. So instead, we create an NULL-data
@@ -103,7 +103,7 @@ IEventQueueBuffer::Type EiEventQueueBuffer::getEvent(Event &event, uint32_t &dat
   // we just have a "something happened" event on the ei fd and the rest is
   // handled by the EiScreen.
   //
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard lock(mutex_);
   auto pair = queue_.front();
   queue_.pop();
 
@@ -120,7 +120,7 @@ IEventQueueBuffer::Type EiEventQueueBuffer::getEvent(Event &event, uint32_t &dat
 
 bool EiEventQueueBuffer::addEvent(uint32_t dataID)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard lock(mutex_);
   queue_.push({false, dataID});
 
   // tickle the pipe so our read thread wakes up
@@ -132,7 +132,7 @@ bool EiEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool EiEventQueueBuffer::isEmpty() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard lock(mutex_);
 
   return queue_.empty();
 }

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -719,7 +719,7 @@ void EiScreen::handle_portal_session_closed(const Event &event, void *)
 
 void EiScreen::handleSystemEvent(const Event &sysevent, void *)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard lock(mutex_);
   bool disconnected = false;
 
   // Only one ei_dispatch per system event, see the comment in

--- a/src/lib/platform/MSWindowsHandle.h
+++ b/src/lib/platform/MSWindowsHandle.h
@@ -1,0 +1,48 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Symless Ltd.
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include "base/Log.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+/**
+ * @brief RAII pattern for a Windows handle (ensures handle is closed when out of scope).
+ */
+class MSWindowsHandle
+{
+public:
+  explicit MSWindowsHandle(HANDLE handle) : m_handle(handle)
+  {
+  }
+
+  MSWindowsHandle(const MSWindowsHandle &) = delete;
+  MSWindowsHandle &operator=(const MSWindowsHandle &) = delete;
+  MSWindowsHandle(MSWindowsHandle &&) = delete;
+  MSWindowsHandle &operator=(MSWindowsHandle &&) = delete;
+
+  ~MSWindowsHandle()
+  {
+    if (m_handle == nullptr || m_handle == INVALID_HANDLE_VALUE) {
+      return;
+    }
+
+    if (!CloseHandle(m_handle)) {
+      LOG_WARN("failed to close handle");
+    }
+  }
+
+  HANDLE
+  get() const
+  {
+    return m_handle;
+  }
+
+private:
+  HANDLE m_handle = nullptr;
+};

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -760,11 +760,11 @@ bool MSWindowsKeyState::fakeCtrlAltDel()
   // History: It used to be possible to use `PostMessage` to send `MOD_CONTROL | MOD_ALT, VK_DELETE`
   // as a backup but this ability was removed by Microsoft for security in favor of requiring the
   // `SendSAS` event to be used, which makes DoS and social engineering attacks more difficult.
-  HANDLE hEvtSendSas = OpenEvent(EVENT_MODIFY_STATE, FALSE, "Global\\SendSAS");
-  if (hEvtSendSas) {
+  HANDLE hSendSasEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, deskflow::common::kSendSasEventName);
+  if (hSendSasEvent) {
     LOG_DEBUG("found SendSAS event, simulating ctrl+alt+del");
-    SetEvent(hEvtSendSas);
-    CloseHandle(hEvtSendSas);
+    SetEvent(hSendSasEvent);
+    CloseHandle(hSendSasEvent);
     return true;
   } else {
     LOG_ERR("couldn't find SendSAS event, unable to simulate ctrl+alt+del");

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -760,7 +760,7 @@ bool MSWindowsKeyState::fakeCtrlAltDel()
   // History: It used to be possible to use `PostMessage` to send `MOD_CONTROL | MOD_ALT, VK_DELETE`
   // as a backup but this ability was removed by Microsoft for security in favor of requiring the
   // `SendSAS` event to be used, which makes DoS and social engineering attacks more difficult.
-  HANDLE hSendSasEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, deskflow::common::kSendSasEventName);
+  HANDLE hSendSasEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, kSendSasEventName);
   if (hSendSasEvent) {
     LOG_DEBUG("found SendSAS event, simulating ctrl+alt+del");
     SetEvent(hSendSasEvent);

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -171,9 +171,6 @@ protected:
 private:
   using GroupList = std::vector<HKL>;
 
-  // send ctrl+alt+del hotkey event on NT family
-  static void ctrlAltDelThread(void *);
-
   bool getGroups(GroupList &) const;
   void setWindowGroup(int32_t group);
 

--- a/src/lib/platform/MSWindowsProcess.cpp
+++ b/src/lib/platform/MSWindowsProcess.cpp
@@ -122,7 +122,7 @@ void MSWindowsProcess::shutdown(HANDLE handle, DWORD pid, int timeout)
   LOG_DEBUG("shutting down process %d", pid);
 
   LOG_DEBUG("sending close event to close process gracefully");
-  HANDLE hCloseEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, deskflow::common::kCloseEventName);
+  HANDLE hCloseEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, kCloseEventName);
   if (hCloseEvent != nullptr) { // NOSONAR -- Readability
     SetEvent(hCloseEvent);
     CloseHandle(hCloseEvent);

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -567,7 +567,7 @@ void MSWindowsWatchdog::sendSas() const
     throw XArch("SendSAS function not initialized");
   }
 
-  HANDLE sendSasEvent = CreateEvent(nullptr, FALSE, FALSE, "Global\\SendSAS");
+  HANDLE sendSasEvent = CreateEvent(nullptr, FALSE, FALSE, deskflow::common::kSendSasEventName);
   if (sendSasEvent == nullptr) {
     LOG_ERR("could not create SendSAS event");
     throw XArch(new XArchEvalWindows());

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -333,7 +333,7 @@ void MSWindowsWatchdog::startProcess()
 void MSWindowsWatchdog::setProcessConfig(const std::string_view &command, bool elevate)
 {
   LOG_DEBUG("updating watchdog process config");
-  std::unique_lock lock(m_processStateMutex);
+  std::lock_guard lock(m_processStateMutex);
 
   m_command = command;
   m_elevateProcess = elevate;

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -567,7 +567,7 @@ void MSWindowsWatchdog::sendSas() const
     throw XArch("SendSAS function not initialized");
   }
 
-  HANDLE sendSasEvent = CreateEvent(nullptr, FALSE, FALSE, deskflow::common::kSendSasEventName);
+  HANDLE sendSasEvent = CreateEvent(nullptr, FALSE, FALSE, kSendSasEventName);
   if (sendSasEvent == nullptr) {
     LOG_ERR("could not create SendSAS event");
     throw XArch(new XArchEvalWindows());

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -81,11 +81,6 @@ private:
   void outputLoop(void *);
 
   /**
-   * @brief Stops any core processes which were not started by the watchdog.
-   */
-  void shutdownExistingProcesses();
-
-  /**
    * @brief Duplicates the process token for the given process.
    *
    * Required for starting a process in the user session; when we start an elevated process
@@ -144,6 +139,11 @@ private:
    * @brief Convert the process state enum to a string (useful for logging).
    */
   static std::string processStateToString(ProcessState state);
+
+  /**
+   * @brief Stops any core processes which were not started by the watchdog.
+   */
+  static void shutdownExistingProcesses();
 
 private:
   Thread *m_thread = nullptr;

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -121,11 +121,6 @@ private:
   void initSasFunc();
 
   /**
-   * @brief Send a SAS (Secure Attention Sequence) for Ctrl+Alt+Del emulation.
-   */
-  void sendSas() const;
-
-  /**
    * @brief Re-run the process to get the active desktop name.
    *
    * It is necessary to run a utility process because the daemon runs in session 0, which does not
@@ -134,6 +129,13 @@ private:
    * @return std::string The name of the active desktop.
    */
   std::string runActiveDesktopUtility();
+
+  /**
+   * @brief Allows the SendSAS function to be called from other processes.
+   *
+   * SendSAS sends a SAS (Secure Attention Sequence) for Ctrl+Alt+Del emulation.
+   */
+  void sasLoop(void *);
 
   /**
    * @brief Convert the process state enum to a string (useful for logging).
@@ -146,11 +148,12 @@ private:
   static void shutdownExistingProcesses();
 
 private:
-  Thread *m_thread = nullptr;
   bool m_running = true;
+  std::unique_ptr<Thread> m_mainThread;
+  std::unique_ptr<Thread> m_outputThread;
+  std::unique_ptr<Thread> m_sasThread;
   HANDLE m_outputWritePipe = nullptr;
   HANDLE m_outputReadPipe = nullptr;
-  Thread *m_outputThread = nullptr;
   bool m_elevateProcess = false;
   MSWindowsSession m_session;
   int m_startFailures = 0;

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -41,7 +41,7 @@ void OSXEventQueueBuffer::init()
 
 void OSXEventQueueBuffer::waitForEvent(double timeout)
 {
-  std::unique_lock<std::mutex> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   if (m_dataQueue.empty()) {
     auto duration = std::chrono::duration<double>(timeout);
     LOG_DEBUG2("waiting for event, timeout: %f seconds", timeout);
@@ -53,7 +53,7 @@ void OSXEventQueueBuffer::waitForEvent(double timeout)
 
 IEventQueueBuffer::Type OSXEventQueueBuffer::getEvent(Event &event, uint32_t &dataID)
 {
-  std::unique_lock<std::mutex> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   if (m_dataQueue.empty()) {
     LOG_DEBUG2("no events in queue");
     return kNone;
@@ -71,7 +71,7 @@ bool OSXEventQueueBuffer::addEvent(uint32_t dataID)
 {
   // Use GCD to dispatch event addition on the main queue
   dispatch_async(dispatch_get_main_queue(), ^{
-    std::lock_guard<std::mutex> lock(this->m_mutex);
+    std::lock_guard lock(this->m_mutex);
     LOG_DEBUG2("adding user event with dataID: %u", dataID);
     this->m_dataQueue.push(dataID);
     this->m_cond.notify_one();
@@ -84,7 +84,7 @@ bool OSXEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool OSXEventQueueBuffer::isEmpty() const
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard lock(m_mutex);
   bool empty = m_dataQueue.empty();
   LOG_DEBUG2("queue is %s", empty ? "empty" : "not empty");
   return empty;


### PR DESCRIPTION
Fixes: #8245

Blocks:
- #8300

Blocked by:
- #8340
- #8339

Moving the SAS event wait and SendSAS call prevents blocking the main thread allowing for more responsive watchdog (e.g. faster restart Core client/server on session switch).