### PR TITLE
fix: user can not start in client mode without a remote host

### DIFF
--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -159,6 +159,8 @@ private:
   void showHostNameEditor();
   void setHostName();
   void daemonIpcClientConnectFailed();
+  void toggleCanRunCore(bool enableButtons);
+  void remoteHostChanged(const QString newRemoteHost);
 
   /**
    * @brief trustedFingerprintDb get the fingerprintDb for the trusted clients or trusted servers.


### PR DESCRIPTION
fixes #8478 
 - Disable the actions and buttons used to enable the service in client mode without a remote host address.
 - Do not auto start the client app if there is no remote host set.