### PR TITLE
chore: remove unused TLSCertificate::getCertificatePath

### DIFF
--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -70,11 +70,6 @@ int TlsCertificate::getCertKeyLength(const QString &path)
   return deskflow::getCertLength(path.toStdString());
 }
 
-QString TlsCertificate::getCertificatePath() const
-{
-  return QStringLiteral("%1/%2").arg(Settings::tlsDir(), kTlsCertificateFilename);
-}
-
 bool TlsCertificate::isCertificateValid(const QString &path)
 {
   OpenSSL_add_all_algorithms();

--- a/src/lib/gui/tls/TlsCertificate.h
+++ b/src/lib/gui/tls/TlsCertificate.h
@@ -20,5 +20,4 @@ public:
   bool generateCertificate(const QString &path, int keyLength);
   bool generateFingerprint(const QString &certificateFilename);
   int getCertKeyLength(const QString &path);
-  QString getCertificatePath() const;
 };


### PR DESCRIPTION

 - remove unused `TLSCertificate::getCertificatePath()`
 
Any new code should use `Settings::tlsLocalDb()` for this path.