### PR TITLE
fix: Use correct casing for `RemoteHost` value in Settings.h

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -36,7 +36,7 @@ public:
     inline static const auto Binary = QStringLiteral("client/binary");
     inline static const auto InvertScrollDirection = QStringLiteral("client/invertscolldirection");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
-    inline static const auto RemoteHost = QStringLiteral("client/remotehost");
+    inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
   };
   struct Core
   {

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -34,7 +34,7 @@ public:
   struct Client
   {
     inline static const auto Binary = QStringLiteral("client/binary");
-    inline static const auto InvertScrollDirection = QStringLiteral("client/invertscolldirection");
+    inline static const auto InvertScrollDirection = QStringLiteral("client/invertScrollDirection");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
   };

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -75,7 +75,7 @@ public:
   };
   struct Security
   {
-    inline static const auto CheckPeers = QStringLiteral("security/checkpeerfingerprints");
+    inline static const auto CheckPeers = QStringLiteral("security/checkPeerFingerprints");
     inline static const auto Certificate = QStringLiteral("security/certificate");
     inline static const auto KeySize = QStringLiteral("security/keySize");
     inline static const auto TlsEnabled = QStringLiteral("security/tlsEnabled");


### PR DESCRIPTION
Fixes typos in settings keys cases
 -  `checkpeerfingerprints` => `checkPeerFingerprints`
 - `invertscrolldirection` => `invertScrollDirection`
 - `remotehost` => `remoteHost`

Draft: Ah, spotted 2 more:
- ~`checkpeerfingerprints`~ (Added by sithlord48)
- ~`invertscolldirection`~ (Added by sithlord48)