### PR TITLE
chore: add default case for EI_EVENT handling

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -820,6 +820,8 @@ void EiScreen::handleSystemEvent(const Event &sysevent, void *)
     case EI_EVENT_SCROLL_STOP:
     case EI_EVENT_SCROLL_CANCEL:
       break;
+    default:
+      break;
     }
     ei_event_unref(event);
   }


### PR DESCRIPTION
- libei added some new Types we do not handle to avoid warnings about this a default case has been added to handling