### PR TITLE
refactor: remove old mac os version checks 

### DIFF
--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -195,7 +195,7 @@ void App::runEventsLoop(void *)
 {
   m_events->loop();
 
-#if defined(MAC_OS_X_VERSION_10_7)
+#if WINAPI_CARBON
 
   stopCocoaLoop();
 

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -44,17 +44,14 @@
 #endif
 
 #if WINAPI_CARBON
+#include "base/TMethodJob.h"
+#include "mt/Thread.h"
 #include "platform/OSXDragSimulator.h"
 #include "platform/OSXScreen.h"
 #endif
 
 #if defined(WINAPI_XWINDOWS) or defined(WINAPI_LIBEI)
 #include "platform/Wayland.h"
-#endif
-
-#if defined(MAC_OS_X_VERSION_10_7)
-#include "base/TMethodJob.h"
-#include "mt/Thread.h"
 #endif
 
 #include <memory>
@@ -455,7 +452,7 @@ int ClientApp::mainLoop()
   // that.
   DAEMON_RUNNING(true);
 
-#if defined(MAC_OS_X_VERSION_10_7)
+#if WINAPI_CARBON
 
   Thread thread(new TMethodJob<ClientApp>(this, &ClientApp::runEventsLoop, NULL));
 

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -47,17 +47,14 @@
 #endif
 
 #if WINAPI_CARBON
+#include "base/TMethodJob.h"
+#include "mt/Thread.h"
 #include "platform/OSXDragSimulator.h"
 #include "platform/OSXScreen.h"
 #endif
 
 #if defined(WINAPI_XWINDOWS) or defined(WINAPI_LIBEI)
 #include "platform/Wayland.h"
-#endif
-
-#if defined(MAC_OS_X_VERSION_10_7)
-#include "base/TMethodJob.h"
-#include "mt/Thread.h"
 #endif
 
 #include <fstream>
@@ -683,7 +680,7 @@ int ServerApp::mainLoop()
   // that.
   DAEMON_RUNNING(true);
 
-#if defined(MAC_OS_X_VERSION_10_7)
+#if WINAPI_CARBON
 
   Thread thread(new TMethodJob<ServerApp>(this, &ServerApp::runEventsLoop, NULL));
 

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -329,10 +329,8 @@ private:
   std::unique_ptr<Thread> m_getDropTargetThread;
   std::string m_dropTarget;
 
-#if defined(MAC_OS_X_VERSION_10_7)
   Mutex *m_carbonLoopMutex;
   CondVar<bool> *m_carbonLoopReady;
-#endif
 
   OSXPowerManager m_powerManager;
 


### PR DESCRIPTION
 - Remove unnecessary  checks for the mac os version  both 10.7 and 10.9 are below our current  required version .  
 - Replace the needed checks with `#if WINAPI_CARBON`

Testing: 
- [X] Tested Client Mode on macOS
- [x] Tested Server Mode on macOS