### PR TITLE
fixes #8463 do not assume C for root

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -20,7 +20,7 @@ class Settings : public QObject
 public:
 #if defined(Q_OS_WIN)
   inline const static auto UserDir = QStringLiteral("%1/AppData/Local/%2").arg(QDir::homePath(), kAppName);
-  inline const static auto SystemDir = QStringLiteral("C:/ProgramData/%1").arg(kAppName);
+  inline const static auto SystemDir = QStringLiteral("%1ProgramData/%2").arg(QDir::rootPath(), kAppName);
 #elif defined(Q_OS_MAC)
   inline const static auto UserDir = QStringLiteral("%1/Library/%2").arg(QDir::homePath(), kAppName);
   inline const static auto SystemDir = QStringLiteral("/Library/%1").arg(kAppName);


### PR DESCRIPTION
When we moved the settings we assumed C we need to use QDir::rootPath in the case of windows not being installed on the "C" drive.