### PR TITLE
fix: incorrect paths for the server configs shown in help message

### DIFF
--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -13,7 +13,6 @@
 #include "base/Log.h"
 #include "base/Path.h"
 #include "base/TMethodEventJob.h"
-#include "common/Settings.h"
 #include "deskflow/App.h"
 #include "deskflow/ArgParser.h"
 #include "deskflow/Screen.h"
@@ -27,6 +26,9 @@
 #include "server/Config.h"
 #include "server/PrimaryClient.h"
 #include "server/Server.h"
+
+// must be before screen header includes
+#include <QFileInfo>
 
 #if SYSAPI_WIN32
 #include "arch/win32/ArchMiscWindows.h"
@@ -57,8 +59,6 @@
 #include "base/TMethodJob.h"
 #include "mt/Thread.h"
 #endif
-
-#include <QFileInfo>
 
 #include <fstream>
 #include <iostream>

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -135,9 +135,4 @@ private:
   ClientListener *m_listener;
   EventQueueTimer *m_timer;
   NetworkAddress *m_deskflowAddress;
-#if SYSAPI_WIN32
-  inline static const std::string CONFIG_NAME = std::string(kAppName) + ".sgc";
-#elif SYSAPI_UNIX
-  inline static const std::string CONFIG_NAME = std::string(kAppName) + ".conf";
-#endif
 };


### PR DESCRIPTION
Related to #8525 

When looking at the above i noticed the server configuration paths are completely wrong and the fallback is also wrong . It is safest to have the user provide them in the command like we do when running from the GUI / Daemon. 

 - No longer use a fallback for the server config
 - Adjust the help message
 - Remove redundant command
 - Update log level when config can't be loaded to `LOG_ERR`
 - Correct the include for `common/Settings.h` => `common/QSettingsProxy.h`
 - Remove unused `CONFIG_NAME` variable
