### PR TITLE
chore: use Type for templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: If you find a bug in Deskflow, please let us know so we can fix it.
-labels: ["bug", "triage", "unanswered"]
+type: "Triage [bug]"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Had an idea how to improve Deskflow? Share it with us.
-labels: ["enhancement", "triage", "unanswered"]
+type: "Triage [feature]"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
  - Modify the bug and feature templates to not add labels but instead add the Type
    - `Triage [feature]` <= for newly proposed features 
    - `Triage [bug]` <= for newly reported bugs

This will allow us to remove the bugs, triage and unanswered, feature request and enhancement and simplify these into a few groups based on their type and status. Also make labels more useful as they will be less clutter 

Workflow for bugs, A new bug is reported, We test etc 
 - Confirmed, have their type changed to `Bug` and at this time we apply any labels we may want.
 - Rejected, are closed.


Workflow for features, A new feature is proposed
 - Accepted Features, have their type changed to `Feature` and at this time we apply any labels we may want.
 - Rejected Features, are closed.
  

I have changed the last few issues at this time to give you an idea of how it would look