### PR TITLE
feat: add help and version to gui,

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 project(
   deskflow
   VERSION "${DESKFLOW_VERSION_MAJOR}.${DESKFLOW_VERSION_MINOR}.${DESKFLOW_VERSION_PATCH}.${DESKFLOW_VERSION_TWEAK}"
-  DESCRIPTION "Mouse and keyboard sharing utility"
+  DESCRIPTION "Keyboard and mouse sharing utility"
   LANGUAGES C CXX)
 
 # Define Additional "PROJECT" vars for packaging and metadata

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -14,7 +14,7 @@ function(generate_app_man TARGET)
   if(HELP2MAN)
     add_custom_command(
       TARGET ${target} POST_BUILD
-        COMMAND ${HELP2MAN}
+        COMMAND QT_QPA_PLATFORM=minimal ${HELP2MAN}
           --include ${CMAKE_SOURCE_DIR}/src/apps/res/manpage.txt
           --no-info
           $<TARGET_FILE:${target}>

--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -84,19 +84,5 @@ elseif(APPLE)
   install(TARGETS ${target} BUNDLE DESTINATION .)
 else()
   install(TARGETS ${target} DESTINATION bin)
-  if(HELP2MAN)
-    configure_file(deskflow.man.template.in ${CMAKE_CURRENT_BINARY_DIR}/${target})
-    add_custom_command(
-    TARGET ${target} POST_BUILD
-      COMMAND ${HELP2MAN}
-        --version-string "${CMAKE_PROJECT_VERSION}"
-        --include ${CMAKE_SOURCE_DIR}/src/apps/res/manpage.txt
-        --no-info ${CMAKE_CURRENT_BINARY_DIR}/${target}
-        -o ${CMAKE_CURRENT_BINARY_DIR}/${target}.1
-  )
-  install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/${target}.1
-    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
-  )
-  endif()
+  generate_app_man(${target})
 endif()

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -129,8 +129,6 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_MAC)
 bool checkMacAssistiveDevices()
 {
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090 // mavericks
-
   // new in mavericks, applications are trusted individually
   // with use of the accessibility api. this call will show a
   // prompt which can show the security/privacy/accessibility
@@ -148,21 +146,5 @@ bool checkMacAssistiveDevices()
   bool result = AXIsProcessTrustedWithOptions(options);
   CFRelease(options);
   return result;
-
-#else
-
-  // now deprecated in mavericks.
-  bool result = AXAPIEnabled();
-  if (!result) {
-    QString msgBody = QString(
-        "Please enable access to assistive devices "
-        "System Preferences -> Security & Privacy -> "
-        "Privacy -> Accessibility, then re-open %1."
-    );
-    QMessageBox::information(NULL, kAppName, msgBody.arg(kAppName));
-  }
-  return result;
-
-#endif
 }
 #endif

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -32,15 +32,6 @@
 
 using namespace deskflow::gui;
 
-class QThreadImpl : public QThread
-{
-public:
-  static void msleep(unsigned long msecs)
-  {
-    QThread::msleep(msecs);
-  }
-};
-
 #if defined(Q_OS_MAC)
 bool checkMacAssistiveDevices();
 #endif

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -16,13 +16,10 @@
 #include "gui/StyleUtils.h"
 
 #include <QApplication>
-#include <QDebug>
 #include <QGuiApplication>
 #include <QLocalSocket>
 #include <QMessageBox>
-#include <QObject>
 #include <QSharedMemory>
-#include <QtGlobal>
 
 #if defined(Q_OS_MAC)
 #include <Carbon/Carbon.h>

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -48,12 +48,6 @@ int main(int argc, char *argv[])
   QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true\nqt.*=false"));
 #endif
 
-#if defined(Q_OS_MAC)
-  /* Workaround for QTBUG-40332 - "High ping when QNetworkAccessManager is
-   * instantiated" */
-  ::setenv("QT_BEARER_POLL_TIMEOUT", "-1", 1);
-#endif
-
   QCoreApplication::setApplicationName(kAppName);
   QCoreApplication::setOrganizationName(kAppName);
   QGuiApplication::setDesktopFileName(QStringLiteral("org.deskflow.deskflow"));

--- a/src/apps/deskflow-gui/deskflow.man.template.in
+++ b/src/apps/deskflow-gui/deskflow.man.template.in
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: Deskflow Developers
-# SPDX-License-Identifier: MIT
-#!/bin/sh -eu
-
-if [ "$1" = '--help' ]; then
-cat << EOM
-@CMAKE_PROJECT_DESCRIPTION@. This is the GUI. It takes no arguments or options.
-EOM
-fi


### PR DESCRIPTION
- Requires #8440 
- Change app description from `Mouse and keyboard sharing utility` => `Keyboard and mouse sharing utility` 


Clean up some unused item in `deskflow-gui.cpp`
 - Remove unused headers
 - Remove unused `QThreadImpl` class
 - Remove workaround for [Qt-40332](https://bugreports.qt.io/browse/QTBUG-40332)
 - Remove fallback for pre mavericks accessibility dialog

Add Cli options 
 - Removes the need for the template man page for deskflow's gui
 - move `--no-reset` to the QCommandLineProcessor 
 - add `--help`
     ```
        Deskflow: 1.21.1.18 (f41b6a45)
          Keyboard and mouse sharing utility

        Usage: deskflow [options]

        Options:
          --help      Display Help on the command line
          --version   Display version information
          --no-reset  Prevent settings reset if DESKFLOW_RESET_ALL is set
     ```
 - add `--version` 
      ```
          Deskflow: 1.21.1.18 (f41b6a45)
          Copyright (C) 2024-2025 Deskflow Devs
          Copyright (C) 2012-2025 Symless Ltd.
          Copyright (C) 2009-2012 Nick Bolton
          Copyright (C) 2002-2009 Chris Schoeneman
      ```