### PR TITLE
refactor: settings for windows 

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,7 +29,7 @@
 
 Windows will save to the install dir if settings are loaded from there. If not, it saves any other config files in: `C:\ProgramData\Deskflow\`
 
-When using settings from the install dir its not recommend to have elevation enabled.
+When using settings from the install dir, the service mode will not be available.
 
 # Server Config Examples
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,18 +1,17 @@
 # GUI Config
 
+ Deskflow will automaticlly figure out where to save settings and other files.
+
+
+## Unix Systems
  The search order for a setting file is:
- 1. `<install-path>/settings/Deskflow.conf`
  1. `<XDG_CONFIG_HOME>/Deskflow/Deskflow.conf`
  1. A user settings file
  1. A system settings file
  
  A new settings file will be created in the user path if no settings file is found.
  The path of the settings file will be used as the base for all other config files.
- 
-### Windows
- - System: `C:\ProgramData\Deskflow\Deskflow.conf`
- - User: `C:\Users\userName\AppData\Local\Deskflow\Deskflow.conf`
- 
+
 ### Linux
  - System: `/etc/Deskflow/Deskflow.conf`
  - User: `~/.config/Deskflow/Deskflow.conf`
@@ -20,6 +19,17 @@
 ### macOS
  - System: `/Library/Deskflow/Deskflow.conf`
  - User: `~/Library/Deskflow/Deskflow.conf`
+ 
+
+## Windows
+
+ The search order for a setting file is:
+ 1. `<install-path>/settings/Deskflow.conf`
+ 1. Windows Registry `HKCU\Software\Deskflow\Deskflow`
+
+Windows will save to the install dir if settings are loaded from there. If not, it saves any other config files in: `C:\ProgramData\Deskflow\`
+
+When using settings from the install dir its not recommend to have elevation enabled.
 
 # Server Config Examples
 

--- a/src/lib/common/QSettingsProxy.cpp
+++ b/src/lib/common/QSettingsProxy.cpp
@@ -25,7 +25,13 @@ QString getSystemSettingsBaseDir()
 
 void QSettingsProxy::load(const QString &fileName)
 {
-  m_pSettings = std::make_unique<QSettings>(fileName, QSettings::IniFormat);
+  if (m_pSettings)
+    m_pSettings.get()->deleteLater();
+
+  if (fileName.isEmpty())
+    m_pSettings = std::make_unique<QSettings>(QSettings::NativeFormat, QSettings::UserScope, kAppName, kAppName);
+  else
+    m_pSettings = std::make_unique<QSettings>(fileName, QSettings::IniFormat);
 }
 
 int QSettingsProxy::beginReadArray(const QString &prefix)

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -109,8 +109,9 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Server::Binary)
     return kServerBinName;
 
-  if (key == Core::ElevateMode)
+  if (key == Core::ElevateMode) {
     return Settings::ElevateMode::Always;
+  }
 
   if (key == Core::UpdateUrl)
     return kUrlUpdateCheck;
@@ -121,8 +122,12 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Core::Port)
     return 24800;
 
-  if (key == Core::ProcessMode)
-    return defaultProcessMode;
+  if (key == Core::ProcessMode) {
+    if (instance()->isNativeMode())
+      return Settings::ProcessMode::Service;
+    else
+      return Settings::ProcessMode::Desktop;
+  }
 
   if (key == Daemon::LogFile) {
 #ifdef Q_OS_WIN

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -110,7 +110,10 @@ QVariant Settings::defaultValue(const QString &key)
     return kServerBinName;
 
   if (key == Core::ElevateMode) {
-    return Settings::ElevateMode::Always;
+    if (instance()->isNativeMode())
+      return Settings::ElevateMode::Always;
+    else
+      return Settings::ElevateMode::Never;
   }
 
   if (key == Core::UpdateUrl)

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -213,10 +213,4 @@ private:
     , Settings::Server::ExternalConfigFile
   };
   // clang-format on
-
-#ifdef Q_OS_WIN
-  inline static const auto defaultProcessMode = Settings::ProcessMode::Service;
-#else
-  inline static const auto defaultProcessMode = Settings::ProcessMode::Desktop;
-#endif
 };

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -140,6 +140,7 @@ public:
   static void restoreDefaultSettings();
   static QVariant defaultValue(const QString &key);
   static bool isWritable();
+  static bool isNativeMode();
   static const QString settingsFile();
   static const QString settingsPath();
   static const QString tlsDir();

--- a/src/lib/gui/Diagnostic.cpp
+++ b/src/lib/gui/Diagnostic.cpp
@@ -42,6 +42,18 @@ void clearSettings(bool enableRestart)
   qDebug("removing profile dir: %s", qPrintable(profileDir.absolutePath()));
   profileDir.removeRecursively();
 
+#ifdef Q_OS_WIN
+  if (Settings::isNativeMode()) {
+    // make a new empty portable settings file
+    if (profileDir.mkpath(Settings::settingsPath())) {
+      QFile file(Settings::settingsFile());
+      file.open(QIODevice::WriteOnly);
+      file.write(" ", 1);
+      file.close();
+    }
+  }
+#endif
+
   if (enableRestart) {
     qDebug("restarting");
     restart();

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -248,15 +248,6 @@ void SettingsDialog::updateKeyLengthOnFile(const QString &path)
 
 void SettingsDialog::updateControls()
 {
-
-#if defined(Q_OS_WIN)
-  const auto serviceAvailable = true;
-#else
-  // service not supported on unix yet, so always disable.
-  const auto serviceAvailable = false;
-  ui->groupService->setTitle("Service (Windows only)");
-#endif
-
   const bool writable = Settings::isWritable();
   const bool serviceChecked = ui->cbServiceEnabled->isChecked();
   const bool logToFile = ui->cbLogToFile->isChecked();
@@ -272,8 +263,16 @@ void SettingsDialog::updateControls()
   ui->comboTlsKeyLength->setEnabled(writable);
   ui->cbCloseToTray->setEnabled(writable);
 
-  ui->cbServiceEnabled->setEnabled(writable && serviceAvailable);
-  ui->widgetElevate->setEnabled(writable && serviceChecked && serviceAvailable);
+  // Handle enable and disable of service items
+  if (Settings::isNativeMode()) {
+    ui->cbServiceEnabled->setEnabled(writable);
+    ui->widgetElevate->setEnabled(writable && serviceChecked);
+  } else if (ui->groupService->isVisibleTo(ui->tabAdvanced)) {
+    ui->groupService->setVisible(false);
+    const int bottomMargin = ui->tabAdvanced->layout()->contentsMargins().bottom() +
+                             (ui->tabAdvanced->layout()->spacing() * 2) + ui->groupService->height();
+    ui->tabAdvanced->layout()->setContentsMargins(9, 9, 9, bottomMargin);
+  }
 
   ui->cbLanguageSync->setEnabled(writable && isClientMode());
   ui->cbScrollDirection->setEnabled(writable && isClientMode());

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -22,6 +22,9 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
      <widget class="QWidget" name="tabRegular">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">


### PR DESCRIPTION
fixes: #8429 
fixes: #8432 
fixes: #8434
 - On windows use the registry to save the items normally in `Deskflow.conf`
 - On windows use the registry unless the portableSettings file `[install-dir]/settings/Deskflow.conf` if found
   - On Windows Use either `ProgramData\Deskflow`  to save tls and other non "settings" when registry is in use
   - On Windows Use either `[installdir]/settings`  to save tls and other non "settings" when registry is not in use
 - Set the default process Type based on the kind of settings loaded
     -  `InI Format` (unix / mac / windows portable) the mode defaults to `Desktop`
     -  `Native Format` settings (only windows installed mode) we default to `Service`
 - Set the default elevation mode based on type also 
     -  `InI Format` (unix / mac / windows portable) the mode defaults to `Never`
     -  `Native Format` settings (only windows installed mode) we default to `Always` 
 - Hide the service section when its not able to be used 
 - Daemon log is always saved in the install dir
 - Make sure if using portable settings the a new empty file is created if settings are cleared.

Windows artifact to test with is [here](https://github.com/deskflow/deskflow/actions/runs/14184097971/artifacts/2855504724) generated via [latest build of this pr](https://github.com/deskflow/deskflow/actions/runs/14184097971/)