### PR TITLE
Retry mechanism for Windows Daemon IPC client

### DIFF
--- a/src/lib/deskflow/ipc/DaemonIpcServer.cpp
+++ b/src/lib/deskflow/ipc/DaemonIpcServer.cpp
@@ -114,8 +114,10 @@ void DaemonIpcServer::processMessage(QLocalSocket *clientSocket, const QString &
 
   const auto &command = parts[0];
   if (command == "hello") { // NOSONAR - if-init is confusing here
+    LOG_DEBUG("ipc server got hello message, sending hello back");
     clientSocket->write("hello\n");
   } else if (command == "noop") {
+    LOG_DEBUG("ipc server got noop message");
     clientSocket->write(kAckMessage);
   } else if (command == "logLevel") {
     processLogLevel(clientSocket, parts);

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -289,7 +289,9 @@ void MainWindow::connectSlots()
   connect(&m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged);
   connect(&m_coreProcess, &CoreProcess::connectionStateChanged, this, &MainWindow::coreConnectionStateChanged);
   connect(&m_coreProcess, &CoreProcess::secureSocket, this, &MainWindow::secureSocket);
-  connect(&m_coreProcess, &CoreProcess::daemonIpcClientConnectFailed, this, &MainWindow::daemonIpcClientConnectFailed);
+  connect(
+      &m_coreProcess, &CoreProcess::daemonIpcClientConnectionFailed, this, &MainWindow::daemonIpcClientConnectionFailed
+  );
 
   connect(m_actionAbout, &QAction::triggered, this, &MainWindow::openAboutDialog);
   connect(m_actionClearSettings, &QAction::triggered, this, &MainWindow::clearSettings);
@@ -1145,7 +1147,7 @@ bool MainWindow::regenerateLocalFingerprints()
   return true;
 }
 
-void MainWindow::daemonIpcClientConnectFailed()
+void MainWindow::daemonIpcClientConnectionFailed()
 {
   if (deskflow::gui::messages::showDaemonOffline(this)) {
     m_coreProcess.retryDaemon();

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -158,7 +158,7 @@ private:
   void showAndActivate();
   void showHostNameEditor();
   void setHostName();
-  void daemonIpcClientConnectFailed();
+  void daemonIpcClientConnectionFailed();
   void toggleCanRunCore(bool enableButtons);
   void remoteHostChanged(const QString newRemoteHost);
 

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -140,7 +140,9 @@ CoreProcess::CoreProcess(const IServerConfig &serverConfig, std::shared_ptr<Deps
       m_daemonIpcClient{new ipc::DaemonIpcClient(this)}
 {
   connect(m_daemonIpcClient, &ipc::DaemonIpcClient::connected, this, &CoreProcess::daemonIpcClientConnected);
-  connect(m_daemonIpcClient, &ipc::DaemonIpcClient::connectFailed, this, &CoreProcess::daemonIpcClientConnectFailed);
+  connect(
+      m_daemonIpcClient, &ipc::DaemonIpcClient::connectionFailed, this, &CoreProcess::daemonIpcClientConnectionFailed
+  );
 
   connect(&m_pDeps->process(), &QProcessProxy::finished, this, &CoreProcess::onProcessFinished);
 

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -120,7 +120,7 @@ signals:
   void connectionStateChanged(ConnectionState state);
   void processStateChanged(ProcessState state);
   void secureSocket(bool enabled);
-  void daemonIpcClientConnectFailed();
+  void daemonIpcClientConnectionFailed();
 
 private slots:
   void onProcessFinished(int exitCode, QProcess::ExitStatus);

--- a/src/lib/gui/ipc/DaemonIpcClient.h
+++ b/src/lib/gui/ipc/DaemonIpcClient.h
@@ -16,9 +16,19 @@ class DaemonIpcClient : public QObject
 {
   Q_OBJECT
 
+  // Represents underlying socket state and whether the server responded to the hello message.
+  enum class State
+  {
+    Unconnected,
+    Connecting,
+    Connected,
+    Disconnecting,
+  };
+
 public:
   explicit DaemonIpcClient(QObject *parent = nullptr);
   bool connectToServer();
+  void disconnectFromServer();
   bool sendLogLevel(const QString &logLevel);
   bool sendStartProcess(const QString &command, bool elevate);
   bool sendStopProcess();
@@ -27,12 +37,12 @@ public:
 
   bool isConnected() const
   {
-    return m_connected;
+    return m_state == State::Connected;
   }
 
 signals:
   void connected();
-  void connectFailed();
+  void connectionFailed();
 
 private slots:
   void handleDisconnected();
@@ -44,8 +54,7 @@ private:
 
 private:
   QLocalSocket *m_socket;
-  bool m_connected{false};
-  bool m_connecting{false};
+  State m_state{State::Unconnected};
 };
 
 } // namespace deskflow::gui::ipc

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -246,7 +246,7 @@ void MSWindowsWatchdog::mainLoop(void *)
   LOG_DEBUG("watchdog main loop finished");
 
   if (m_process != nullptr) {
-    LOG_DEBUG("terminated running process on exit");
+    LOG_DEBUG("terminating running process on exit");
     m_process->shutdown();
     m_process.reset();
   }


### PR DESCRIPTION
Fixes #8505

Todo:
- [x] Remove timeout change (ineffective)
- [x] Retry mechnaism for when hello back isn't received
- [x] Test for a few days to confirm the intermittent bug is fixed