### PR TITLE
Remove unused items in ArchMiscWindows

### DIFF
--- a/src/lib/arch/Arch.cpp
+++ b/src/lib/arch/Arch.cpp
@@ -30,9 +30,6 @@ Arch::Arch(Arch *arch)
 
 Arch::~Arch()
 {
-#if SYSAPI_WIN32
-  ArchMiscWindows::cleanup();
-#endif
 }
 
 void Arch::init()

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -71,12 +71,6 @@ void ArchMiscWindows::init()
   s_dialogs = new Dialogs;
 }
 
-void ArchMiscWindows::getIcons(HICON &largeIcon, HICON &smallIcon)
-{
-  largeIcon = s_largeIcon;
-  smallIcon = s_smallIcon;
-}
-
 int ArchMiscWindows::runDaemon(RunFunc runFunc)
 {
   return ArchDaemonWindows::runDaemon(runFunc);

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -243,11 +243,6 @@ std::string ArchMiscWindows::readValueString(HKEY key, const TCHAR *name)
   return readBinaryOrString(key, name, REG_SZ);
 }
 
-std::string ArchMiscWindows::readValueBinary(HKEY key, const TCHAR *name)
-{
-  return readBinaryOrString(key, name, REG_BINARY);
-}
-
 DWORD
 ArchMiscWindows::readValueInt(HKEY key, const TCHAR *name)
 {

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -248,11 +248,6 @@ ArchMiscWindows::readValueInt(HKEY key, const TCHAR *name)
   return value;
 }
 
-bool ArchMiscWindows::processDialog(MSG *msg)
-{
-  return false;
-}
-
 void ArchMiscWindows::addBusyState(DWORD busyModes)
 {
   s_busyState |= busyModes;

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -191,13 +191,6 @@ void ArchMiscWindows::deleteKeyTree(HKEY key, const TCHAR *name)
   RegDeleteTree(key, name);
 }
 
-bool ArchMiscWindows::hasValue(HKEY key, const TCHAR *name)
-{
-  DWORD type;
-  LONG result = RegQueryValueEx(key, name, 0, &type, NULL, NULL);
-  return (result == ERROR_SUCCESS && (type == REG_DWORD || type == REG_SZ));
-}
-
 ArchMiscWindows::EValueType ArchMiscWindows::typeOfValue(HKEY key, const TCHAR *name)
 {
   DWORD type;

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -71,12 +71,6 @@ void ArchMiscWindows::init()
   s_dialogs = new Dialogs;
 }
 
-void ArchMiscWindows::setIcons(HICON largeIcon, HICON smallIcon)
-{
-  s_largeIcon = largeIcon;
-  s_smallIcon = smallIcon;
-}
-
 void ArchMiscWindows::getIcons(HICON &largeIcon, HICON &smallIcon)
 {
   largeIcon = s_largeIcon;

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -203,17 +203,6 @@ void ArchMiscWindows::setValue(HKEY key, const TCHAR *name, DWORD value)
   RegSetValueEx(key, name, 0, REG_DWORD, reinterpret_cast<CONST BYTE *>(&value), sizeof(DWORD));
 }
 
-void ArchMiscWindows::setValueBinary(HKEY key, const TCHAR *name, const std::string &value)
-{
-  assert(key != NULL);
-  assert(name != NULL);
-  if (key == NULL || name == NULL) {
-    // TODO: throw exception
-    return;
-  }
-  RegSetValueEx(key, name, 0, REG_BINARY, reinterpret_cast<const BYTE *>(value.data()), (DWORD)value.size());
-}
-
 std::string ArchMiscWindows::readBinaryOrString(HKEY key, const TCHAR *name, DWORD type)
 {
   // get the size of the string

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -51,24 +51,16 @@ const std::string s_binaryName = getBinaryName();
 // ArchMiscWindows
 //
 
-ArchMiscWindows::Dialogs *ArchMiscWindows::s_dialogs = NULL;
 DWORD ArchMiscWindows::s_busyState = 0;
 ArchMiscWindows::STES_t ArchMiscWindows::s_stes = NULL;
 HICON ArchMiscWindows::s_largeIcon = NULL;
 HICON ArchMiscWindows::s_smallIcon = NULL;
 HINSTANCE ArchMiscWindows::s_instanceWin32 = NULL;
 
-void ArchMiscWindows::cleanup()
-{
-  delete s_dialogs;
-}
-
 void ArchMiscWindows::init()
 {
   // stop windows system error dialogs from showing.
   SetErrorMode(SEM_FAILCRITICALERRORS);
-
-  s_dialogs = new Dialogs;
 }
 
 int ArchMiscWindows::runDaemon(RunFunc runFunc)
@@ -258,11 +250,6 @@ ArchMiscWindows::readValueInt(HKEY key, const TCHAR *name)
 
 bool ArchMiscWindows::processDialog(MSG *msg)
 {
-  for (Dialogs::const_iterator index = s_dialogs->begin(); index != s_dialogs->end(); ++index) {
-    if (IsDialogMessage(*index, msg)) {
-      return true;
-    }
-  }
   return false;
 }
 

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -161,15 +161,6 @@ void ArchMiscWindows::deleteKey(HKEY key, const TCHAR *name)
   RegDeleteKey(key, name);
 }
 
-void ArchMiscWindows::deleteValue(HKEY key, const TCHAR *name)
-{
-  assert(key != NULL);
-  assert(name != NULL);
-  if (key == NULL || name == NULL)
-    return;
-  RegDeleteValue(key, name);
-}
-
 void ArchMiscWindows::deleteKeyTree(HKEY key, const TCHAR *name)
 {
   assert(key != NULL);

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -256,11 +256,6 @@ ArchMiscWindows::readValueInt(HKEY key, const TCHAR *name)
   return value;
 }
 
-void ArchMiscWindows::removeDialog(HWND hwnd)
-{
-  s_dialogs->erase(hwnd);
-}
-
 bool ArchMiscWindows::processDialog(MSG *msg)
 {
   for (Dialogs::const_iterator index = s_dialogs->begin(); index != s_dialogs->end(); ++index) {

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -256,11 +256,6 @@ ArchMiscWindows::readValueInt(HKEY key, const TCHAR *name)
   return value;
 }
 
-void ArchMiscWindows::addDialog(HWND hwnd)
-{
-  s_dialogs->insert(hwnd);
-}
-
 void ArchMiscWindows::removeDialog(HWND hwnd)
 {
   s_dialogs->erase(hwnd);

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -161,15 +161,6 @@ void ArchMiscWindows::deleteKey(HKEY key, const TCHAR *name)
   RegDeleteKey(key, name);
 }
 
-void ArchMiscWindows::deleteKeyTree(HKEY key, const TCHAR *name)
-{
-  assert(key != NULL);
-  assert(name != NULL);
-  if (key == NULL || name == NULL)
-    return;
-  RegDeleteTree(key, name);
-}
-
 ArchMiscWindows::EValueType ArchMiscWindows::typeOfValue(HKEY key, const TCHAR *name)
 {
   DWORD type;

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -95,12 +95,6 @@ public:
   //! Set a DWORD value in the registry
   static void setValue(HKEY key, const TCHAR *name, DWORD value);
 
-  //! Set a BINARY value in the registry
-  /*!
-  Sets the \p name value of \p key to \p value.data().
-  */
-  static void setValueBinary(HKEY key, const TCHAR *name, const std::string &value);
-
   //! Read a string value from the registry
   static std::string readValueString(HKEY, const TCHAR *name);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -104,9 +104,6 @@ public:
   //! Delete a tree of keys from the registry
   static void deleteKeyTree(HKEY parent, const TCHAR *name);
 
-  //! Test if a value exists
-  static bool hasValue(HKEY key, const TCHAR *name);
-
   //! Get type of value
   static EValueType typeOfValue(HKEY key, const TCHAR *name);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -44,12 +44,6 @@ public:
   //! Delete memory
   static void cleanup();
 
-  //! Get the application icons
-  /*!
-  Get the application icons.
-  */
-  static void getIcons(HICON &largeIcon, HICON &smallIcon);
-
   //! Run the daemon
   /*!
   Delegates to ArchDaemonWindows.

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -101,9 +101,6 @@ public:
   //! Read a DWORD value from the registry
   static DWORD readValueInt(HKEY, const TCHAR *name);
 
-  //! Read a BINARY value from the registry
-  static std::string readValueBinary(HKEY, const TCHAR *name);
-
   //! Add a dialog
   static void addDialog(HWND);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -97,13 +97,6 @@ public:
   //! Read a DWORD value from the registry
   static DWORD readValueInt(HKEY, const TCHAR *name);
 
-  //! Process dialog message
-  /*!
-  Checks if the message is destined for a dialog.  If so the message
-  is passed to the dialog and returns true, otherwise returns false.
-  */
-  static bool processDialog(MSG *);
-
   //! Disable power saving
   static void addBusyState(DWORD busyModes);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -44,12 +44,6 @@ public:
   //! Delete memory
   static void cleanup();
 
-  //! Set the application icons
-  /*!
-  Set the application icons.
-  */
-  static void setIcons(HICON largeIcon, HICON smallIcon);
-
   //! Get the application icons
   /*!
   Get the application icons.

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -86,9 +86,6 @@ public:
   //! Delete a key (which should have no subkeys)
   static void deleteKey(HKEY parent, const TCHAR *name);
 
-  //! Delete a value
-  static void deleteValue(HKEY parent, const TCHAR *name);
-
   //! Delete a tree of keys from the registry
   static void deleteKeyTree(HKEY parent, const TCHAR *name);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -101,9 +101,6 @@ public:
   //! Read a DWORD value from the registry
   static DWORD readValueInt(HKEY, const TCHAR *name);
 
-  //! Add a dialog
-  static void addDialog(HWND);
-
   //! Remove a dialog
   static void removeDialog(HWND);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <set>
 #include <string>
 
 #define WIN32_LEAN_AND_MEAN
@@ -40,9 +39,6 @@ public:
 
   //! Initialize
   static void init();
-
-  //! Delete memory
-  static void cleanup();
 
   //! Run the daemon
   /*!
@@ -173,10 +169,8 @@ private:
   static HMODULE findLoadedModule(std::array<const char *, 2> moduleNames);
 
 private:
-  using Dialogs = std::set<HWND>;
   typedef DWORD(WINAPI *STES_t)(DWORD);
 
-  static Dialogs *s_dialogs;
   static DWORD s_busyState;
   static STES_t s_stes; // STES: Set thread execution state
   static HICON s_largeIcon;

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -86,9 +86,6 @@ public:
   //! Delete a key (which should have no subkeys)
   static void deleteKey(HKEY parent, const TCHAR *name);
 
-  //! Delete a tree of keys from the registry
-  static void deleteKeyTree(HKEY parent, const TCHAR *name);
-
   //! Get type of value
   static EValueType typeOfValue(HKEY key, const TCHAR *name);
 

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -101,9 +101,6 @@ public:
   //! Read a DWORD value from the registry
   static DWORD readValueInt(HKEY, const TCHAR *name);
 
-  //! Remove a dialog
-  static void removeDialog(HWND);
-
   //! Process dialog message
   /*!
   Checks if the message is destined for a dialog.  If so the message

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -931,9 +931,6 @@ void MSWindowsScreen::handleSystemEvent(const Event &event, void *)
   MSG *msg = static_cast<MSG *>(event.getData());
   assert(msg != NULL);
 
-  if (ArchMiscWindows::processDialog(msg)) {
-    return;
-  }
   if (onPreDispatch(msg->hwnd, msg->message, msg->wParam, msg->lParam)) {
     return;
   }


### PR DESCRIPTION
Remove a bunch of unused methods from `ArchMiscWindows`
 - remove unused `ArchMiscWindows::hasValue`
 - remove unused `ArchMiscWindows::setIcons`
 - remove unused `ArchMiscWindows::getIcons`
 - remove unused `ArchMiscWindows::deleteValue`
 - remove unused `ArchMiscWindows::deleteKeyTree`
 - remove unused `ArchMiscWindows::setValueBinary`
 - remove unused `ArchMiscWindows::readValueBinary`
 - remove unused `ArchMiscWindows::addDialog`
 - remove unused `ArchMiscWindows::removeDialog`
 - remove unused `ArchMiscWindows::s_dialog`
 - remove unused `ArchMiscWindows::cleanup`
 - remove unused `ArchMiscWindows::processDialog`