### PR TITLE
Fix: settings releated issues, prepare it for testing

### DIFF
--- a/deploy/windows/wix-patch.xml.in
+++ b/deploy/windows/wix-patch.xml.in
@@ -39,6 +39,13 @@
 
     <Binary Id="CustomDLL" SourceFile="@CMAKE_CURRENT_BINARY_DIR@/wix-custom.dll" />
 
+    <UI>
+       <Publish Dialog="ExitDialog"
+           Control="Finish"
+           Event="DoAction"
+           Value="RunDeskflow"
+           Condition= "NOT Installed" />
+    </UI>
     <CustomAction
       Id="CheckVCRedist"
       BinaryRef="CustomDLL"
@@ -51,8 +58,10 @@
 
     <CustomAction
       Id="RunDeskflow"
-      ExeCommand="Deskflow"
-      FileRef="CM_FP_deskflow.exe"
+      ExeCommand="[INSTALL_ROOT]deskflow.exe"
+      Directory="INSTALL_ROOT"
+      Execute="immediate"
+      Impersonate="yes"
       Return="asyncNoWait" />
 
     <InstallExecuteSequence>
@@ -64,10 +73,6 @@
         Action="ShowVCRedistError"
         Before="InstallInitialize"
         Condition="NOT Installed AND (NOT VC_REDIST_INSTALLED OR NOT VC_REDIST_VERSION_OK)" />
-      <Custom
-        Action="RunDeskflow"
-        OnExit="success"
-        Condition="NOT Installed" />
     </InstallExecuteSequence>
   </CPackWiXFragment>
 </CPackWiXPatch>

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2,6 +2,7 @@
 
  The search order for a setting file is:
  1. `<install-path>/settings/Deskflow.conf`
+ 1. `<XDG_CONFIG_HOME>/Deskflow/Deskflow.conf`
  1. A user settings file
  1. A system settings file
  

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,13 +1,12 @@
-# Gui Config
+# GUI Config
 
-The search path for settings ar as follows:
+ The search order for a setting file is:
+ 1. `<install-path>/settings/Deskflow.conf`
+ 1. A user settings file
+ 1. A system settings file
  
- - Check Install_path/settings/Deskflow.conf
- - Check if User Settings Path
- - Check if System Settings File
- - Make a User Setting file
- 
- The path of the settings file will be used as the base for all other config files
+ A new settings file will be created in the user path if no settings file is found.
+ The path of the settings file will be used as the base for all other config files.
  
 ### Windows
  - System: `C:\ProgramData\Deskflow\Deskflow.conf`

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,3 +1,26 @@
+# Gui Config
+
+The search path for settings ar as follows:
+ 
+ - Check Install_path/settings/Deskflow.conf
+ - Check if User Settings Path
+ - Check if System Settings File
+ - Make a User Setting file
+ 
+ The path of the settings file will be used as the base for all other config files
+ 
+### Windows
+ - System: `C:\ProgramData\Deskflow\Deskflow.conf`
+ - User: `C:\Users\userName\AppData\Local\Deskflow\Deskflow.conf`
+ 
+### Linux
+ - System: `/etc/Deskflow/Deskflow.conf`
+ - User: `~/.config/Deskflow/Deskflow.conf`
+ 
+### macOS
+ - System: `/Library/Deskflow/Deskflow.conf`
+ - User: `~/Library/Deskflow/Deskflow.conf`
+
 # Server Config Examples
 
 The `deskflow-server` command accepts the `-c` or `--config` option, which takes one argument,

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -40,7 +40,9 @@ Settings::Settings(QObject *parent) : QObject(parent)
   if (QFile(m_portableSettingsFile).exists()) {
     fileToLoad = m_portableSettingsFile;
   } else {
-    if (QFile(UserSettingFile).exists())
+    if (!qEnvironmentVariable("XDG_CONFIG_HOME").isEmpty())
+      fileToLoad = QStringLiteral("%1/%2/%2.conf").arg(qEnvironmentVariable("XDG_CONFIG_HOME"), kAppName);
+    else if (QFile(UserSettingFile).exists())
       fileToLoad = UserSettingFile;
     else if (QFile(SystemSettingFile).exists())
       fileToLoad = SystemSettingFile;

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -40,16 +40,12 @@ Settings::Settings(QObject *parent) : QObject(parent)
   if (QFile(m_portableSettingsFile).exists()) {
     fileToLoad = m_portableSettingsFile;
   } else {
-#ifdef Q_OS_WIN
-    fileToLoad = SystemSettingFile;
-#else
     if (QFile(UserSettingFile).exists())
       fileToLoad = UserSettingFile;
     else if (QFile(SystemSettingFile).exists())
       fileToLoad = SystemSettingFile;
     else
       fileToLoad = UserSettingFile;
-#endif
   }
 
   m_settings = new QSettings(fileToLoad, QSettings::IniFormat);
@@ -122,7 +118,11 @@ QVariant Settings::defaultValue(const QString &key)
     return defaultProcessMode;
 
   if (key == Daemon::LogFile) {
+#ifdef Q_OS_WIN
+    return QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kDaemonLogFilename);
+#else
     return QStringLiteral("%1/%2").arg(instance()->settingsPath(), kDaemonLogFilename);
+#endif
   }
 
   if (key == Daemon::Elevate)

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -8,6 +8,7 @@
 
 #include "UrlConstants.h"
 
+#include <QCoreApplication>
 #include <QFile>
 #include <QRect>
 
@@ -34,6 +35,7 @@ void Settings::setSettingFile(const QString &settingsFile)
 
 Settings::Settings(QObject *parent) : QObject(parent)
 {
+  m_portableSettingsFile = m_portableSettingsFile.arg(QCoreApplication::applicationDirPath(), kAppName);
   QString fileToLoad;
   if (QFile(m_portableSettingsFile).exists()) {
     fileToLoad = m_portableSettingsFile;

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -56,11 +56,6 @@ Settings::Settings(QObject *parent) : QObject(parent)
   qInfo().noquote() << "settings file:" << m_settings->fileName();
 }
 
-bool Settings::isPortableSettings()
-{
-  return (QFile(instance()->m_portableSettingsFile).exists());
-}
-
 void Settings::cleanSettings()
 {
   const QStringList keys = m_settings->allKeys();

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -146,6 +146,11 @@ void Settings::save(bool emitSaving)
   instance()->m_settings->sync();
 }
 
+const QStringList Settings::validKeys()
+{
+  return instance()->m_validKeys;
+}
+
 bool Settings::isWritable()
 {
   return instance()->m_settings->isWritable();

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -161,7 +161,6 @@ private:
   Settings *operator=(Settings &other) = delete;
   Settings(const Settings &other) = delete;
   ~Settings() = default;
-  static bool isPortableSettings();
   void cleanSettings();
 
   QSettings *m_settings = nullptr;

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -151,7 +151,6 @@ public:
   static void save(bool emitSaving = true);
 
 signals:
-  void scopeChanged(bool isSystemScope);
   void writableChanged(bool canWrite);
   void settingsChanged(const QString key);
   void serverSettingsChanged();

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -151,7 +151,6 @@ public:
   static void save(bool emitSaving = true);
 
 signals:
-  void writableChanged(bool canWrite);
   void settingsChanged(const QString key);
   void serverSettingsChanged();
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -149,6 +149,7 @@ public:
   static const QString logLevelText();
   static QSettingsProxy &proxy();
   static void save(bool emitSaving = true);
+  static const QStringList validKeys();
 
 signals:
   void settingsChanged(const QString key);

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -163,7 +163,7 @@ private:
   void cleanSettings();
 
   QSettings *m_settings = nullptr;
-  QString m_portableSettingsFile = QStringLiteral("settings/%1.conf").arg(kAppName);
+  QString m_portableSettingsFile = QStringLiteral("%1/settings/%2.conf");
   std::shared_ptr<QSettingsProxy> m_settingsProxy;
 
   // clang-format off

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -169,7 +169,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
   ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
   ui->comboElevate->setCurrentIndex(Settings::value(Settings::Core::ElevateMode).toInt());
-  ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::Autohide).toBool());
+  ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
   ui->cbServiceEnabled->setChecked(processMode == Settings::ProcessMode::Service);

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -57,7 +57,6 @@ SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfi
 void SettingsDialog::initConnections()
 {
   connect(this, &SettingsDialog::shown, this, &SettingsDialog::showReadOnlyMessage, Qt::QueuedConnection);
-  connect(Settings::instance(), &Settings::writableChanged, this, &SettingsDialog::showReadOnlyMessage);
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);


### PR DESCRIPTION
Cleanup Settings:
  - Remove unused private `Settings::isPortableSettings`
  - Remove unused signal `Settings::scopeChanged`
  - Remove unused signal `Settings::writableChanged`
  - Add `Settings::validKeys` method to get the list of valid keys
  - Use the same logic for the settings file on all platforms
  - Change the default for the daemon log file on windows to the path of the daemon
  - Update the configuration.md file include a section on the gui config
  - Use `XDG_CONFIG_DIR` if set.
  - Fix: mixmatch set / read for `UpdateCheck`

Fix Settings Issues:
  - fixes: #8418 
  - fixes: #8409 
  - fixes: #8421 

Wix Installer Changes:
  - Run deskflow when the finish button is clicked
  - Run deskflow as a normal user post install


Tested on a Win11 CleanVm to make sure setting worked and daemon was picked up after mode selection
Tested flatpak via action build