### PR TITLE
Change Qt mirror (`download.qt.io` is down/flakey)

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -70,6 +70,8 @@ runs:
     - name: Install Qt
       if: ${{runner.os != 'Linux' }}
       uses: jurplel/install-qt-action@v4
+      env:
+        AQT_CONFIG: ${{ github.workspace }}/.github/actions/install-dependencies/aqt.ini
       with:
         dir: ${{inputs.qt-install-dir}}
         version: ${{inputs.qt-version}}

--- a/.github/actions/install-dependencies/aqt.ini
+++ b/.github/actions/install-dependencies/aqt.ini
@@ -1,0 +1,14 @@
+[aqt]
+# Using this mirror instead of download.qt.io because of timeouts in CI
+baseurl: https://qt.mirror.constant.com
+
+[requests]
+hash_algorithm: sha1
+
+[mirrors]
+trusted_mirrors:
+    https://qt.mirror.constant.com
+fallbacks:
+    https://qt.mirror.constant.com
+    https://mirrors.ocf.berkeley.edu
+    https://download.qt.io


### PR DESCRIPTION
Qt default base (`download.qt.io`) has been flakey over the last few days:
- https://github.com/jurplel/install-qt-action/issues/285
- https://github.com/jurplel/install-qt-action/issues/283#issuecomment-2807825345

```
ERROR   : Failed to download checksum for the file '6.9.0-0-202503301022d3dcompiler_47-x64.7z' from mirrors '['https://download.qt.io/']
```

On my local machine:
```
curl https://download.qt.io/                                                              
curl: (7) Failed to connect to download.qt.io port 443 after 43 ms: Could not connect to server
```

We should try a mirror.

Edit: I tried setting `--base` but it turns out that `aqt` ignores that for checksums. The only way to get `aqt` to use checksums from the mirror seems to be to write a `.ini` file and pass it via `AQT_CONFIG` env var.