### PR TITLE
ci: add osxSysroot to mac os14 job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -138,7 +138,6 @@ jobs:
           - name: "macos-14-arm64"
             runs-on: "macos-14"
             timeout: 10
-            arch: arm64
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64\" -DCMAKE_OSX_SYSROOT=/Applications/Xcode_15.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
             qt-install-dir: "/Users/runner"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -139,7 +139,7 @@ jobs:
             runs-on: "macos-14"
             timeout: 10
             arch: arm64
-            config-args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64\""
+            config-args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64\" -DCMAKE_OSX_SYSROOT=/Applications/Xcode_15.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
             qt-install-dir: "/Users/runner"
 
           - name: "macos-13-x64"


### PR DESCRIPTION
 - mac os 14 failed a few times missing libpthread to prevent this set the OSX-Sysroot like we do on macos-13
 - remove unused arch variable from the macos-14 ci job