### PR TITLE
docs: Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to Deskflow
+
+Thanks for your interest in contributing to Deskflow! We welcome all kinds of contributions — bug reports, feature suggestions, documentation improvements, and code.
+
+## Read the Full Guidelines
+
+To keep this repository clean and contribution-friendly, we've outlined our full contributing guidelines on the Deskflow Wiki:
+
+👉 [How to Contribute to Deskflow](https://github.com/deskflow/deskflow/wiki/Contributing)
+
+Please take a moment to read through the page before opening an issue or submitting a pull request.
+
+Thanks again for helping make Deskflow better!


### PR DESCRIPTION
Blocks: 
- https://github.com/DeepSourceCorp/good-first-issue/pull/2321

Adds a CONTRIBUTING.md file to the project root. I totally understand the preference to keep the root directory clean and normally I'd agree. However, GitHub requires CONTRIBUTING.md to be in the root in order to automatically show a “Contribute” prompt when someone opens a new issue or PR.

It also means we can be recognized by platforms like goodfirstissue.dev (https://github.com/DeepSourceCorp/good-first-issue?tab=readme-ov-file#adding-a-new-project:~:text=project%2C%20and%20a-,CONTRIBUTING.md,-with%20guidelines%20for), which requires the file to be in the root to detect a repo as contributor-friendly

The file itself is very lightweight, just a short intro and a link to our full guide on the wiki: https://github.com/deskflow/deskflow/wiki/Contributing

This keeps the root file tidy while still meeting the visibility requirements for tools and new contributors.

Let me know if you'd prefer any tweaks to keep it as non-intrusive as possible.