### PR TITLE
fixes #8423, set unit test to force external config on for server tests

### DIFF
--- a/src/test/unittests/main.cpp
+++ b/src/test/unittests/main.cpp
@@ -27,6 +27,7 @@ int main(int argc, char **argv)
   std::filesystem::create_directories(testDir);
 
   Settings::setSettingFile("tmp/test/settings.ini");
+  Settings::setValue(Settings::Server::ExternalConfig, true);
 
   ExitTimeout exitTimeout(1, "Unit tests");
 


### PR DESCRIPTION
 - fixes: #8423  by setting the external config on for the server connection test to use later