### PR TITLE
ensure client, server and core use correct setting path

### DIFF
--- a/src/apps/deskflow-client/deskflow-client.cpp
+++ b/src/apps/deskflow-client/deskflow-client.cpp
@@ -13,11 +13,16 @@
 
 #if SYSAPI_WIN32
 #include "arch/win32/ArchMiscWindows.h"
+#include <QCoreApplication>
 #endif
 
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  // HACK to make sure settings gets the correct qApp path
+  QCoreApplication m(argc, argv);
+  m.deleteLater();
+
   ArchMiscWindows::guardRuntimeVersion();
 
   // record window instance for tray icon, etc

--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -14,6 +14,7 @@
 
 #if SYSAPI_WIN32
 #include "arch/win32/ArchMiscWindows.h"
+#include <QCoreApplication>
 #endif
 
 #include <iostream>
@@ -39,6 +40,10 @@ bool isClient(int argc, char **argv)
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  // HACK to make sure settings gets the correct qApp path
+  QCoreApplication m(argc, argv);
+  m.deleteLater();
+
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
 #endif
 

--- a/src/apps/deskflow-server/deskflow-server.cpp
+++ b/src/apps/deskflow-server/deskflow-server.cpp
@@ -13,11 +13,16 @@
 
 #if SYSAPI_WIN32
 #include "arch/win32/ArchMiscWindows.h"
+#include <QCoreApplication>
 #endif
 
 int main(int argc, char **argv)
 {
 #if SYSAPI_WIN32
+  // HACK to make sure settings gets the correct qApp path
+  QCoreApplication m(argc, argv);
+  m.deleteLater();
+
   ArchMiscWindows::guardRuntimeVersion();
 
   // record window instance for tray icon, etc


### PR DESCRIPTION
fixes #8534

`deskflow-server`, `deskflow-core` and `deskflow-client` are not QApplications this causes the qApp used in our settings object to fallback to the default path and make the settings read from different paths (if not using the default one) 

To Fix this on windows only we make a QCoreApplication in each of them and delete it after , this is enough to initialize the qApp.

We should consider in the future making these apps use a QCoreApplication in place of the `App`
