### PR TITLE
fix: add reuse info to **.md by default

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -43,13 +43,7 @@ SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = "README.md"
-precedence = "override"
-SPDX-FileCopyrightText = "Deskflow Developers"
-SPDX-License-Identifier = "MIT"
-
-[[annotations]]
-path = "SECURITY.md"
+path = "**/*.md"
 precedence = "override"
 SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
 - reuse lint is upset we landed a non reuse compliant md file 
 - rather then have ever md file trigger a rebuild we will auto assign `**/*.md` to MIT this is inline with our ci filter to not run on those files.