### PR TITLE
Portable windows build

### DIFF
--- a/deploy/windows/cpack-options.cmake.in
+++ b/deploy/windows/cpack-options.cmake.in
@@ -1,0 +1,6 @@
+#SPDX-FileCopyrightText: 2025 Chris Rizzitello <sithlord48@gmail.com>
+#SPDX-License-Identifier: MIT
+
+if(CPACK_GENERATOR MATCHES 7Z|ZIP)
+  set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME}-portable)
+endif()

--- a/deploy/windows/deploy.cmake
+++ b/deploy/windows/deploy.cmake
@@ -5,9 +5,19 @@
 # calling CMAKE_CURRENT_LIST_DIR after include would return the wrong scope var
 set(MY_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION .)
+include(InstallRequiredSystemLibraries)
+
 install(CODE "execute_process(
   COMMAND ${DEPLOYQT} --no-compiler-runtime --no-system-d3d-compiler --no-quick-import -network \"\${CMAKE_INSTALL_PREFIX}/deskflow.exe\"
 )")
+
+configure_file(${MY_DIR}/pre-cpack.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/pre-cpack.cmake @ONLY)
+set(CPACK_PRE_BUILD_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/pre-cpack.cmake)
+
+configure_file(${MY_DIR}/cpack-options.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/cpack-options.cmake @ONLY)
+set(CPACK_PROJECT_CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/cpack-options.cmake)
 
 # Setup OS_STRING
 if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
@@ -17,6 +27,8 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES ARM64)
 else()
   set(OS_STRING "win-${CMAKE_SYSTEM_PROCESSOR}")
 endif()
+
+list(APPEND CPACK_GENERATOR "7Z")
 
 # If Wix4+ is installed make a package
 find_program(WIX_APP wix)

--- a/deploy/windows/pre-cpack.cmake.in
+++ b/deploy/windows/pre-cpack.cmake.in
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 Chris Rizzitello <sithlord48@gmail.com>
+# SPDX-License-Identifier: MIT
+
+if(CPACK_GENERATOR MATCHES 7Z|ZIP)
+  string(REPLACE " " "*" _TEMP_LIST "@CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS@")
+  set(${PORTABLE_LIBS} "")
+  foreach(ITEM ${_TEMP_LIST})
+    string(REPLACE "*" " " _ITEM ${ITEM})
+    file(COPY ${_ITEM} DESTINATION ${CPACK_TEMPORARY_INSTALL_DIRECTORY})
+  endforeach()
+  file(WRITE ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/settings/Deskflow.conf " ")
+  file(REMOVE ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/deskflow-daemon.exe)
+  file(WRITE ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/README.txt
+" Portable Deskflow: @CMAKE_PROJECT_VERSION@
+
+  The portable version must have the settings/Deskflow.conf file to save settings, or it will try to use the system settings location.
+  The portable version does not include the daemon, so the client will not work at UAC prompts or the login screen.
+")
+endif()


### PR DESCRIPTION
 - fixes: #6378 
 - new artifact name is `deskflow-version-w64-portable.7z`
 - portable version does not ship the `daemon`
 - portable should be portable on most windows 10 / 11 