### PR TITLE
ci: Adjust back to main flatpak builder

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -377,7 +377,7 @@ jobs:
         run: flatpak-builder-lint manifest deploy/linux/flatpak/org.deskflow.deskflow.yml
 
       - name: Build
-        uses: flathub-infra/flatpak-github-actions/flatpak-builder@53987ffa5f687586936d85fdce3f440848bea04d
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: deskflow-${{env.DESKFLOW_PACKAGE_VERSION}}-linux-${{matrix.flatpak.arch}}.flatpak
           manifest-path: deploy/linux/flatpak/org.deskflow.deskflow.yml


### PR DESCRIPTION
The fork we use for the action is being absorbed back into the main project. This switches us back to the main action.
see: https://github.com/flathub-infra/flatpak-github-actions/issues/17 for more details