### PR TITLE
ci: Sync local flatpak depends to those on flathub

### DIFF
--- a/deploy/linux/flatpak/org.deskflow.deskflow.yml
+++ b/deploy/linux/flatpak/org.deskflow.deskflow.yml
@@ -57,8 +57,8 @@ modules:
     sources:
         - type: git
           url: https://gitlab.freedesktop.org/libinput/libei
-          tag: 1.3.0
-          commit: 997b7c0f37faea4f8bae59613c8f27370925d5b0
+          tag: 1.4.0
+          commit: 5d6d8e6590df210b75559a889baa9459c68d9366
   - name: libportal
     buildsystem: meson
     config-opts:
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/flatpak/libportal.git
-        tag: 0.8.1
-        commit: 26c15008cbe579f57f89468384f8efc033f25f6f
+        tag: 0.9.1
+        commit: 8f5dc8d192f6e31dafe69e35219e3b707bde71ce
   - name: puixml
     buildsystem: cmake-ninja
     sources:


### PR DESCRIPTION
 - Sync our local flatpak to the same depends used in the flathub recipe
    -  `libei 1.3.0` => `libei 1.4.0`
    -  `libportal 0.8.1` => `libportal 0.9.1`