### PR TITLE
fix: firstshown called on every re open

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -383,6 +383,9 @@ void MainWindow::firstShown()
       return;
     m_coreProcess.start();
   }
+
+  // Do not call firstshow for any more show events
+  disconnect(this, &MainWindow::shown, this, &MainWindow::firstShown);
 }
 
 void MainWindow::settingsChanged(const QString &key)


### PR DESCRIPTION
fixes #8522

#8522 was caused by it shown being connected to firstShown so we could : 
 1. Add more code that calls disconnect in firstShown
 2. Skip the connection and call firstShown once from the constructor
 3. Remove firstShown and just do the stuff in the constructor

I picked option 1, since 2 and 3 resulted in a new dialog being under the mainwindow