### PR TITLE
Clean unneeded includes in lib/base

### DIFF
--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -9,8 +9,6 @@
 
 #include "common/Common.h"
 
-#include <map>
-
 class EventData
 {
 public:

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -11,7 +11,6 @@
 #include "base/IEventJob.h"
 #include "base/Log.h"
 #include "base/SimpleEventQueueBuffer.h"
-#include "base/Stopwatch.h"
 #include "mt/Lock.h"
 #include "mt/Mutex.h"
 

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "arch/IArchMultithread.h"
-#include "base/Event.h"
 #include "base/EventTypes.h"
 #include "base/IEventQueue.h"
 #include "base/PriorityQueue.h"

--- a/src/lib/base/EventTypes.cpp
+++ b/src/lib/base/EventTypes.cpp
@@ -8,7 +8,6 @@
 #include "base/IEventQueue.h"
 
 #include <assert.h>
-#include <stddef.h>
 
 EventTypes::EventTypes() : m_events(NULL)
 {

--- a/src/lib/base/FinalAction.h
+++ b/src/lib/base/FinalAction.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <utility>
-
 namespace deskflow {
 
 /**

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -11,9 +11,6 @@
 #include "arch/IArchMultithread.h"
 #include "common/Common.h"
 
-#include <list>
-#include <stdarg.h>
-
 #define CLOG (Log::getInstance())
 #define BYE "\nTry `%s --help' for more information."
 

--- a/src/lib/base/LogOutputters.cpp
+++ b/src/lib/base/LogOutputters.cpp
@@ -10,7 +10,6 @@
 #include "arch/Arch.h"
 #include "base/Path.h"
 #include "base/String.h"
-#include "base/TMethodJob.h"
 
 #include <fstream>
 

--- a/src/lib/base/LogOutputters.h
+++ b/src/lib/base/LogOutputters.h
@@ -12,11 +12,6 @@
 #include "common/Common.h"
 #include "mt/Thread.h"
 
-#include <deque>
-#include <fstream>
-#include <list>
-#include <string>
-
 //! Stop traversing log chain outputter
 /*!
 This outputter performs no output and returns false from \c write(),

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <algorithm>
-#include <functional>
 #include <vector>
 
 //! A priority queue with an iterator

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -9,18 +9,9 @@
 #include "base/String.h"
 
 #include <algorithm>
-#include <cctype>
-#include <cerrno>
 #include <cstdarg>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <iomanip>
 #include <sstream>
-#include <stdio.h>
-#include <string>
-#include <vector>
 
 namespace deskflow {
 namespace string {

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include "common/Common.h"
-#include <string>
 
-#include <stdarg.h>
+#include <string>
 #include <vector>
 
 namespace deskflow {

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -8,8 +8,6 @@
 #include "base/Unicode.h"
 #include "arch/Arch.h"
 
-#include <cstring>
-
 //
 // local utility functions
 //

--- a/src/lib/base/XBase.cpp
+++ b/src/lib/base/XBase.cpp
@@ -8,9 +8,7 @@
 #include "base/XBase.h"
 #include "base/String.h"
 
-#include <cerrno>
 #include <cstdarg>
-#include <cstring>
 
 //
 // XBase

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -15,6 +15,7 @@
 #include "platform/MSWindowsHook.h"
 #include "platform/MSWindowsPowerManager.h"
 
+#include <map>
 #include <string>
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Remove unneeded includes in `lib/base`
 - remove unused includes in `lib/base/Event`
 - remove unused includes in `lib/base/EventQueue`
 - remove unused includes in `lib/base/EventTypes`
 - remove unused includes in `lib/base/FinalAction`
 - remove unused includes in `lib/base/Log`
 - remove unused includes in `lib/base/LogOutputters`
 - remove unused includes in `lib/base/PriorityQueue`
 - remove unused includes in `lib/base/Unicode`
 - remove unused includes in `lib/base/String`
 - remove unused includes in `lib/base/XBase`
