### PR TITLE
ci: force osxSysroot for osx13 builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -145,7 +145,7 @@ jobs:
           - name: "macos-13-x64"
             runs-on: macos-13
             timeout: 20
-            config-args: "-DCMAKE_OSX_ARCHITECTURES=\"x86_64\""
+            config-args: "-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" -DCMAKE_OSX_SYSROOT=/Applications/Xcode_15.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
             qt-install-dir: "/Users/runner"
 
           - name: "debian-13-x86_64"


### PR DESCRIPTION
 - osx 13 build fail randomly to find pthread, force this build to use the xcode15 sdk path in place of the 15.2 default