### PR TITLE
fix: windows looking in deskflow/deskflow for items

### DIFF
--- a/src/lib/arch/win32/ArchFileWindows.cpp
+++ b/src/lib/arch/win32/ArchFileWindows.cpp
@@ -143,10 +143,6 @@ std::string ArchFileWindows::getProfileDirectory()
       dir = getUserDirectory();
     }
   }
-
-  // HACK: append program name, this seems wrong.
-  dir.append("\\Deskflow");
-
   return dir;
 }
 


### PR DESCRIPTION
fixes #8371
 
on windows the old arch method was appending `\\Deskflow` to our paths. (only on windows) 