### PR TITLE
fix a few items in the mainwindow

### DIFF
--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -501,14 +501,12 @@ void MainWindow::resetCore()
 void MainWindow::updateSize()
 {
   if (Settings::value(Settings::Gui::LogExpanded).toBool()) {
-    setMaximumHeight(16777215);
-    setMaximumWidth(16777215);
+    setMaximumSize(16777215, 16777215);
     resize(m_expandedSize);
   } else {
     adjustSize();
     // Prevent Resize with log collapsed
-    setMaximumHeight(height());
-    setMaximumWidth(width());
+    setMaximumSize(width(), height());
   }
 }
 

--- a/src/apps/deskflow-gui/MainWindow.cpp
+++ b/src/apps/deskflow-gui/MainWindow.cpp
@@ -640,16 +640,16 @@ void MainWindow::setStatus(const QString &status)
 
 void MainWindow::createMenuBar()
 {
-  auto menuFile = new QMenu(tr("File"));
+  auto menuFile = new QMenu(tr("File"), this);
   menuFile->addAction(m_actionStartCore);
   menuFile->addAction(m_actionStopCore);
   menuFile->addSeparator();
   menuFile->addAction(m_actionQuit);
 
-  auto menuEdit = new QMenu(tr("Edit"));
+  auto menuEdit = new QMenu(tr("Edit"), this);
   menuEdit->addAction(m_actionSettings);
 
-  auto menuHelp = new QMenu(tr("Help"));
+  auto menuHelp = new QMenu(tr("Help"), this);
   menuHelp->addAction(m_actionAbout);
   menuHelp->addAction(m_actionReportBug);
   menuHelp->addSeparator();

--- a/src/apps/deskflow-gui/MainWindow.ui
+++ b/src/apps/deskflow-gui/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>735</width>
-    <height>525</height>
+    <height>515</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -341,33 +341,6 @@
          </layout>
         </widget>
        </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QWidget" name="widgetModes" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
-       <property name="spacing">
-        <number>20</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION

- Give the menus in createMenu() parents, this prevents a tiny leak (according to valgrind)
- Use `setMaximumSize`  in place of calls to `setMaximumWidth` and `setMaximumHeight` in updateSize
- Remove from the UI an empty unused layout