### PR TITLE
fix: log Resize update the timer to 15ms

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -363,8 +363,8 @@ void MainWindow::toggleLogVisible(bool visible)
   }
   ui->textLog->setVisible(visible);
   Settings::setValue(Settings::Gui::LogExpanded, visible);
-  // 1 ms delay is to make sure we have left the function before calling updateSize
-  QTimer::singleShot(1, this, &MainWindow::updateSize);
+  // 15 ms delay is to make sure we have left the function before calling updateSize
+  QTimer::singleShot(15, this, &MainWindow::updateSize);
 }
 
 void MainWindow::firstShown()


### PR DESCRIPTION
 fix the jank resize for logs on windows / gnome / mac os (sometimes) .

fixes https://github.com/deskflow/deskflow/issues/8217
fixes https://github.com/deskflow/deskflow/issues/8081

Tested on windows and works perfect now.