### PR TITLE
Save the host name if the lineEdit is not empty

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -697,7 +697,7 @@ void MainWindow::saveSettings()
   } else if (ui->rbModeServer->isChecked()) {
     Settings::setValue(Settings::Core::CoreMode, Settings::CoreMode::Server);
   }
-  if (!Settings::value(Settings::Client::RemoteHost).isNull())
+  if (!ui->lineHostname->text().isEmpty())
     Settings::setValue(Settings::Client::RemoteHost, ui->lineHostname->text());
   Settings::save();
 }


### PR DESCRIPTION
requires: https://github.com/deskflow/deskflow/pull/8519
fixes #8517

the previous logic would only save if the setting was already not empty, when we want to only save if the lineHostname is not empty
