### PR TITLE
fix: build issue on Qt 6.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,7 +258,7 @@ jobs:
         id: get-deps
         uses: ./.github/actions/install-dependencies
         with:
-          qt-version: 6.8.2
+          qt-version: 6.9.0
           qt-install-dir: ${{matrix.target.qt-install-dir}}
           like: ${{ matrix.target.like }}
 

--- a/src/lib/gui/KeySequence.cpp
+++ b/src/lib/gui/KeySequence.cpp
@@ -207,8 +207,14 @@ QString KeySequence::keyToString(int key)
   }
 
   // representable in ucs2?
-  if (key < 0x10000)
-    return QString("\\u%1").arg(QChar(key).toLower().unicode(), 4, 16, QChar('0'));
+  if (key < 0x10000) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    const uint16_t keyHex = QChar(key).toLower().unicode();
+    return QString("\\u%1").arg(keyHex, kStrSize, kBase, kFillChar);
+#else
+    return QString("\\u%1").arg(QChar(key).toLower().unicode(), kStrSize, kBase, kFillChar);
+#endif
+  }
 
   // give up, deskflow probably won't handle this
   return "";

--- a/src/lib/gui/KeySequence.h
+++ b/src/lib/gui/KeySequence.h
@@ -58,5 +58,9 @@ private:
   int m_Modifiers;
   bool m_IsValid;
 
+  inline static const int kStrSize = 4;
+  inline static const int kBase = 16;
+  inline static const QChar kFillChar = QChar('0');
+
   static QString keyToString(int key);
 };


### PR DESCRIPTION
- requires: #8453 
- fixes: #8448 
- bump windows and mac os ci to use Qt 6.9