### PR TITLE
Fix 7680

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -134,24 +134,20 @@ void Client::connect(size_t addressIndex)
   auto securityLevel = m_useSecureNetwork ? SecurityLevel::PeerAuth : SecurityLevel::PlainText;
 
   try {
-    if (m_args.m_hostMode) {
-      LOG((CLOG_NOTE "waiting for server connection on %i port", m_serverAddress.getPort()));
-    } else {
-      // resolve the server hostname.  do this every time we connect
-      // in case we couldn't resolve the address earlier or the address
-      // has changed (which can happen frequently if this is a laptop
-      // being shuttled between various networks).  patch by Brent
-      // Priddy.
-      m_resolvedAddressesCount = m_serverAddress.resolve(addressIndex);
+    // resolve the server hostname.  do this every time we connect
+    // in case we couldn't resolve the address earlier or the address
+    // has changed (which can happen frequently if this is a laptop
+    // being shuttled between various networks).  patch by Brent
+    // Priddy.
+    m_resolvedAddressesCount = m_serverAddress.resolve(addressIndex);
 
-      // m_serverAddress will be null if the hostname address is not reolved
-      if (m_serverAddress.getAddress() != nullptr) {
-        // to help users troubleshoot, show server host name (issue: 60)
-        LOG(
-            (CLOG_NOTE "connecting to '%s': %s:%i", m_serverAddress.getHostname().c_str(),
-             ARCH->addrToString(m_serverAddress.getAddress()).c_str(), m_serverAddress.getPort())
-        );
-      }
+    // m_serverAddress will be null if the hostname address is not reolved
+    if (m_serverAddress.getAddress() != nullptr) {
+      // to help users troubleshoot, show server host name (issue: 60)
+      LOG(
+          (CLOG_NOTE "connecting to '%s': %s:%i", m_serverAddress.getHostname().c_str(),
+           ARCH->addrToString(m_serverAddress.getAddress()).c_str(), m_serverAddress.getPort())
+      );
     }
 
     // create the socket
@@ -509,11 +505,8 @@ void Client::setupScreen()
 void Client::setupTimer()
 {
   assert(m_timer == NULL);
-
-  if (!m_args.m_hostMode) {
-    m_timer = m_events->newOneShotTimer(2.0, NULL);
-    m_events->adoptHandler(Event::kTimer, m_timer, new TMethodEventJob<Client>(this, &Client::handleConnectTimeout));
-  }
+  m_timer = m_events->newOneShotTimer(2.0, NULL);
+  m_events->adoptHandler(Event::kTimer, m_timer, new TMethodEventJob<Client>(this, &Client::handleConnectTimeout));
 }
 
 void Client::cleanup()

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -173,9 +173,10 @@ private:
   "  -1, --no-restart         do not try to restart on failure.\n"                                                     \
   "*     --restart            restart the server automatically if it fails.\n"                                         \
   "  -l  --log <file>         write log messages to file.\n"                                                           \
-  "      --enable-drag-drop   enable file drag & drop.\n"                                                              \
   "      --enable-crypto      enable TLS encryption.\n"                                                                \
   "      --tls-cert           specify the path to the TLS certificate file.\n"
+
+#define DRAG_AND_DROP "      --enable-drag-drop   enable file drag & drop.\n"
 
 #define HELP_COMMON_INFO_2                                                                                             \
   "  -h, --help               display this help and exit.\n"                                                           \

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -88,8 +88,6 @@ bool ArgParser::parseClientArgs(deskflow::ClientArgs &args, int argc, const char
       args.m_enableLangSync = true;
     } else if (isArg(i, argc, argv, nullptr, "--invert-scroll")) {
       args.m_clientScrollDirection = deskflow::ClientScrollDirection::INVERT_SERVER;
-    } else if (isArg(i, argc, argv, nullptr, "--host")) {
-      args.m_hostMode = true;
     } else if (isArg(i, argc, argv, nullptr, "client")) {
       ++i;
       continue;

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -113,7 +113,6 @@ void ClientApp::help()
        << " [--yscroll <delta>]"
        << " [--sync-language]"
        << " [--invert-scroll]"
-       << " [--host]"
 #ifdef WINAPI_XWINDOWS
        << " [--display <display>]"
        << " [--no-xinitthreads]"
@@ -131,8 +130,6 @@ void ClientApp::help()
        << "      --sync-language      enable language synchronization.\n"
        << "      --invert-scroll      invert scroll direction on this\n"
        << "                             computer.\n"
-       << "      --host               act as a host; invert server/client mode\n"
-       << "                             and listen instead of connecting.\n"
 #if WINAPI_XWINDOWS
        << "      --display <display>  when in X mode, connect to the X server\n"
        << "                             at <display>.\n"

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -118,9 +118,6 @@ void ClientApp::help()
        << " [--display <display>]"
        << " [--no-xinitthreads]"
 #endif
-#ifdef WINAPI_LIBEI
-       << " [--use-x-window]"
-#endif
        << HELP_SYS_ARGS << HELP_COMMON_ARGS << " <server-address>"
        << "\n\n"
        << "Connect to a " << kAppName << " mouse/keyboard sharing server.\n"

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -125,6 +125,9 @@ void ClientApp::help()
        << "  -a, --address <address>  local network interface address.\n"
        << HELP_COMMON_INFO_1 << HELP_SYS_INFO << "      --yscroll <delta>    defines the vertical scrolling delta,\n"
        << "                             which is 120 by default.\n"
+#ifndef WINAPI_XWINDOWS
+       << DRAG_AND_DROP "\n"
+#endif
        << "      --sync-language      enable language synchronization.\n"
        << "      --invert-scroll      invert scroll direction on this\n"
        << "                             computer.\n"

--- a/src/lib/deskflow/ClientArgs.h
+++ b/src/lib/deskflow/ClientArgs.h
@@ -35,12 +35,6 @@ public:
   ClientScrollDirection m_clientScrollDirection = ClientScrollDirection::SERVER;
 
   /**
-   * @brief m_hostMode - activates host mode.
-   * Client starts a listener and waits for a server connection.
-   */
-  bool m_hostMode = false;
-
-  /**
    * @brief m_serverAddress stores deskflow server address
    */
   std::string m_serverAddress;

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -148,7 +148,6 @@ void ServerApp::help()
        << "      --no-xinitthreads    do not call XInitThreads()\n"
 #endif
 
-       << HELP_SYS_INFO HELP_COMMON_INFO_2 "\n"
        << "* marks defaults.\n"
 
        << kHelpNoWayland

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -132,7 +132,11 @@ void ServerApp::help()
        << " [--no-wayland-ei]"
 #endif
 
-       << HELP_SYS_ARGS HELP_COMMON_ARGS "\n\n"
+       << HELP_SYS_ARGS HELP_COMMON_ARGS "\n"
+#ifndef WINAPI_XWINDOWS
+       << DRAG_AND_DROP "\n"
+#endif
+       << "\n"
        << "Start the " << kAppName << " mouse/keyboard sharing server.\n"
        << "\n"
        << "  -a, --address <address>  listen for clients on the given address.\n"

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -128,10 +128,6 @@ void ServerApp::help()
        << " [--display <display>] [--no-xinitthreads]"
 #endif
 
-#ifdef WINAPI_LIBEI
-       << " [--no-wayland-ei]"
-#endif
-
        << HELP_SYS_ARGS HELP_COMMON_ARGS "\n"
 #ifndef WINAPI_XWINDOWS
        << DRAG_AND_DROP "\n"


### PR DESCRIPTION
 fixes #7680 
- remove additional `--host` from deskflow-client (unused from invert connection removal)

server-help
```
❯ ./deskflow-server --help
Mouse and keyboard sharing utility 


./deskflow-server [OPTIONS]


OPTIONS:
  -h,     --help              Print this help message and exit 
          --config-toml TEXT  Use TOML configuration file 
Usage: settings/Deskflow [--address <address>] [--config <pathname>] [--display <display>] [--no-xinitthreads] [--daemon|--no-daemon] [--name <screen-name>] [--restart|--no-restart] [--debug <level>]

Start the Deskflow mouse/keyboard sharing server.

  -a, --address <address>  listen for clients on the given address.
  -c, --config <pathname>  use the named configuration file instead.
  -d, --debug <level>      filter out log messages with priority below level.
                             level may be: FATAL, ERROR, WARNING, NOTE, INFO,
                             DEBUG, DEBUG1, DEBUG2.
  -n, --name <screen-name> use screen-name instead the hostname to identify
                             this screen in the configuration.
  -1, --no-restart         do not try to restart on failure.
*     --restart            restart the server automatically if it fails.
  -l  --log <file>         write log messages to file.
      --enable-crypto      enable TLS encryption.
      --tls-cert           specify the path to the TLS certificate file.
      --disable-client-cert-check disable client SSL certificate 
                                     checking (deprecated)
  -f, --no-daemon          run in the foreground.
*     --daemon             run as a daemon.
  -h, --help               display this help and exit.
      --version            display version information and exit.

      --display <display>  when in X mode, connect to the X server
                             at <display>.
      --no-xinitthreads    do not call XInitThreads()
* marks defaults.

The argument for --address is of the form: [<hostname>][:<port>].  The
hostname must be the address or hostname of an interface on the system.
The default is to listen on all interfaces.  The port overrides the
default port, 24800.

If no configuration file pathname is provided then the first of the
following to load successfully sets the configuration:
  settings/Deskflow
  /home/chris/.config/Deskflow/Deskflow.conf
  /etc/Deskflow/Deskflow.conf
```

client-help 
```
Mouse and keyboard sharing utility 


./deskflow-client [OPTIONS]


OPTIONS:
  -h,     --help              Print this help message and exit 
          --config-toml TEXT  Use TOML configuration file 
Usage: deskflow-client [--address <address>] [--yscroll <delta>] [--sync-language] [--invert-scroll] [--host] [--display <display>] [--no-xinitthreads] [--daemon|--no-daemon] [--name <screen-name>] [--restart|--no-restart] [--debug <level>] <server-address>

Connect to a Deskflow mouse/keyboard sharing server.

  -a, --address <address>  local network interface address.
  -d, --debug <level>      filter out log messages with priority below level.
                             level may be: FATAL, ERROR, WARNING, NOTE, INFO,
                             DEBUG, DEBUG1, DEBUG2.
  -n, --name <screen-name> use screen-name instead the hostname to identify
                             this screen in the configuration.
  -1, --no-restart         do not try to restart on failure.
*     --restart            restart the server automatically if it fails.
  -l  --log <file>         write log messages to file.
      --enable-crypto      enable TLS encryption.
      --tls-cert           specify the path to the TLS certificate file.
  -f, --no-daemon          run in the foreground.
*     --daemon             run as a daemon.
      --yscroll <delta>    defines the vertical scrolling delta,
                             which is 120 by default.
      --sync-language      enable language synchronization.
      --invert-scroll      invert scroll direction on this
                             computer.
      --display <display>  when in X mode, connect to the X server
                             at <display>.
      --no-xinitthreads    do not call XInitThreads()
  -h, --help               display this help and exit.
      --version            display version information and exit.

* marks defaults.

The server address is of the form: [<hostname>][:<port>].
The hostname must be the address or hostname of the server.
The port overrides the default port, 24800.
```
As seen on linux.