### PR TITLE
chore: update formating for clang-format 20.1.0

### DIFF
--- a/.github/actions/lint-check/action.yml
+++ b/.github/actions/lint-check/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Dependencies
-      run: pipx install --global clang_format
+      run: pipx install --global clang-format==20.1.0
       shell: bash
 
     - name: Run format command

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -1125,11 +1125,12 @@ void MainWindow::setHostName()
     if (existingScreen) {
       body = tr("Screen name already exists");
     } else {
-      body = tr("The name you have chosen is invalid.\n\n"
-                "Valid names:\n"
-                "• Use letters and numbers\n"
-                "• May also use _ or -\n"
-                "• Are between 1 and 255 characters");
+      body =
+          tr("The name you have chosen is invalid.\n\n"
+             "Valid names:\n"
+             "• Use letters and numbers\n"
+             "• May also use _ or -\n"
+             "• Are between 1 and 255 characters");
     }
     QMessageBox::information(this, title, body);
     return;

--- a/src/apps/deskflow-gui/dialogs/FingerprintDialog.cpp
+++ b/src/apps/deskflow-gui/dialogs/FingerprintDialog.cpp
@@ -45,8 +45,9 @@ FingerprintDialog::FingerprintDialog(
     connect(m_buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, &QDialog::accept);
   } else {
     setWindowTitle(tr("Security Question"));
-    auto body = tr("Compare the fingerprints in this dialog to those on the %1.\n"
-                   "Only connect if they match!");
+    auto body =
+        tr("Compare the fingerprints in this dialog to those on the %1.\n"
+           "Only connect if they match!");
 
     if (mode == FingerprintDialogMode::Server) {
       m_lblHeader->setText(tr("A new client is connecting.\n%1").arg(body.arg(tr("client"))));

--- a/src/apps/deskflow-gui/main.cpp
+++ b/src/apps/deskflow-gui/main.cpp
@@ -120,8 +120,10 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_MAC)
 
   if (app.applicationDirPath().startsWith("/Volumes/")) {
-    QString msgBody = QStringLiteral("Please drag %1 to the Applications folder, "
-                                     "and open it from there.");
+    QString msgBody = QStringLiteral(
+        "Please drag %1 to the Applications folder, "
+        "and open it from there."
+    );
     QMessageBox::information(NULL, kAppName, msgBody.arg(kAppName));
     return 1;
   }
@@ -181,9 +183,11 @@ bool checkMacAssistiveDevices()
   // now deprecated in mavericks.
   bool result = AXAPIEnabled();
   if (!result) {
-    QString msgBody = QString("Please enable access to assistive devices "
-                              "System Preferences -> Security & Privacy -> "
-                              "Privacy -> Accessibility, then re-open %1.");
+    QString msgBody = QString(
+        "Please enable access to assistive devices "
+        "System Preferences -> Security & Privacy -> "
+        "Privacy -> Accessibility, then re-open %1."
+    );
     QMessageBox::information(NULL, kAppName, msgBody.arg(kAppName));
   }
   return result;

--- a/src/lib/arch/win32/XArchWindows.cpp
+++ b/src/lib/arch/win32/XArchWindows.cpp
@@ -41,92 +41,166 @@ std::string XArchEvalWinsock::eval() const throw()
   {
     int m_code;
     const char *m_msg;
-  } s_netErrorCodes[] = {
-      /* 10004 */ {WSAEINTR, "The (blocking) call was canceled via WSACancelBlockingCall"},
-      /* 10009 */ {WSAEBADF, "Bad file handle"},
-      /* 10013 */
-      {WSAEACCES, "The requested address is a broadcast address, but the "
-                  "appropriate flag was not set"},
-      /* 10014 */ {WSAEFAULT, "WSAEFAULT"},
-      /* 10022 */ {WSAEINVAL, "WSAEINVAL"},
-      /* 10024 */ {WSAEMFILE, "No more file descriptors available"},
-      /* 10035 */
-      {WSAEWOULDBLOCK, "Socket is marked as non-blocking and no connections "
-                       "are present or the receive operation would block"},
-      /* 10036 */
+  }
+
+  s_netErrorCodes[] = {
+
+      // 10004
+      {WSAEINTR, "The (blocking) call was canceled via WSACancelBlockingCall"},
+
+      // 10009
+      {WSAEBADF, "Bad file handle"},
+
+      // 10013
+      {WSAEACCES, "The requested address is a broadcast address, but the appropriate flag was not set"},
+
+      // 10014
+      {WSAEFAULT, "WSAEFAULT"},
+
+      // 10022
+      {WSAEINVAL, "WSAEINVAL"},
+
+      // 10024
+      {WSAEMFILE, "No more file descriptors available"},
+
+      // 10035
+      {WSAEWOULDBLOCK,
+       "Socket is marked as non-blocking and no connections are present or the receive operation would block"},
+
+      // 10036
       {WSAEINPROGRESS, "A blocking Windows Sockets operation is in progress"},
-      /* 10037 */
+
+      // 10037
       {WSAEALREADY, "The asynchronous routine being canceled has already completed"},
-      /* 10038 */ {WSAENOTSOCK, "At least on descriptor is not a socket"},
-      /* 10039 */ {WSAEDESTADDRREQ, "A destination address is required"},
-      /* 10040 */
-      {WSAEMSGSIZE, "The datagram was too large to fit into the specified "
-                    "buffer and was truncated"},
-      /* 10041 */
+
+      // 10038
+      {WSAENOTSOCK, "At least on descriptor is not a socket"},
+
+      // 10039
+      {WSAEDESTADDRREQ, "A destination address is required"},
+
+      // 10040
+      {WSAEMSGSIZE, "The datagram was too large to fit into the specified buffer and was truncated"},
+
+      // 10041
       {WSAEPROTOTYPE, "The specified protocol is the wrong type for this socket"},
-      /* 10042 */ {WSAENOPROTOOPT, "The option is unknown or unsupported"},
-      /* 10043 */
+
+      // 10042
+      {WSAENOPROTOOPT, "The option is unknown or unsupported"},
+
+      // 10043
       {WSAEPROTONOSUPPORT, "The specified protocol is not supported"},
-      /* 10044 */
+
+      // 10044
       {WSAESOCKTNOSUPPORT, "The specified socket type is not supported by this address family"},
-      /* 10045 */
+
+      // 10045
       {WSAEOPNOTSUPP, "The referenced socket is not a type that supports that operation"},
-      /* 10046 */ {WSAEPFNOSUPPORT, "BSD: Protocol family not supported"},
-      /* 10047 */
+
+      // 10046
+      {WSAEPFNOSUPPORT, "BSD: Protocol family not supported"},
+
+      // 10047
       {WSAEAFNOSUPPORT, "The specified address family is not supported"},
-      /* 10048 */ {WSAEADDRINUSE, "The specified address is already in use"},
-      /* 10049 */
+
+      // 10048
+      {WSAEADDRINUSE, "The specified address is already in use"},
+
+      // 10049
       {WSAEADDRNOTAVAIL, "The specified address is not available from the local machine"},
-      /* 10050 */
-      {WSAENETDOWN, "The Windows Sockets implementation has detected that the "
-                    "network subsystem has failed"},
-      /* 10051 */
+
+      // 10050
+      {WSAENETDOWN, "The Windows Sockets implementation has detected that the network subsystem has failed"},
+
+      // 10051
       {WSAENETUNREACH, "The network can't be reached from this host at this time"},
-      /* 10052 */
-      {WSAENETRESET, "The connection must be reset because the Windows Sockets "
-                     "implementation dropped it"},
-      /* 10053 */
+
+      // 10052
+      {WSAENETRESET, "The connection must be reset because the Windows Sockets implementation dropped it"},
+
+      // 10053
       {WSAECONNABORTED, "The virtual circuit was aborted due to timeout or other failure"},
-      /* 10054 */
+
+      // 10054
       {WSAECONNRESET, "The virtual circuit was reset by the remote side"},
-      /* 10055 */
-      {WSAENOBUFS, "No buffer space is available or a buffer deadlock has "
-                   "occured. The socket cannot be created"},
-      /* 10056 */ {WSAEISCONN, "The socket is already connected"},
-      /* 10057 */ {WSAENOTCONN, "The socket is not connected"},
-      /* 10058 */ {WSAESHUTDOWN, "The socket has been shutdown"},
-      /* 10059 */ {WSAETOOMANYREFS, "BSD: Too many references"},
-      /* 10060 */
+
+      // 10055
+      {WSAENOBUFS, "No buffer space is available or a buffer deadlock has occurred. The socket cannot be created"},
+
+      // 10056
+      {WSAEISCONN, "The socket is already connected"},
+
+      // 10057
+      {WSAENOTCONN, "The socket is not connected"},
+
+      // 10058
+      {WSAESHUTDOWN, "The socket has been shutdown"},
+
+      // 10059
+      {WSAETOOMANYREFS, "BSD: Too many references"},
+
+      // 10060
       {WSAETIMEDOUT, "Attempt to connect timed out without establishing a connection"},
-      /* 10061 */ {WSAECONNREFUSED, "Connection was refused"},
-      /* 10062 */ {WSAELOOP, "Undocumented WinSock error code used in BSD"},
-      /* 10063 */
+
+      // 10061
+      {WSAECONNREFUSED, "Connection was refused"},
+
+      // 10062
+      {WSAELOOP, "Undocumented WinSock error code used in BSD"},
+
+      // 10063
       {WSAENAMETOOLONG, "Undocumented WinSock error code used in BSD"},
-      /* 10064 */ {WSAEHOSTDOWN, "Undocumented WinSock error code used in BSD"},
-      /* 10065 */ {WSAEHOSTUNREACH, "No route to host"},
-      /* 10066 */ {WSAENOTEMPTY, "Undocumented WinSock error code"},
-      /* 10067 */ {WSAEPROCLIM, "Undocumented WinSock error code"},
-      /* 10068 */ {WSAEUSERS, "Undocumented WinSock error code"},
-      /* 10069 */ {WSAEDQUOT, "Undocumented WinSock error code"},
-      /* 10070 */ {WSAESTALE, "Undocumented WinSock error code"},
-      /* 10071 */ {WSAEREMOTE, "Undocumented WinSock error code"},
-      /* 10091 */
+
+      // 10064
+      {WSAEHOSTDOWN, "Undocumented WinSock error code used in BSD"},
+
+      // 10065
+      {WSAEHOSTUNREACH, "No route to host"},
+
+      // 10066
+      {WSAENOTEMPTY, "Undocumented WinSock error code"},
+
+      // 10067
+      {WSAEPROCLIM, "Undocumented WinSock error code"},
+
+      // 10068
+      {WSAEUSERS, "Undocumented WinSock error code"},
+
+      // 10069
+      {WSAEDQUOT, "Undocumented WinSock error code"},
+
+      // 10070
+      {WSAESTALE, "Undocumented WinSock error code"},
+
+      // 10071
+      {WSAEREMOTE, "Undocumented WinSock error code"},
+
+      // 10091
       {WSASYSNOTREADY, "Underlying network subsytem is not ready for network communication"},
-      /* 10092 */
-      {WSAVERNOTSUPPORTED, "The version of WinSock API support requested is "
-                           "not provided in this implementation"},
-      /* 10093 */
+
+      // 10092
+      {WSAVERNOTSUPPORTED, "The version of WinSock API support requested is not provided in this implementation"},
+
+      // 10093
       {WSANOTINITIALISED, "WinSock subsystem not properly initialized"},
-      /* 10101 */
+
+      // 10101
       {WSAEDISCON, "Virtual circuit has gracefully terminated connection"},
-      /* 11001 */ {WSAHOST_NOT_FOUND, "The specified host is unknown"},
-      /* 11002 */
+
+      // 11001
+      {WSAHOST_NOT_FOUND, "The specified host is unknown"},
+
+      // 11002
       {WSATRY_AGAIN, "A temporary error occurred on an authoritative name server"},
-      /* 11003 */
+
+      // 11003
       {WSANO_RECOVERY, "A non-recoverable name server error occurred"},
-      /* 11004 */
+
+      // 11004
       {WSANO_DATA, "The requested name is valid but does not have an IP address"},
-      /* end   */ {0, NULL}
+
+      // end
+      {0, NULL}
   };
 
   for (unsigned int i = 0; s_netErrorCodes[i].m_code != 0; ++i) {

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -222,8 +222,10 @@ void AppUtilWindows::showNotification(const std::string &title, const std::strin
     return;
   }
   if (!WinToastLib::WinToast::instance()->isInitialized()) {
-    WinToastLib::WinToast::instance()->setAppName(L""
-                                                  "Deskflow");
+    WinToastLib::WinToast::instance()->setAppName(
+        L""
+        "Deskflow"
+    );
     const auto aumi = WinToastLib::WinToast::configureAUMI(
         L""
         "Deskflow Developers",

--- a/src/lib/gui/config/ConfigScopes.h
+++ b/src/lib/gui/config/ConfigScopes.h
@@ -40,8 +40,9 @@ public:
   bool scopeContains(const QString &name, Scope scope = Scope::Current) const override;
   bool isActiveScopeWritable() const override;
   void setInScope(const QString &name, const QVariant &value, Scope scope = Scope::Current) override;
-  QVariant getFromScope(const QString &name, const QVariant &defaultValue = QVariant(), Scope scope = Scope::Current)
-      const override;
+  QVariant getFromScope(
+      const QString &name, const QVariant &defaultValue = QVariant(), Scope scope = Scope::Current
+  ) const override;
   void setActiveScope(Scope scope = Scope::User) override;
   Scope activeScope() const override;
   QSettingsProxy &activeSettings() override;

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -49,8 +49,10 @@ void showErrorDialog(const QString &message, const QString &fileLine, QtMsgType 
     text = "<p>Sorry, a critical error has occurred.</p>";
   }
 
-  text += QString(R"(<p>Please <a href="%1" style="color: %2">report a bug</a>)"
-                  " and copy/paste the following error:</p>")
+  text += QString(
+              R"(<p>Please <a href="%1" style="color: %2">report a bug</a>)"
+              " and copy/paste the following error:</p>"
+  )
               .arg(kUrlHelp, kColorSecondary);
 
   text += QString("<pre>v%1\n%2\n%3</pre>").arg(kVersion, message, fileLine);
@@ -117,18 +119,22 @@ void messageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
 
 void showCloseReminder(QWidget *parent)
 {
-  QString message = QString("<p>%1 will continue to run in the background and can be accessed "
-                            "via the %1 icon in your system notifications area. This "
-                            "setting "
-                            "can be disabled.</p>")
+  QString message = QString(
+                        "<p>%1 will continue to run in the background and can be accessed "
+                        "via the %1 icon in your system notifications area. This "
+                        "setting "
+                        "can be disabled.</p>"
+  )
                         .arg(kAppName);
 
 #if defined(Q_OS_LINUX)
-  message += QString("<p>On some Linux systems such as GNOME 3, the "
-                     "notification area might be disabled. "
-                     "You may need to "
-                     R"(<a href="%1" %2>enable an extension</a>)"
-                     " to see the %3 tray icon.</p>")
+  message += QString(
+                 "<p>On some Linux systems such as GNOME 3, the "
+                 "notification area might be disabled. "
+                 "You may need to "
+                 R"(<a href="%1" %2>enable an extension</a>)"
+                 " to see the %3 tray icon.</p>"
+  )
                  .arg(kUrlGnomeTrayFix, kStyleLink, kAppName);
 #endif
 
@@ -139,10 +145,12 @@ void showFirstServerStartMessage(QWidget *parent)
 {
   QMessageBox::information(
       parent, "Server is running",
-      QString("<p>Great, the %1 server is now running.</p>"
-              "<p>Now you can connect your client computers to this server. "
-              "You should see a prompt here on the server when a new client "
-              "tries to connect.</p>")
+      QString(
+          "<p>Great, the %1 server is now running.</p>"
+          "<p>Now you can connect your client computers to this server. "
+          "You should see a prompt here on the server when a new client "
+          "tries to connect.</p>"
+      )
           .arg(kAppName)
   );
 }
@@ -161,13 +169,17 @@ void showFirstConnectedMessage(QWidget *parent, bool closeToTray, bool enableSer
   }
 
   if (!closeToTray && !enableService) {
-    message += QString("<p>As you do not have the setting enabled to keep %1 running in "
-                       "the background, you'll need to keep this window open or minimized "
-                       "to keep %1 running.</p>")
+    message += QString(
+                   "<p>As you do not have the setting enabled to keep %1 running in "
+                   "the background, you'll need to keep this window open or minimized "
+                   "to keep %1 running.</p>"
+    )
                    .arg(kAppName);
   } else {
-    message += QString("<p>You can now close this window and %1 will continue to run in "
-                       "the background. This setting can be disabled.</p>")
+    message += QString(
+                   "<p>You can now close this window and %1 will continue to run in "
+                   "the background. This setting can be disabled.</p>"
+    )
                    .arg(kAppName);
   }
 
@@ -240,8 +252,10 @@ bool showClearSettings(QWidget *parent)
   QMessageBox message(parent);
   message.addButton(QObject::tr("Cancel"), QMessageBox::RejectRole);
   const auto clear = message.addButton(QObject::tr("Clear settings"), QMessageBox::AcceptRole);
-  message.setText(QString("<p>Are you sure you want to clear all settings and restart %1?</p>"
-                          "<p>This action cannot be undone.</p>")
+  message.setText(QString(
+                      "<p>Are you sure you want to clear all settings and restart %1?</p>"
+                      "<p>This action cannot be undone.</p>"
+  )
                       .arg(kAppName));
   message.exec();
 
@@ -253,8 +267,10 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath)
   QString nativePath = QDir::toNativeSeparators(systemSettingsPath);
   QMessageBox::information(
       parent, "Read-only settings",
-      QString("<p>Settings are read-only because you only have read access "
-              "to the file:</p><p>%1</p>")
+      QString(
+          "<p>Settings are read-only because you only have read access "
+          "to the file:</p><p>%1</p>"
+      )
           .arg(nativePath)
   );
 }
@@ -263,14 +279,16 @@ void showWaylandLibraryError(QWidget *parent)
 {
   QMessageBox::critical(
       parent, "Library problem",
-      QString("<p>Sorry, while this version of %1 does support Wayland, "
-              "this build was not linked with one or more of the required "
-              "libraries.</p>"
-              "<p>Please either switch to X from your login screen or use a build "
-              "that uses the correct libraries.</p>"
-              "<p>If you think this is incorrect, please "
-              R"(<a href="%2" style="color: %3">report a bug</a>.</p>)"
-              "<p>Please check the logs for more information.</p>")
+      QString(
+          "<p>Sorry, while this version of %1 does support Wayland, "
+          "this build was not linked with one or more of the required "
+          "libraries.</p>"
+          "<p>Please either switch to X from your login screen or use a build "
+          "that uses the correct libraries.</p>"
+          "<p>If you think this is incorrect, please "
+          R"(<a href="%2" style="color: %3">report a bug</a>.</p>)"
+          "<p>Please check the logs for more information.</p>"
+      )
           .arg(kAppName, kUrlHelp, kColorSecondary)
   );
 }
@@ -280,9 +298,11 @@ bool showUpdateCheckOption(QWidget *parent)
   QMessageBox message(parent);
   message.addButton(QObject::tr("No thanks"), QMessageBox::RejectRole);
   const auto checkButton = message.addButton(QObject::tr("Check for updates"), QMessageBox::AcceptRole);
-  message.setText(QString("<p>Would you like to check for updates when %1 starts?</p>"
-                          "<p>Checking for updates requires an Internet connection.</p>"
-                          "<p>URL: <pre>%2</pre></p>")
+  message.setText(QString(
+                      "<p>Would you like to check for updates when %1 starts?</p>"
+                      "<p>Checking for updates requires an Internet connection.</p>"
+                      "<p>URL: <pre>%2</pre></p>"
+  )
                       .arg(kAppName, env_vars::versionUrl()));
 
   message.exec();

--- a/src/lib/gui/styles.h
+++ b/src/lib/gui/styles.h
@@ -23,19 +23,25 @@ const auto kStyleLineEditErrorBorder =
     QStringLiteral("border: 1px solid %1; border-radius: 2px; padding: 2px;").arg(kColorError);
 
 const auto kStyleErrorActiveLabel = //
-    QStringLiteral("padding: 3px 5px; border-radius: 3px; "
-                   "background-color: %1; color: %2")
+    QStringLiteral(
+        "padding: 3px 5px; border-radius: 3px; "
+        "background-color: %1; color: %2"
+    )
         .arg(kColorError, kColorWhite);
 
 const auto kStyleErrorInactiveLabel = //
-    QStringLiteral("padding: 3px 5px; border-radius: 3px;"
-                   "background-color: none");
+    QStringLiteral(
+        "padding: 3px 5px; border-radius: 3px;"
+        "background-color: none"
+    );
 
 const auto kStyleFlatButton = QStringLiteral("QAbstractButton{background-color: none; border: none;}");
 
-const auto kStyleFlatButtonHoverable = QStringLiteral("%1\n"
-                                                      "QAbstractButton:hover{border: 1px solid palette(highlight);"
-                                                      " border-radius: 6px}")
+const auto kStyleFlatButtonHoverable = QStringLiteral(
+                                           "%1\n"
+                                           "QAbstractButton:hover{border: 1px solid palette(highlight);"
+                                           " border-radius: 6px}"
+)
                                            .arg(kStyleFlatButton);
 
 } // namespace deskflow::gui

--- a/src/lib/gui/tls/TlsUtility.cpp
+++ b/src/lib/gui/tls/TlsUtility.cpp
@@ -25,12 +25,16 @@ bool TlsUtility::isEnabled() const
 
 bool TlsUtility::generateCertificate()
 {
-  qDebug("generating tls certificate, "
-         "all clients must trust the new fingerprint");
+  qDebug(
+      "generating tls certificate, "
+      "all clients must trust the new fingerprint"
+  );
 
   if (!isEnabled()) {
-    qCritical("unable to generate tls certificate, "
-              "tls is either not available or not enabled");
+    qCritical(
+        "unable to generate tls certificate, "
+        "tls is either not available or not enabled"
+    );
     return false;
   }
 

--- a/src/lib/gui/validators/ScreenNameValidator.cpp
+++ b/src/lib/gui/validators/ScreenNameValidator.cpp
@@ -23,9 +23,11 @@ ScreenNameValidator::ScreenNameValidator(QLineEdit *lineEdit, ValidationError *e
   addValidator(std::make_unique<EmptyStringValidator>("Computer name cannot be empty"));
   addValidator(std::make_unique<SpacesValidator>("Computer name cannot contain spaces"));
   addValidator(std::make_unique<ComputerNameValidator>("Contains invalid characters or is too long"));
-  addValidator(std::make_unique<ScreenDuplicationsValidator>(
-      "A computer with this name already exists", lineEdit ? lineEdit->text() : "", pScreens
-  ));
+  addValidator(
+      std::make_unique<ScreenDuplicationsValidator>(
+          "A computer with this name already exists", lineEdit ? lineEdit->text() : "", pScreens
+      )
+  );
 }
 
 } // namespace validators

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
@@ -36,10 +36,12 @@ UINT MSWindowsClipboardHTMLConverter::getWin32Format() const
 std::string MSWindowsClipboardHTMLConverter::doFromIClipboard(const std::string &data) const
 {
   // prepare to CF_HTML format prefix and suffix
-  std::string prefix("Version:0.9\r\nStartHTML:0000000105\r\n"
-                     "EndHTML:ZZZZZZZZZZ\r\n"
-                     "StartFragment:XXXXXXXXXX\r\nEndFragment:YYYYYYYYYY\r\n"
-                     "<!DOCTYPE><HTML><BODY><!--StartFragment-->");
+  std::string prefix(
+      "Version:0.9\r\nStartHTML:0000000105\r\n"
+      "EndHTML:ZZZZZZZZZZ\r\n"
+      "StartFragment:XXXXXXXXXX\r\nEndFragment:YYYYYYYYYY\r\n"
+      "<!DOCTYPE><HTML><BODY><!--StartFragment-->"
+  );
   std::string suffix("<!--EndFragment--></BODY></HTML>\r\n");
 
   // Get byte offsets for header

--- a/src/test/unittests/deskflow/KeyStateTests.cpp
+++ b/src/test/unittests/deskflow/KeyStateTests.cpp
@@ -472,8 +472,10 @@ void assertMaskIsOne(ForeachKeyCallback cb, void *userData)
   ASSERT_EQ(1, ((KeyState::AddActiveModifierContext *)userData)->m_mask);
 }
 
-const deskflow::KeyMap::KeyItem *
-stubMapKey(deskflow::KeyMap::Keystrokes &keys, KeyID, int32_t, deskflow::KeyMap::ModifierToKeys &, KeyModifierMask &, KeyModifierMask, bool, const std::string &)
+const deskflow::KeyMap::KeyItem *stubMapKey(
+    deskflow::KeyMap::Keystrokes &keys, KeyID, int32_t, deskflow::KeyMap::ModifierToKeys &, KeyModifierMask &,
+    KeyModifierMask, bool, const std::string &
+)
 {
   keys.push_back(s_stubKeystroke);
   return &s_stubKeyItem;

--- a/src/test/unittests/gui/core/ClientConnectionTests.cpp
+++ b/src/test/unittests/gui/core/ClientConnectionTests.cpp
@@ -52,8 +52,10 @@ TEST_F(ClientConnectionTests, handleLogLine_alreadyConnected_showError)
 
   EXPECT_CALL(*m_pDeps, showError(_, AlreadyConnected, serverName));
 
-  clientConnection.handleLogLine("failed to connect to server\n"
-                                 "server already has a connected client with our name");
+  clientConnection.handleLogLine(
+      "failed to connect to server\n"
+      "server already has a connected client with our name"
+  );
 }
 
 TEST_F(ClientConnectionTests, handleLogLine_withHostname_showError)
@@ -95,8 +97,10 @@ TEST_F(ClientConnectionTests, handleLogLine_serverRefusedClient_shouldNotShowErr
 
   EXPECT_CALL(*m_pDeps, showError(_, _, _)).Times(0);
 
-  clientConnection.handleLogLine("failed to connect to server\n"
-                                 "server refused client with our name");
+  clientConnection.handleLogLine(
+      "failed to connect to server\n"
+      "server refused client with our name"
+  );
 }
 
 TEST_F(ClientConnectionTests, handleLogLine_connected_shouldPreventFutureError)


### PR DESCRIPTION
Looks like a new version of clang has come out and its some how changed our linting.. (-1 for linting yet again ...)

This pr: 
 - updated files based on clang 20.1.0 rules
 - Pins the lint-action to use clang-format 20.1.0 

Related: https://github.com/deskflow/scripts/pull/2

Set to automerge on accept
