### PR TITLE
Settings service update

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -110,12 +110,8 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Server::Binary)
     return kServerBinName;
 
-  if (key == Core::ElevateMode) {
-    if (instance()->isNativeMode())
-      return Settings::ElevateMode::Always;
-    else
-      return Settings::ElevateMode::Never;
-  }
+  if (key == Daemon::Elevate)
+    return instance()->isNativeMode();
 
   if (key == Core::UpdateUrl)
     return kUrlUpdateCheck;
@@ -140,9 +136,6 @@ QVariant Settings::defaultValue(const QString &key)
     return QStringLiteral("%1/%2").arg(instance()->settingsPath(), kDaemonLogFilename);
 #endif
   }
-
-  if (key == Daemon::Elevate)
-    return true;
 
   return QVariant();
 }

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -75,7 +75,8 @@ void Settings::cleanSettings()
 QVariant Settings::defaultValue(const QString &key)
 {
   if ((key == Gui::Autohide) || (key == Core::StartedBefore) || (key == Core::PreventSleep) ||
-      (key == Server::ExternalConfig) || (key == Client::InvertScrollDirection) || (key == Log::ToFile)) {
+      (key == Server::ExternalConfig) || (key == Client::InvertScrollDirection) || (key == Log::ToFile) ||
+      (key == Core::StopOnDeskSwitch)) {
     return false;
   }
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -41,7 +41,6 @@ public:
   struct Core
   {
     inline static const auto CoreMode = QStringLiteral("core/coreMode");
-    inline static const auto ElevateMode = QStringLiteral("core/elevateMode");
     inline static const auto Interface = QStringLiteral("core/interface");
     inline static const auto LastVersion = QStringLiteral("core/lastVersion");
     inline static const auto Port = QStringLiteral("core/port");
@@ -104,28 +103,6 @@ public:
   };
   Q_ENUM(ProcessMode)
 
-  /**
-   * @brief The elevate mode tristate determines two behaviors on Windows.
-   * The matrix for these two behaviors is as follows:
-   *               |    sods   |   elevate  |
-   *               |-----------|------------|
-   *  kAutomatic   |   true    |   false    |
-   *  kAlways      |   false   |   true     |
-   *  kNever       |   false   |   false    |
-   * The first, --stop-on-desk-switch (sods), is passed through the daemon as a
-   * command line argument to the server/client, and determines if it restarts
-   * when switching Windows desktops (e.g. when Windows UAC dialog pops up).
-   * The second, elevate, is passed as a boolean flag to the daemon over IPC,
-   * and determines whether the server/client should be started with elevated privileges.
-   */
-  enum ElevateMode
-  {
-    Automatic = 0,
-    Always = 1,
-    Never = 2
-  };
-  Q_ENUM(ElevateMode)
-
   enum CoreMode
   {
     None,
@@ -182,7 +159,6 @@ private:
     , Settings::Client::LanguageSync
     , Settings::Client::RemoteHost
     , Settings::Core::CoreMode
-    , Settings::Core::ElevateMode
     , Settings::Core::Interface
     , Settings::Core::LastVersion
     , Settings::Core::Port

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -48,6 +48,7 @@ public:
     inline static const auto PreventSleep = QStringLiteral("core/preventSleep");
     inline static const auto ProcessMode = QStringLiteral("core/processMode");
     inline static const auto ScreenName = QStringLiteral("core/screenName");
+    inline static const auto StopOnDeskSwitch = QStringLiteral("core/stopOnDeskSwitch");
     inline static const auto StartedBefore = QStringLiteral("core/startedBefore");
     inline static const auto UpdateUrl = QStringLiteral("core/updateUrl");
   };
@@ -189,6 +190,7 @@ private:
     , Settings::Core::ProcessMode
     , Settings::Core::ScreenName
     , Settings::Core::StartedBefore
+    , Settings::Core::StopOnDeskSwitch
     , Settings::Core::UpdateUrl
     , Settings::Daemon::Command
     , Settings::Daemon::Elevate

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -264,8 +264,7 @@ void CoreProcess::startProcessFromDaemon(const QString &app, const QStringList &
 
   qInfo("running command: %s", qPrintable(commandQuoted));
 
-  auto elevateMode = Settings::value(Settings::Core::ElevateMode).value<Settings::ElevateMode>();
-  if (!m_daemonIpcClient->sendStartProcess(commandQuoted, elevateMode)) {
+  if (!m_daemonIpcClient->sendStartProcess(commandQuoted, Settings::value(Settings::Daemon::Elevate).toBool())) {
     qCritical("cannot start process, ipc command failed");
     return;
   }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -470,8 +470,7 @@ bool CoreProcess::addGenericArgs(QStringList &args, const ProcessMode processMod
     // unnecessary restarts when deskflow was started elevated or
     // when it is not allowed to elevate. In these cases restarting
     // the server is fruitless.
-    auto elevateMode = Settings::value(Settings::Core::ElevateMode).value<Settings::ElevateMode>();
-    if (elevateMode == Settings::ElevateMode::Automatic) {
+    if (Settings::value(Settings::Core::StopOnDeskSwitch).toBool()) {
       args << "--stop-on-desk-switch";
     }
 #endif

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -254,9 +254,7 @@ void CoreProcess::startForegroundProcess(const QString &app, const QStringList &
 
 void CoreProcess::startProcessFromDaemon(const QString &app, const QStringList &args)
 {
-  using enum ProcessState;
-
-  if (m_processState != Starting) {
+  if (m_processState != ProcessState::Starting) {
     qFatal("core process must be in starting state");
   }
 
@@ -269,7 +267,7 @@ void CoreProcess::startProcessFromDaemon(const QString &app, const QStringList &
     return;
   }
 
-  setProcessState(Started);
+  setProcessState(ProcessState::Started);
 }
 
 void CoreProcess::stopForegroundProcess() const

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -62,7 +62,7 @@ void SettingsDialog::initConnections()
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   connect(ui->groupSecurity, &QGroupBox::toggled, this, &SettingsDialog::updateTlsControlsEnabled);
-  connect(ui->cbServiceEnabled, &QCheckBox::toggled, this, &SettingsDialog::updateControls);
+  connect(ui->groupService, &QGroupBox::toggled, this, &SettingsDialog::updateControls);
   connect(ui->btnTlsRegenCert, &QPushButton::clicked, this, &SettingsDialog::regenCertificates);
   connect(ui->comboTlsKeyLength, &QComboBox::currentIndexChanged, this, &SettingsDialog::updateRequestedKeySize);
   connect(ui->btnTlsCertPath, &QPushButton::clicked, this, &SettingsDialog::browseCertificatePath);
@@ -146,7 +146,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Security::CheckPeers, ui->cbRequireClientCert->isChecked());
 
   Settings::ProcessMode mode;
-  if (ui->cbServiceEnabled->isChecked())
+  if (ui->groupService->isChecked())
     mode = Settings::ProcessMode::Service;
   else
     mode = Settings::ProcessMode::Desktop;
@@ -171,7 +171,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
-  ui->cbServiceEnabled->setChecked(processMode == Settings::ProcessMode::Service);
+  ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);
 
   if (Settings::value(Settings::Gui::SymbolicTrayIcon).toBool())
     ui->rbIconMono->setChecked(true);
@@ -249,7 +249,7 @@ void SettingsDialog::updateKeyLengthOnFile(const QString &path)
 void SettingsDialog::updateControls()
 {
   const bool writable = Settings::isWritable();
-  const bool serviceChecked = ui->cbServiceEnabled->isChecked();
+  const bool serviceChecked = ui->groupService->isChecked();
   const bool logToFile = ui->cbLogToFile->isChecked();
 
   ui->sbPort->setEnabled(writable);
@@ -265,7 +265,7 @@ void SettingsDialog::updateControls()
 
   // Handle enable and disable of service items
   if (Settings::isNativeMode()) {
-    ui->cbServiceEnabled->setEnabled(writable);
+    ui->groupService->setEnabled(writable);
     ui->widgetElevate->setEnabled(writable && serviceChecked);
   } else if (ui->groupService->isVisibleTo(ui->tabAdvanced)) {
     ui->groupService->setVisible(false);

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -68,6 +68,25 @@ void SettingsDialog::initConnections()
   connect(ui->btnTlsCertPath, &QPushButton::clicked, this, &SettingsDialog::browseCertificatePath);
   connect(ui->btnBrowseLog, &QPushButton::clicked, this, &SettingsDialog::browseLogPath);
   connect(ui->cbLogToFile, &QCheckBox::toggled, this, &SettingsDialog::setLogToFile);
+  connect(ui->cbElevateDaemon, &QCheckBox::toggled, this, [&](bool checked) {
+    if (!checked)
+      return;
+    if (ui->cbStopOnDeskSwitch->isChecked()) {
+      blockSignals(true);
+      ui->cbStopOnDeskSwitch->setChecked(false);
+      blockSignals(false);
+    }
+  });
+
+  connect(ui->cbStopOnDeskSwitch, &QCheckBox::toggled, this, [&](bool checked) {
+    if (!checked)
+      return;
+    if (ui->cbElevateDaemon->isChecked()) {
+      blockSignals(true);
+      ui->cbElevateDaemon->setChecked(false);
+      blockSignals(false);
+    }
+  });
 }
 
 void SettingsDialog::regenCertificates()
@@ -133,7 +152,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Log::ToFile, ui->cbLogToFile->isChecked());
   Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
   Settings::setValue(Settings::Core::StopOnDeskSwitch, ui->cbStopOnDeskSwitch->isChecked());
-  Settings::setValue(Settings::Core::ElevateMode, ui->comboElevate->currentIndex());
+  Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
   Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
   Settings::setValue(Settings::Gui::AutoUpdateCheck, ui->cbAutoUpdate->isChecked());
   Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
@@ -169,7 +188,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
   ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
   ui->cbStopOnDeskSwitch->setChecked(Settings::value(Settings::Core::StopOnDeskSwitch).toBool());
-  ui->comboElevate->setCurrentIndex(Settings::value(Settings::Core::ElevateMode).toInt());
+  ui->cbElevateDaemon->setChecked(Settings::value(Settings::Daemon::Elevate).toBool());
   ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
@@ -268,7 +287,7 @@ void SettingsDialog::updateControls()
   // Handle enable and disable of service items
   if (Settings::isNativeMode()) {
     ui->groupService->setEnabled(writable);
-    ui->widgetElevate->setEnabled(writable && serviceChecked);
+    ui->cbElevateDaemon->setEnabled(writable && serviceChecked);
     ui->cbStopOnDeskSwitch->setEnabled(writable && serviceChecked);
   } else if (ui->groupService->isVisibleTo(ui->tabAdvanced)) {
     ui->groupService->setVisible(false);

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -132,6 +132,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Log::Level, ui->comboLogLevel->currentIndex());
   Settings::setValue(Settings::Log::ToFile, ui->cbLogToFile->isChecked());
   Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
+  Settings::setValue(Settings::Core::StopOnDeskSwitch, ui->cbStopOnDeskSwitch->isChecked());
   Settings::setValue(Settings::Core::ElevateMode, ui->comboElevate->currentIndex());
   Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
   Settings::setValue(Settings::Gui::AutoUpdateCheck, ui->cbAutoUpdate->isChecked());
@@ -167,6 +168,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbLanguageSync->setChecked(Settings::value(Settings::Client::LanguageSync).toBool());
   ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
   ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
+  ui->cbStopOnDeskSwitch->setChecked(Settings::value(Settings::Core::StopOnDeskSwitch).toBool());
   ui->comboElevate->setCurrentIndex(Settings::value(Settings::Core::ElevateMode).toInt());
   ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
 
@@ -267,6 +269,7 @@ void SettingsDialog::updateControls()
   if (Settings::isNativeMode()) {
     ui->groupService->setEnabled(writable);
     ui->widgetElevate->setEnabled(writable && serviceChecked);
+    ui->cbStopOnDeskSwitch->setEnabled(writable && serviceChecked);
   } else if (ui->groupService->isVisibleTo(ui->tabAdvanced)) {
     ui->groupService->setVisible(false);
     const int bottomMargin = ui->tabAdvanced->layout()->contentsMargins().bottom() +

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabRegular">
       <property name="sizePolicy">
@@ -548,31 +548,16 @@
           </sizepolicy>
          </property>
          <property name="title">
-          <string>Service</string>
+          <string>Use background service (daemon)</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="_6">
           <item row="0" column="0">
-           <widget class="QCheckBox" name="cbServiceEnabled">
-            <property name="toolTip">
-             <string>Whether to launch the server or client process through the Windows background
-                service or direct from the GUI.</string>
-            </property>
-            <property name="whatsThis">
-             <string>
-              &lt;p&gt;The background service is only available on Windows.&lt;/p&gt;
-              &lt;p&gt;The Windows background service is used to:&lt;/p&gt;
-              &lt;ul&gt;
-              &lt;li&gt;Start the server or client automatically when the computer starts.&lt;/li&gt;
-              &lt;li&gt;Run the server or client in an elevated mode (e.g. on login screen, UAC dialogs, etc).&lt;/li&gt;
-              &lt;/ul&gt;
-              </string>
-            </property>
-            <property name="text">
-             <string>Use background service (daemon)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
            <widget class="QWidget" name="widgetElevate" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -688,7 +673,6 @@
   <tabstop>comboLogLevel</tabstop>
   <tabstop>lineLogFilename</tabstop>
   <tabstop>btnBrowseLog</tabstop>
-  <tabstop>cbServiceEnabled</tabstop>
   <tabstop>comboElevate</tabstop>
  </tabstops>
  <resources/>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -22,9 +22,6 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
      <widget class="QWidget" name="tabRegular">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -557,7 +554,7 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="_6">
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QWidget" name="widgetElevate" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -630,6 +627,16 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="cbStopOnDeskSwitch">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Run as system only when at the login screen and UAC prompt</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -147,6 +147,9 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
          <layout class="QVBoxLayout" name="_11">
           <item>
            <widget class="QWidget" name="widgetTlsCert" native="true">
@@ -538,6 +541,9 @@
        </item>
        <item>
         <widget class="QGroupBox" name="groupService">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
            <horstretch>0</horstretch>
@@ -554,81 +560,6 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="_6">
-          <item row="1" column="0">
-           <widget class="QWidget" name="widgetElevate" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QHBoxLayout" name="_7">
-             <item>
-              <widget class="QLabel" name="lblElevate">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Launch with elevated privileges</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="comboElevate">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Specify when the Windows background service should run the server or client
-                  process at an elevated privilege level.</string>
-               </property>
-               <property name="whatsThis">
-                <string>
-                &lt;p&gt;You may want to alter whether or not the privilege level of the server or client 
-                  process is automatically changed depending on your use case. In some cases it can help
-                  to diagnose or solve some problems related to elevated processes in Windows.&lt;/p&gt;
-                &lt;ul&gt;
-                  &lt;li&gt;Automatic: Elevate when the window session changes to secure mode&lt;/li&gt;
-                  &lt;li&gt;Always elevate: Always run in elevated mode (could be unsafe)&lt;/li&gt;
-                  &lt;li&gt;Never elevate: Turn off compatibility with login screen and UAC&lt;/li&gt;
-                &lt;/ul&gt;
-                </string>
-               </property>
-               <property name="currentIndex">
-                <number>0</number>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Automatic (as needed)</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Always elevate</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Never elevate</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="2" column="0">
            <widget class="QCheckBox" name="cbStopOnDeskSwitch">
             <property name="toolTip">
@@ -636,6 +567,19 @@
             </property>
             <property name="text">
              <string>Run as system only when at the login screen and UAC prompt</string>
+            </property>
+            <property name="autoExclusive">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="cbElevateDaemon">
+            <property name="text">
+             <string>Always run as system (work at login screen and UAC)</string>
+            </property>
+            <property name="autoExclusive">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -680,7 +624,6 @@
   <tabstop>comboLogLevel</tabstop>
   <tabstop>lineLogFilename</tabstop>
   <tabstop>btnBrowseLog</tabstop>
-  <tabstop>comboElevate</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/lib/gui/ipc/DaemonIpcClient.cpp
+++ b/src/lib/gui/ipc/DaemonIpcClient.cpp
@@ -132,13 +132,12 @@ bool DaemonIpcClient::sendLogLevel(const QString &logLevel)
   return true;
 }
 
-bool DaemonIpcClient::sendStartProcess(const QString &command, Settings::ElevateMode elevateMode)
+bool DaemonIpcClient::sendStartProcess(const QString &command, bool elevate)
 {
   if (!keepAlive())
     return false;
 
-  using ElevateMode = Settings::ElevateMode;
-  if (!sendMessage("elevate=" + (elevateMode == ElevateMode::Always ? QStringLiteral("yes") : QStringLiteral("no")))) {
+  if (!sendMessage("elevate=" + (elevate ? QStringLiteral("yes") : QStringLiteral("no")))) {
     return false;
   }
 

--- a/src/lib/gui/ipc/DaemonIpcClient.h
+++ b/src/lib/gui/ipc/DaemonIpcClient.h
@@ -22,7 +22,7 @@ public:
   explicit DaemonIpcClient(QObject *parent = nullptr);
   bool connectToServer();
   bool sendLogLevel(const QString &logLevel);
-  bool sendStartProcess(const QString &command, Settings::ElevateMode elevateMode);
+  bool sendStartProcess(const QString &command, bool elevate);
   bool sendStopProcess();
   bool sendClearSettings();
   QString requestLogPath();


### PR DESCRIPTION
 fixes: #8350 

 - Removes `Settings::Core::ElevateMode` and sets `Daemon::Elevate` Instead (default: true)
 - New Settings: `Settings::Core::StopOnDeskSwitch` (default: false) 

You can only select one of the option 