### PR TITLE
remove more unused defines

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -92,7 +92,6 @@ macro(configure_unix_libs)
   check_include_files(sys/select.h HAVE_SYS_SELECT_H)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
-  check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
   check_include_files(unistd.h HAVE_UNISTD_H)
   check_include_files(wchar.h HAVE_WCHAR_H)
 

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -89,7 +89,6 @@ macro(configure_unix_libs)
   include(CheckSymbolExists)
   include(CheckCSourceCompiles)
 
-  check_include_files(locale.h HAVE_LOCALE_H)
   check_include_files(sys/select.h HAVE_SYS_SELECT_H)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -89,8 +89,6 @@ macro(configure_unix_libs)
   include(CheckSymbolExists)
   include(CheckCSourceCompiles)
 
-  check_include_file_cxx(sstream HAVE_SSTREAM)
-
   check_include_files(locale.h HAVE_LOCALE_H)
   check_include_files(sys/select.h HAVE_SYS_SELECT_H)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -93,7 +93,6 @@ macro(configure_unix_libs)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
   check_include_files(unistd.h HAVE_UNISTD_H)
-  check_include_files(wchar.h HAVE_WCHAR_H)
 
   check_function_exists(getpwuid_r HAVE_GETPWUID_R)
   check_function_exists(gmtime_r HAVE_GMTIME_R)

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -89,7 +89,6 @@ macro(configure_unix_libs)
   include(CheckSymbolExists)
   include(CheckCSourceCompiles)
 
-  check_include_file_cxx(ostream HAVE_OSTREAM)
   check_include_file_cxx(sstream HAVE_SSTREAM)
 
   check_include_files(locale.h HAVE_LOCALE_H)

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -89,7 +89,6 @@ macro(configure_unix_libs)
   include(CheckSymbolExists)
   include(CheckCSourceCompiles)
 
-  check_include_file_cxx(istream HAVE_ISTREAM)
   check_include_file_cxx(ostream HAVE_OSTREAM)
   check_include_file_cxx(sstream HAVE_SSTREAM)
 

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -94,7 +94,6 @@ macro(configure_unix_libs)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
   check_include_files(unistd.h HAVE_UNISTD_H)
 
-  check_function_exists(getpwuid_r HAVE_GETPWUID_R)
   check_function_exists(gmtime_r HAVE_GMTIME_R)
   check_function_exists(nanosleep HAVE_NANOSLEEP)
   check_function_exists(sigwait HAVE_POSIX_SIGWAIT)

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -94,7 +94,6 @@ macro(configure_unix_libs)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
   check_include_files(unistd.h HAVE_UNISTD_H)
 
-  check_function_exists(gmtime_r HAVE_GMTIME_R)
   check_function_exists(nanosleep HAVE_NANOSLEEP)
   check_function_exists(sigwait HAVE_POSIX_SIGWAIT)
   check_function_exists(inet_aton HAVE_INET_ATON)

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -49,9 +49,6 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H @HAVE_UNISTD_H@
 
-/* Define to 1 if you have the <wchar.h> header file. */
-#cmakedefine HAVE_WCHAR_H @HAVE_WCHAR_H@
-
 /* Define to 1 if you have the <X11/extensions/Xrandr.h> header file. */
 #cmakedefine HAVE_X11_EXTENSIONS_XRANDR_H @HAVE_X11_EXTENSIONS_XRANDR_H@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -37,9 +37,6 @@
 /* Define if your compiler defines socklen_t. */
 #cmakedefine HAVE_SOCKLEN_T @HAVE_SOCKLEN_T@
 
-/* Define to 1 if you have the <sstream> header file. */
-#cmakedefine HAVE_SSTREAM @HAVE_SSTREAM@
-
 /* Define to 1 if you have the <sys/select.h> header file. */
 #cmakedefine HAVE_SYS_SELECT_H @HAVE_SYS_SELECT_H@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -19,9 +19,6 @@
 /* Define if you have the `inet_aton` function. */
 #cmakedefine HAVE_INET_ATON @HAVE_INET_ATON@
 
-/* Define to 1 if you have the <locale.h> header file. */
-#cmakedefine HAVE_LOCALE_H @HAVE_LOCALE_H@
-
 /* Define if you have the `nanosleep` function. */
 #cmakedefine HAVE_NANOSLEEP @HAVE_NANOSLEEP@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -46,9 +46,6 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TYPES_H @HAVE_SYS_TYPES_H@
 
-/* Define to 1 if you have the <sys/utsname.h> header file. */
-#cmakedefine HAVE_SYS_UTSNAME_H @HAVE_SYS_UTSNAME_H@
-
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H @HAVE_UNISTD_H@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -25,9 +25,6 @@
 /* Define if you have the `nanosleep` function. */
 #cmakedefine HAVE_NANOSLEEP @HAVE_NANOSLEEP@
 
-/* Define to 1 if you have the <ostream> header file. */
-#cmakedefine HAVE_OSTREAM @HAVE_OSTREAM@
-
 /* Define if you have a POSIX `sigwait` function. */
 #cmakedefine HAVE_POSIX_SIGWAIT @HAVE_POSIX_SIGWAIT@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -10,9 +10,6 @@
 /* Define if the <X11/extensions/dpms.h> header file declares function prototypes. */
 #cmakedefine HAVE_DPMS_PROTOTYPES @HAVE_DPMS_PROTOTYPES@
 
-/* Define to 1 if you have the `gmtime_r` function. */
-#cmakedefine HAVE_GMTIME_R @HAVE_GMTIME_R@
-
 /* Define if you have the `inet_aton` function. */
 #cmakedefine HAVE_INET_ATON @HAVE_INET_ATON@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -19,9 +19,6 @@
 /* Define if you have the `inet_aton` function. */
 #cmakedefine HAVE_INET_ATON @HAVE_INET_ATON@
 
-/* Define to 1 if you have the <istream> header file. */
-#cmakedefine HAVE_ISTREAM @HAVE_ISTREAM@
-
 /* Define to 1 if you have the <locale.h> header file. */
 #cmakedefine HAVE_LOCALE_H @HAVE_LOCALE_H@
 

--- a/src/lib/Config.h.in
+++ b/src/lib/Config.h.in
@@ -10,9 +10,6 @@
 /* Define if the <X11/extensions/dpms.h> header file declares function prototypes. */
 #cmakedefine HAVE_DPMS_PROTOTYPES @HAVE_DPMS_PROTOTYPES@
 
-/* Define if you have a working `getpwuid_r` function. */
-#cmakedefine HAVE_GETPWUID_R @HAVE_GETPWUID_R@
-
 /* Define to 1 if you have the `gmtime_r` function. */
 #cmakedefine HAVE_GMTIME_R @HAVE_GMTIME_R@
 


### PR DESCRIPTION
 Remove unused defines from `Config.in.h` / `Libaraies.cmake`

 - remove unused define `HAVE_ISTREAM`
 - remove unused define `HAVE_OSTREAM`
 - remove unused define `HAVE_SSTREAM`
 - remove unused define `HAVE_LOCALE_H`
 - remove unused define `HAVE_SYS_UTSNAME_H`
 - remove unused define `HAVE_WCHAR_H`
 - remove unused define `HAVE_GETPWUID_R`
 - remove unused define `HAVE_GMTTIME_R`