### PR TITLE
ci: use normal built in vcpkg cache

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -85,6 +85,20 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       uses: seanmiddleditch/gha-setup-ninja@master
 
+    - name: Export GitHub Actions cache environment variables
+      if: ${{ runner.os == 'Windows' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      #Set vcpkg binary sources to use GitHub Actions cache
+    - name: Set vcpkg binary sources
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite" >> $GITHUB_ENV
+      shell: bash
+
     - name: Build and cache vcpkg
       if: ${{ runner.os == 'Windows' }}
       id: vcpkg
@@ -94,7 +108,7 @@ runs:
         extra-args: --classic
         triplet: x64-windows-release
         token: ${{ github.token }}
-        github-binarycache: true
+        github-binarycache: false
 
     - name: Install Wix
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
 Attempt to fix #8539 