### PR TITLE
chore: Use override for override methods

### DIFF
--- a/src/lib/arch/Arch.h
+++ b/src/lib/arch/Arch.h
@@ -81,14 +81,14 @@ class Arch : public ARCH_CONSOLE,
 public:
   Arch();
   Arch(Arch *arch);
-  virtual ~Arch();
+  ~Arch() override;
 
   //! Call init on other arch classes.
   /*!
   Some arch classes depend on others to exist first. When init is called
   these classes will have ARCH available for use.
   */
-  virtual void init();
+  void init() override;
 
   //
   // accessors

--- a/src/lib/arch/ArchConsoleStd.h
+++ b/src/lib/arch/ArchConsoleStd.h
@@ -16,19 +16,19 @@ public:
   ArchConsoleStd()
   {
   }
-  virtual ~ArchConsoleStd()
+  ~ArchConsoleStd() override
   {
   }
 
   // IArchConsole overrides
-  virtual void openConsole(const char *title)
+  void openConsole(const char *title) override
   {
   }
-  virtual void closeConsole()
+  void closeConsole() override
   {
   }
-  virtual void showConsole(bool)
+  void showConsole(bool) override
   {
   }
-  virtual void writeConsole(ELevel level, const char *);
+  void writeConsole(ELevel level, const char *) override;
 };

--- a/src/lib/arch/ArchDaemonNone.h
+++ b/src/lib/arch/ArchDaemonNone.h
@@ -22,17 +22,17 @@ class ArchDaemonNone : public IArchDaemon
 {
 public:
   ArchDaemonNone();
-  virtual ~ArchDaemonNone();
+  ~ArchDaemonNone() override;
 
   // IArchDaemon overrides
-  virtual void installDaemon(
+  void installDaemon(
       const char *name, const char *description, const char *pathname, const char *commandLine, const char *dependencies
-  );
-  virtual void uninstallDaemon(const char *name);
-  virtual int daemonize(const char *name, DaemonFunc func);
-  virtual bool canInstallDaemon(const char *name);
-  virtual bool isDaemonInstalled(const char *name);
-  virtual void installDaemon();
-  virtual void uninstallDaemon();
-  virtual std::string commandLine() const;
+  ) override;
+  void uninstallDaemon(const char *name) override;
+  int daemonize(const char *name, DaemonFunc func) override;
+  bool canInstallDaemon(const char *name) override;
+  bool isDaemonInstalled(const char *name) override;
+  void installDaemon() override;
+  void uninstallDaemon() override;
+  std::string commandLine() const override;
 };

--- a/src/lib/arch/IArchString.h
+++ b/src/lib/arch/IArchString.h
@@ -24,7 +24,7 @@ public:
   IArchString() = default;
   IArchString(const IArchString &) = delete;
   IArchString(IArchString &&) = delete;
-  virtual ~IArchString();
+  ~IArchString() override;
 
   IArchString &operator=(const IArchString &) = delete;
   IArchString &operator=(IArchString &&) = delete;

--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -76,7 +76,7 @@ public:
   XArch(const std::string &msg) : std::runtime_error(msg)
   {
   }
-  virtual ~XArch() throw()
+  ~XArch() throw() override
   {
   }
 };

--- a/src/lib/arch/unix/ArchConsoleUnix.h
+++ b/src/lib/arch/unix/ArchConsoleUnix.h
@@ -15,5 +15,5 @@ class ArchConsoleUnix : public ArchConsoleStd
 {
 public:
   ArchConsoleUnix();
-  virtual ~ArchConsoleUnix();
+  ~ArchConsoleUnix() override;
 };

--- a/src/lib/arch/unix/ArchDaemonUnix.h
+++ b/src/lib/arch/unix/ArchDaemonUnix.h
@@ -17,8 +17,8 @@ class ArchDaemonUnix : public ArchDaemonNone
 {
 public:
   ArchDaemonUnix();
-  virtual ~ArchDaemonUnix();
+  ~ArchDaemonUnix() override;
 
   // IArchDaemon overrides
-  virtual int daemonize(const char *name, DaemonFunc func);
+  int daemonize(const char *name, DaemonFunc func) override;
 };

--- a/src/lib/arch/unix/ArchLogUnix.h
+++ b/src/lib/arch/unix/ArchLogUnix.h
@@ -16,11 +16,11 @@ class ArchLogUnix : public IArchLog
 {
 public:
   ArchLogUnix();
-  virtual ~ArchLogUnix();
+  ~ArchLogUnix() override;
 
   // IArchLog overrides
-  virtual void openLog(const char *name);
-  virtual void closeLog();
-  virtual void showLog(bool);
-  virtual void writeLog(ELevel, const char *);
+  void openLog(const char *name) override;
+  void closeLog() override;
+  void showLog(bool) override;
+  void writeLog(ELevel, const char *) override;
 };

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -33,7 +33,7 @@ public:
   ArchMultithreadPosix();
   ArchMultithreadPosix(ArchMultithreadPosix const &) = delete;
   ArchMultithreadPosix(ArchMultithreadPosix &&) = delete;
-  virtual ~ArchMultithreadPosix();
+  ~ArchMultithreadPosix() override;
 
   ArchMultithreadPosix &operator=(ArchMultithreadPosix const &) = delete;
   ArchMultithreadPosix &operator=(ArchMultithreadPosix &&) = delete;
@@ -54,29 +54,29 @@ public:
   //@}
 
   // IArchMultithread overrides
-  virtual ArchCond newCondVar();
-  virtual void closeCondVar(ArchCond);
-  virtual void signalCondVar(ArchCond);
-  virtual void broadcastCondVar(ArchCond);
-  virtual bool waitCondVar(ArchCond, ArchMutex, double timeout);
-  virtual ArchMutex newMutex();
-  virtual void closeMutex(ArchMutex);
-  virtual void lockMutex(ArchMutex);
-  virtual void unlockMutex(ArchMutex);
-  virtual ArchThread newThread(ThreadFunc, void *);
-  virtual ArchThread newCurrentThread();
-  virtual ArchThread copyThread(ArchThread);
-  virtual void closeThread(ArchThread);
-  virtual void cancelThread(ArchThread);
-  virtual void setPriorityOfThread(ArchThread, int n);
-  virtual void testCancelThread();
-  virtual bool wait(ArchThread, double timeout);
-  virtual bool isSameThread(ArchThread, ArchThread);
-  virtual bool isExitedThread(ArchThread);
-  virtual void *getResultOfThread(ArchThread);
-  virtual ThreadID getIDOfThread(ArchThread);
-  virtual void setSignalHandler(ESignal, SignalFunc, void *);
-  virtual void raiseSignal(ESignal);
+  ArchCond newCondVar() override;
+  void closeCondVar(ArchCond) override;
+  void signalCondVar(ArchCond) override;
+  void broadcastCondVar(ArchCond) override;
+  bool waitCondVar(ArchCond, ArchMutex, double timeout) override;
+  ArchMutex newMutex() override;
+  void closeMutex(ArchMutex) override;
+  void lockMutex(ArchMutex) override;
+  void unlockMutex(ArchMutex) override;
+  ArchThread newThread(ThreadFunc, void *) override;
+  ArchThread newCurrentThread() override;
+  ArchThread copyThread(ArchThread) override;
+  void closeThread(ArchThread) override;
+  void cancelThread(ArchThread) override;
+  void setPriorityOfThread(ArchThread, int n) override;
+  void testCancelThread() override;
+  bool wait(ArchThread, double timeout) override;
+  bool isSameThread(ArchThread, ArchThread) override;
+  bool isExitedThread(ArchThread) override;
+  void *getResultOfThread(ArchThread) override;
+  ThreadID getIDOfThread(ArchThread) override;
+  void setSignalHandler(ESignal, SignalFunc, void *) override;
+  void raiseSignal(ESignal) override;
 
 private:
   void startSignalHandler();

--- a/src/lib/arch/unix/ArchSleepUnix.h
+++ b/src/lib/arch/unix/ArchSleepUnix.h
@@ -16,8 +16,8 @@ class ArchSleepUnix : public IArchSleep
 {
 public:
   ArchSleepUnix();
-  virtual ~ArchSleepUnix();
+  ~ArchSleepUnix() override;
 
   // IArchSleep overrides
-  virtual void sleep(double timeout);
+  void sleep(double timeout) override;
 };

--- a/src/lib/arch/unix/ArchStringUnix.h
+++ b/src/lib/arch/unix/ArchStringUnix.h
@@ -16,8 +16,8 @@ class ArchStringUnix : public IArchString
 {
 public:
   ArchStringUnix();
-  virtual ~ArchStringUnix();
+  ~ArchStringUnix() override;
 
   // IArchString overrides
-  virtual EWideCharEncoding getWideCharEncoding();
+  EWideCharEncoding getWideCharEncoding() override;
 };

--- a/src/lib/arch/unix/ArchTimeUnix.h
+++ b/src/lib/arch/unix/ArchTimeUnix.h
@@ -16,8 +16,8 @@ class ArchTimeUnix : public IArchTime
 {
 public:
   ArchTimeUnix();
-  virtual ~ArchTimeUnix();
+  ~ArchTimeUnix() override;
 
   // IArchTime overrides
-  virtual double time();
+  double time() override;
 };

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -16,11 +16,11 @@ public:
   XArchEvalUnix(int error) : m_error(error)
   {
   }
-  virtual ~XArchEvalUnix() throw()
+  ~XArchEvalUnix() throw() override
   {
   }
 
-  virtual std::string eval() const;
+  std::string eval() const override;
 
 private:
   int m_error;

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -30,29 +30,29 @@ public:
   EventQueue();
   EventQueue(EventQueue const &) = delete;
   EventQueue(EventQueue &&) = delete;
-  virtual ~EventQueue();
+  ~EventQueue() override;
   EventQueue &operator=(EventQueue const &) = delete;
   EventQueue &operator=(EventQueue &&) = delete;
 
   // IEventQueue overrides
-  virtual void loop();
-  virtual void adoptBuffer(IEventQueueBuffer *);
-  virtual bool getEvent(Event &event, double timeout = -1.0);
-  virtual bool dispatchEvent(const Event &event);
-  virtual void addEvent(const Event &event);
-  virtual EventQueueTimer *newTimer(double duration, void *target);
-  virtual EventQueueTimer *newOneShotTimer(double duration, void *target);
-  virtual void deleteTimer(EventQueueTimer *);
-  virtual void adoptHandler(Event::Type type, void *target, IEventJob *handler);
-  virtual void removeHandler(Event::Type type, void *target);
-  virtual void removeHandlers(void *target);
-  virtual Event::Type registerTypeOnce(Event::Type &type, const char *name);
-  virtual bool isEmpty() const;
-  virtual IEventJob *getHandler(Event::Type type, void *target) const;
-  virtual const char *getTypeName(Event::Type type);
-  virtual Event::Type getRegisteredType(const std::string &name) const;
-  void *getSystemTarget();
-  virtual void waitForReady() const;
+  void loop() override;
+  void adoptBuffer(IEventQueueBuffer *) override;
+  bool getEvent(Event &event, double timeout = -1.0) override;
+  bool dispatchEvent(const Event &event) override;
+  void addEvent(const Event &event) override;
+  EventQueueTimer *newTimer(double duration, void *target) override;
+  EventQueueTimer *newOneShotTimer(double duration, void *target) override;
+  void deleteTimer(EventQueueTimer *) override;
+  void adoptHandler(Event::Type type, void *target, IEventJob *handler) override;
+  void removeHandler(Event::Type type, void *target) override;
+  void removeHandlers(void *target) override;
+  Event::Type registerTypeOnce(Event::Type &type, const char *name) override;
+  bool isEmpty() const override;
+  IEventJob *getHandler(Event::Type type, void *target) const override;
+  const char *getTypeName(Event::Type type) override;
+  Event::Type getRegisteredType(const std::string &name) const override;
+  void *getSystemTarget() override;
+  void waitForReady() const override;
 
 private:
   uint32_t saveEvent(const Event &event);
@@ -126,23 +126,23 @@ public:
   //
   // Event type providers.
   //
-  ClientEvents &forClient();
-  IStreamEvents &forIStream();
-  IDataSocketEvents &forIDataSocket();
-  IListenSocketEvents &forIListenSocket();
-  ISocketEvents &forISocket();
-  OSXScreenEvents &forOSXScreen();
-  ClientListenerEvents &forClientListener();
-  ClientProxyEvents &forClientProxy();
-  ClientProxyUnknownEvents &forClientProxyUnknown();
-  ServerEvents &forServer();
-  ServerAppEvents &forServerApp();
-  IKeyStateEvents &forIKeyState();
-  IPrimaryScreenEvents &forIPrimaryScreen();
-  IScreenEvents &forIScreen();
-  ClipboardEvents &forClipboard();
-  FileEvents &forFile();
-  EiEvents &forEi();
+  ClientEvents &forClient() override;
+  IStreamEvents &forIStream() override;
+  IDataSocketEvents &forIDataSocket() override;
+  IListenSocketEvents &forIListenSocket() override;
+  ISocketEvents &forISocket() override;
+  OSXScreenEvents &forOSXScreen() override;
+  ClientListenerEvents &forClientListener() override;
+  ClientProxyEvents &forClientProxy() override;
+  ClientProxyUnknownEvents &forClientProxyUnknown() override;
+  ServerEvents &forServer() override;
+  ServerAppEvents &forServerApp() override;
+  IKeyStateEvents &forIKeyState() override;
+  IPrimaryScreenEvents &forIPrimaryScreen() override;
+  IScreenEvents &forIScreen() override;
+  ClipboardEvents &forClipboard() override;
+  FileEvents &forFile() override;
+  EiEvents &forEi() override;
 
 private:
   ClientEvents *m_typesForClient;

--- a/src/lib/base/FunctionEventJob.h
+++ b/src/lib/base/FunctionEventJob.h
@@ -18,10 +18,10 @@ class FunctionEventJob : public IEventJob
 public:
   //! run() invokes \c func(arg)
   FunctionEventJob(void (*func)(const Event &, void *), void *arg = NULL);
-  virtual ~FunctionEventJob();
+  ~FunctionEventJob() override;
 
   // IEventJob overrides
-  virtual void run(const Event &);
+  void run(const Event &) override;
 
 private:
   void (*m_func)(const Event &, void *);

--- a/src/lib/base/FunctionJob.h
+++ b/src/lib/base/FunctionJob.h
@@ -18,10 +18,10 @@ class FunctionJob : public IJob
 public:
   //! run() invokes \c func(arg)
   FunctionJob(void (*func)(void *), void *arg = NULL);
-  virtual ~FunctionJob();
+  ~FunctionJob() override;
 
   // IJob overrides
-  virtual void run();
+  void run() override;
 
 private:
   void (*m_func)(void *);

--- a/src/lib/base/LogOutputters.h
+++ b/src/lib/base/LogOutputters.h
@@ -22,13 +22,13 @@ class StopLogOutputter : public ILogOutputter
 {
 public:
   StopLogOutputter();
-  virtual ~StopLogOutputter();
+  ~StopLogOutputter() override;
 
   // ILogOutputter overrides
-  virtual void open(const char *title);
-  virtual void close();
-  virtual void show(bool showIfEmpty);
-  virtual bool write(ELevel level, const char *message);
+  void open(const char *title) override;
+  void close() override;
+  void show(bool showIfEmpty) override;
+  bool write(ELevel level, const char *message) override;
 };
 
 //! Write log to console
@@ -40,14 +40,14 @@ class ConsoleLogOutputter : public ILogOutputter
 {
 public:
   ConsoleLogOutputter();
-  virtual ~ConsoleLogOutputter();
+  ~ConsoleLogOutputter() override;
 
   // ILogOutputter overrides
-  virtual void open(const char *title);
-  virtual void close();
-  virtual void show(bool showIfEmpty);
-  virtual bool write(ELevel level, const char *message);
-  virtual void flush();
+  void open(const char *title) override;
+  void close() override;
+  void show(bool showIfEmpty) override;
+  bool write(ELevel level, const char *message) override;
+  void flush();
 };
 
 //! Write log to file
@@ -60,13 +60,13 @@ class FileLogOutputter : public ILogOutputter
 {
 public:
   FileLogOutputter(const char *logFile);
-  virtual ~FileLogOutputter();
+  ~FileLogOutputter() override;
 
   // ILogOutputter overrides
-  virtual void open(const char *title);
-  virtual void close();
-  virtual void show(bool showIfEmpty);
-  virtual bool write(ELevel level, const char *message);
+  void open(const char *title) override;
+  void close() override;
+  void show(bool showIfEmpty) override;
+  bool write(ELevel level, const char *message) override;
 
   void setLogFilename(const char *title);
 
@@ -82,13 +82,13 @@ class SystemLogOutputter : public ILogOutputter
 {
 public:
   SystemLogOutputter();
-  virtual ~SystemLogOutputter();
+  ~SystemLogOutputter() override;
 
   // ILogOutputter overrides
-  virtual void open(const char *title);
-  virtual void close();
-  virtual void show(bool showIfEmpty);
-  virtual bool write(ELevel level, const char *message);
+  void open(const char *title) override;
+  void close() override;
+  void show(bool showIfEmpty) override;
+  bool write(ELevel level, const char *message) override;
 };
 
 //! Write log to system log only

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -21,21 +21,21 @@ public:
   SimpleEventQueueBuffer();
   SimpleEventQueueBuffer(SimpleEventQueueBuffer const &) = delete;
   SimpleEventQueueBuffer(SimpleEventQueueBuffer &&) = delete;
-  ~SimpleEventQueueBuffer();
+  ~SimpleEventQueueBuffer() override;
 
   SimpleEventQueueBuffer &operator=(SimpleEventQueueBuffer const &) = delete;
   SimpleEventQueueBuffer &operator=(SimpleEventQueueBuffer &&) = delete;
 
   // IEventQueueBuffer overrides
-  void init()
+  void init() override
   {
   }
-  virtual void waitForEvent(double timeout);
-  virtual Type getEvent(Event &event, uint32_t &dataID);
-  virtual bool addEvent(uint32_t dataID);
-  virtual bool isEmpty() const;
-  virtual EventQueueTimer *newTimer(double duration, bool oneShot) const;
-  virtual void deleteTimer(EventQueueTimer *) const;
+  void waitForEvent(double timeout) override;
+  Type getEvent(Event &event, uint32_t &dataID) override;
+  bool addEvent(uint32_t dataID) override;
+  bool isEmpty() const override;
+  EventQueueTimer *newTimer(double duration, bool oneShot) const override;
+  void deleteTimer(EventQueueTimer *) const override;
 
 private:
   using EventDeque = std::deque<uint32_t>;

--- a/src/lib/base/TMethodEventJob.h
+++ b/src/lib/base/TMethodEventJob.h
@@ -18,10 +18,10 @@ template <class T> class TMethodEventJob : public IEventJob
 public:
   //! run(event) invokes \c object->method(event, arg)
   TMethodEventJob(T *object, void (T::*method)(const Event &, void *), void *arg = NULL);
-  virtual ~TMethodEventJob();
+  ~TMethodEventJob() override;
 
   // IJob overrides
-  virtual void run(const Event &);
+  void run(const Event &) override;
 
 private:
   T *m_object;

--- a/src/lib/base/TMethodJob.h
+++ b/src/lib/base/TMethodJob.h
@@ -18,10 +18,10 @@ template <class T> class TMethodJob : public IJob
 public:
   //! run() invokes \c object->method(arg)
   TMethodJob(T *object, void (T::*method)(void *), void *arg = NULL);
-  virtual ~TMethodJob();
+  ~TMethodJob() override;
 
   // IJob overrides
-  virtual void run();
+  void run() override;
 
 private:
   T *m_object;

--- a/src/lib/base/XBase.h
+++ b/src/lib/base/XBase.h
@@ -21,10 +21,10 @@ public:
   XBase();
   //! Use \c msg as the result of what()
   XBase(const std::string &msg);
-  virtual ~XBase() throw();
+  ~XBase() throw() override;
 
   //! Reason for exception
-  virtual const char *what() const throw();
+  const char *what() const throw() override;
 
 protected:
   //! Get a human readable string describing the exception

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -63,7 +63,7 @@ public:
   );
   Client(Client const &) = delete;
   Client(Client &&) = delete;
-  ~Client();
+  ~Client() override;
 
   Client &operator=(Client const &) = delete;
   Client &operator=(Client &&) = delete;
@@ -160,29 +160,29 @@ public:
   //@}
 
   // IScreen overrides
-  virtual void *getEventTarget() const;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const;
+  void *getEventTarget() const override;
+  bool getClipboard(ClipboardID id, IClipboard *) const override;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override;
+  void getCursorPos(int32_t &x, int32_t &y) const override;
 
   // IClient overrides
-  virtual void enter(int32_t xAbs, int32_t yAbs, uint32_t seqNum, KeyModifierMask mask, bool forScreensaver);
-  virtual bool leave();
-  virtual void setClipboard(ClipboardID, const IClipboard *);
-  virtual void grabClipboard(ClipboardID);
-  virtual void setClipboardDirty(ClipboardID, bool);
-  virtual void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &);
-  virtual void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &lang);
-  virtual void keyUp(KeyID, KeyModifierMask, KeyButton);
-  virtual void mouseDown(ButtonID);
-  virtual void mouseUp(ButtonID);
-  virtual void mouseMove(int32_t xAbs, int32_t yAbs);
-  virtual void mouseRelativeMove(int32_t xRel, int32_t yRel);
-  virtual void mouseWheel(int32_t xDelta, int32_t yDelta);
-  virtual void screensaver(bool activate);
-  virtual void resetOptions();
-  virtual void setOptions(const OptionsList &options);
-  virtual std::string getName() const;
+  void enter(int32_t xAbs, int32_t yAbs, uint32_t seqNum, KeyModifierMask mask, bool forScreensaver) override;
+  bool leave() override;
+  void setClipboard(ClipboardID, const IClipboard *) override;
+  void grabClipboard(ClipboardID) override;
+  void setClipboardDirty(ClipboardID, bool) override;
+  void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &) override;
+  void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &lang) override;
+  void keyUp(KeyID, KeyModifierMask, KeyButton) override;
+  void mouseDown(ButtonID) override;
+  void mouseUp(ButtonID) override;
+  void mouseMove(int32_t xAbs, int32_t yAbs) override;
+  void mouseRelativeMove(int32_t xRel, int32_t yRel) override;
+  void mouseWheel(int32_t xDelta, int32_t yDelta) override;
+  void screensaver(bool activate) override;
+  void resetOptions() override;
+  void setOptions(const OptionsList &options) override;
+  std::string getName() const override;
 
 private:
   void sendClipboard(ClipboardID);

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -137,7 +137,7 @@ private:
   explicit Settings(QObject *parent = nullptr);
   Settings *operator=(Settings &other) = delete;
   Settings(const Settings &other) = delete;
-  ~Settings() = default;
+  ~Settings() override = default;
   void cleanSettings();
 
   QSettings *m_settings = nullptr;

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -43,7 +43,7 @@ public:
   App(IEventQueue *events, deskflow::ArgsBase *args);
   App(App const &) = delete;
   App(App &&) = delete;
-  virtual ~App();
+  ~App() override;
 
   App &operator=(App const &) = delete;
   App &operator=(App &&) = delete;
@@ -56,15 +56,15 @@ public:
   virtual std::string configSection() const = 0;
 
   virtual void version();
-  virtual void setByeFunc(void (*bye)(int))
+  void setByeFunc(void (*bye)(int)) override
   {
     m_bye = bye;
   }
-  virtual void bye(int error)
+  void bye(int error) override
   {
     m_bye(error);
   }
-  virtual IEventQueue *getEvents() const
+  IEventQueue *getEvents() const override
   {
     return m_events;
   }
@@ -73,7 +73,7 @@ public:
   {
     return m_appUtil;
   }
-  deskflow::ArgsBase &argsBase() const
+  deskflow::ArgsBase &argsBase() const override
   {
     return *m_args;
   }
@@ -81,7 +81,7 @@ public:
   int daemonMainLoop(int, const char **);
   void setupFileLogging();
   void loggingFilterWarning();
-  void initApp(int argc, const char **argv);
+  void initApp(int argc, const char **argv) override;
   void initApp(int argc, char **argv)
   {
     initApp(argc, (const char **)argv);
@@ -126,20 +126,20 @@ class MinimalApp : public App
 {
 public:
   MinimalApp();
-  virtual ~MinimalApp();
+  ~MinimalApp() override;
 
   // IApp overrides
-  virtual int standardStartup(int argc, char **argv) override;
-  virtual int runInner(int argc, char **argv, StartupFunc startup) override;
-  virtual void startNode() override;
-  virtual int mainLoop() override;
-  virtual int foregroundStartup(int argc, char **argv) override;
-  virtual deskflow::Screen *createScreen() override;
-  virtual void loadConfig() override;
-  virtual bool loadConfig(const std::string &pathname) override;
-  virtual const char *daemonInfo() const override;
-  virtual const char *daemonName() const override;
-  virtual void parseArgs(int argc, const char *const *argv) override;
+  int standardStartup(int argc, char **argv) override;
+  int runInner(int argc, char **argv, StartupFunc startup) override;
+  void startNode() override;
+  int mainLoop() override;
+  int foregroundStartup(int argc, char **argv) override;
+  deskflow::Screen *createScreen() override;
+  void loadConfig() override;
+  bool loadConfig(const std::string &pathname) override;
+  const char *daemonInfo() const override;
+  const char *daemonName() const override;
+  void parseArgs(int argc, const char *const *argv) override;
 
   //
   // App overrides

--- a/src/lib/deskflow/AppUtil.h
+++ b/src/lib/deskflow/AppUtil.h
@@ -14,10 +14,10 @@ class AppUtil : public IAppUtil
 {
 public:
   AppUtil();
-  virtual ~AppUtil();
+  ~AppUtil() override;
 
-  virtual void adoptApp(IApp *app);
-  IApp &app() const;
+  void adoptApp(IApp *app) override;
+  IApp &app() const override;
   virtual void exitApp(int code)
   {
     throw XExitApp(code);

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -24,7 +24,7 @@ class ClientApp : public App
 {
 public:
   ClientApp(IEventQueue *events);
-  virtual ~ClientApp();
+  ~ClientApp() override;
 
   //
   // IApp overrides

--- a/src/lib/deskflow/Clipboard.h
+++ b/src/lib/deskflow/Clipboard.h
@@ -17,7 +17,7 @@ class Clipboard : public IClipboard
 {
 public:
   Clipboard();
-  virtual ~Clipboard();
+  ~Clipboard() override;
 
   //! @name manipulators
   //@{
@@ -43,13 +43,13 @@ public:
   //@}
 
   // IClipboard overrides
-  virtual bool empty();
-  virtual void add(EFormat, const std::string &data);
-  virtual bool open(Time) const;
-  virtual void close() const;
-  virtual Time getTime() const;
-  virtual bool has(EFormat) const;
-  virtual std::string get(EFormat) const;
+  bool empty() override;
+  void add(EFormat, const std::string &data) override;
+  bool open(Time) const override;
+  void close() const override;
+  Time getTime() const override;
+  bool has(EFormat) const override;
+  std::string get(EFormat) const override;
 
 private:
   mutable bool m_open;

--- a/src/lib/deskflow/IClient.h
+++ b/src/lib/deskflow/IClient.h
@@ -156,8 +156,8 @@ public:
   //@}
 
   // IScreen overrides
-  virtual void *getEventTarget() const = 0;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const = 0;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const = 0;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const = 0;
+  void *getEventTarget() const override = 0;
+  bool getClipboard(ClipboardID id, IClipboard *) const override = 0;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override = 0;
+  void getCursorPos(int32_t &x, int32_t &y) const override = 0;
 };

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -150,44 +150,44 @@ public:
   //@}
 
   // IScreen overrides
-  virtual void *getEventTarget() const = 0;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const = 0;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const = 0;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const = 0;
+  void *getEventTarget() const override = 0;
+  bool getClipboard(ClipboardID id, IClipboard *) const override = 0;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override = 0;
+  void getCursorPos(int32_t &x, int32_t &y) const override = 0;
 
   // IPrimaryScreen overrides
-  virtual void reconfigure(uint32_t activeSides) = 0;
-  virtual void warpCursor(int32_t x, int32_t y) = 0;
-  virtual uint32_t registerHotKey(KeyID key, KeyModifierMask mask) = 0;
-  virtual void unregisterHotKey(uint32_t id) = 0;
-  virtual void fakeInputBegin() = 0;
-  virtual void fakeInputEnd() = 0;
-  virtual int32_t getJumpZoneSize() const = 0;
-  virtual bool isAnyMouseButtonDown(uint32_t &buttonID) const = 0;
-  virtual void getCursorCenter(int32_t &x, int32_t &y) const = 0;
+  void reconfigure(uint32_t activeSides) override = 0;
+  void warpCursor(int32_t x, int32_t y) override = 0;
+  uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override = 0;
+  void unregisterHotKey(uint32_t id) override = 0;
+  void fakeInputBegin() override = 0;
+  void fakeInputEnd() override = 0;
+  int32_t getJumpZoneSize() const override = 0;
+  bool isAnyMouseButtonDown(uint32_t &buttonID) const override = 0;
+  void getCursorCenter(int32_t &x, int32_t &y) const override = 0;
 
   // ISecondaryScreen overrides
-  virtual void fakeMouseButton(ButtonID id, bool press) = 0;
-  virtual void fakeMouseMove(int32_t x, int32_t y) = 0;
-  virtual void fakeMouseRelativeMove(int32_t dx, int32_t dy) const = 0;
-  virtual void fakeMouseWheel(int32_t xDelta, int32_t yDelta) const = 0;
+  void fakeMouseButton(ButtonID id, bool press) override = 0;
+  void fakeMouseMove(int32_t x, int32_t y) override = 0;
+  void fakeMouseRelativeMove(int32_t dx, int32_t dy) const override = 0;
+  void fakeMouseWheel(int32_t xDelta, int32_t yDelta) const override = 0;
 
   // IKeyState overrides
-  virtual void updateKeyMap() = 0;
-  virtual void updateKeyState() = 0;
-  virtual void setHalfDuplexMask(KeyModifierMask) = 0;
-  virtual void fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &lang) = 0;
-  virtual bool
-  fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang) = 0;
-  virtual bool fakeKeyUp(KeyButton button) = 0;
-  virtual void fakeAllKeysUp() = 0;
-  virtual bool fakeCtrlAltDel() = 0;
-  virtual bool fakeMediaKey(KeyID id);
-  virtual bool isKeyDown(KeyButton) const = 0;
-  virtual KeyModifierMask getActiveModifiers() const = 0;
-  virtual KeyModifierMask pollActiveModifiers() const = 0;
-  virtual int32_t pollActiveGroup() const = 0;
-  virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const = 0;
+  void updateKeyMap() override = 0;
+  void updateKeyState() override = 0;
+  void setHalfDuplexMask(KeyModifierMask) override = 0;
+  void fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &lang) override = 0;
+  bool
+  fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang) override = 0;
+  bool fakeKeyUp(KeyButton button) override = 0;
+  void fakeAllKeysUp() override = 0;
+  bool fakeCtrlAltDel() override = 0;
+  bool fakeMediaKey(KeyID id) override;
+  bool isKeyDown(KeyButton) const override = 0;
+  KeyModifierMask getActiveModifiers() const override = 0;
+  KeyModifierMask pollActiveModifiers() const override = 0;
+  int32_t pollActiveGroup() const override = 0;
+  void pollPressedKeys(KeyButtonSet &pressedKeys) const override = 0;
 
   virtual std::string &getDraggingFilename() = 0;
   virtual void clearDraggingFilename() = 0;

--- a/src/lib/deskflow/KeyState.h
+++ b/src/lib/deskflow/KeyState.h
@@ -20,7 +20,7 @@ class KeyState : public IKeyState
 public:
   KeyState(IEventQueue *events, std::vector<std::string> layouts, bool isLangSyncEnabled);
   KeyState(IEventQueue *events, deskflow::KeyMap &keyMap, std::vector<std::string> layouts, bool isLangSyncEnabled);
-  virtual ~KeyState();
+  ~KeyState() override;
 
   //! @name manipulators
   //@{
@@ -67,10 +67,10 @@ public:
   bool isKeyDown(KeyButton) const override;
   KeyModifierMask getActiveModifiers() const override;
   // Left abstract
-  virtual bool fakeCtrlAltDel() override = 0;
-  virtual KeyModifierMask pollActiveModifiers() const override = 0;
-  virtual int32_t pollActiveGroup() const override = 0;
-  virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const override = 0;
+  bool fakeCtrlAltDel() override = 0;
+  KeyModifierMask pollActiveModifiers() const override = 0;
+  int32_t pollActiveGroup() const override = 0;
+  void pollPressedKeys(KeyButtonSet &pressedKeys) const override = 0;
 
   int32_t getKeyState(KeyButton keyButton)
   {

--- a/src/lib/deskflow/PacketStreamFilter.h
+++ b/src/lib/deskflow/PacketStreamFilter.h
@@ -21,19 +21,19 @@ class PacketStreamFilter : public StreamFilter
 {
 public:
   PacketStreamFilter(IEventQueue *events, deskflow::IStream *stream, bool adoptStream = true);
-  ~PacketStreamFilter();
+  ~PacketStreamFilter() override;
 
   // IStream overrides
-  virtual void close();
-  virtual uint32_t read(void *buffer, uint32_t n);
-  virtual void write(const void *buffer, uint32_t n);
-  virtual void shutdownInput();
-  virtual bool isReady() const;
-  virtual uint32_t getSize() const;
+  void close() override;
+  uint32_t read(void *buffer, uint32_t n) override;
+  void write(const void *buffer, uint32_t n) override;
+  void shutdownInput() override;
+  bool isReady() const override;
+  uint32_t getSize() const override;
 
 protected:
   // StreamFilter overrides
-  virtual void filterEvent(const Event &);
+  void filterEvent(const Event &) override;
 
 private:
   bool isReadyNoLock() const;

--- a/src/lib/deskflow/PlatformScreen.h
+++ b/src/lib/deskflow/PlatformScreen.h
@@ -25,84 +25,84 @@ public:
   PlatformScreen(
       IEventQueue *events, deskflow::ClientScrollDirection scrollDirection = deskflow::ClientScrollDirection::SERVER
   );
-  virtual ~PlatformScreen();
+  ~PlatformScreen() override;
 
   // IScreen overrides
-  virtual void *getEventTarget() const = 0;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const = 0;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const = 0;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const = 0;
+  void *getEventTarget() const override = 0;
+  bool getClipboard(ClipboardID id, IClipboard *) const override = 0;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override = 0;
+  void getCursorPos(int32_t &x, int32_t &y) const override = 0;
 
   // IPrimaryScreen overrides
-  virtual void reconfigure(uint32_t activeSides) = 0;
-  virtual void warpCursor(int32_t x, int32_t y) = 0;
-  virtual uint32_t registerHotKey(KeyID key, KeyModifierMask mask) = 0;
-  virtual void unregisterHotKey(uint32_t id) = 0;
-  virtual void fakeInputBegin() = 0;
-  virtual void fakeInputEnd() = 0;
-  virtual int32_t getJumpZoneSize() const = 0;
-  virtual bool isAnyMouseButtonDown(uint32_t &buttonID) const = 0;
-  virtual void getCursorCenter(int32_t &x, int32_t &y) const = 0;
+  void reconfigure(uint32_t activeSides) override = 0;
+  void warpCursor(int32_t x, int32_t y) override = 0;
+  uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override = 0;
+  void unregisterHotKey(uint32_t id) override = 0;
+  void fakeInputBegin() override = 0;
+  void fakeInputEnd() override = 0;
+  int32_t getJumpZoneSize() const override = 0;
+  bool isAnyMouseButtonDown(uint32_t &buttonID) const override = 0;
+  void getCursorCenter(int32_t &x, int32_t &y) const override = 0;
 
   // ISecondaryScreen overrides
-  virtual void fakeMouseButton(ButtonID id, bool press) = 0;
-  virtual void fakeMouseMove(int32_t x, int32_t y) = 0;
-  virtual void fakeMouseRelativeMove(int32_t dx, int32_t dy) const = 0;
-  virtual void fakeMouseWheel(int32_t xDelta, int32_t yDelta) const = 0;
+  void fakeMouseButton(ButtonID id, bool press) override = 0;
+  void fakeMouseMove(int32_t x, int32_t y) override = 0;
+  void fakeMouseRelativeMove(int32_t dx, int32_t dy) const override = 0;
+  void fakeMouseWheel(int32_t xDelta, int32_t yDelta) const override = 0;
 
   // IKeyState overrides
-  virtual void updateKeyMap();
-  virtual void updateKeyState();
-  virtual void setHalfDuplexMask(KeyModifierMask);
-  virtual void fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &);
-  virtual bool fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang);
-  virtual bool fakeKeyUp(KeyButton button);
-  virtual void fakeAllKeysUp();
-  virtual bool fakeCtrlAltDel();
-  virtual bool isKeyDown(KeyButton) const;
-  virtual KeyModifierMask getActiveModifiers() const;
-  virtual KeyModifierMask pollActiveModifiers() const;
-  virtual int32_t pollActiveGroup() const;
-  virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const;
+  void updateKeyMap() override;
+  void updateKeyState() override;
+  void setHalfDuplexMask(KeyModifierMask) override;
+  void fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &) override;
+  bool fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang) override;
+  bool fakeKeyUp(KeyButton button) override;
+  void fakeAllKeysUp() override;
+  bool fakeCtrlAltDel() override;
+  bool isKeyDown(KeyButton) const override;
+  KeyModifierMask getActiveModifiers() const override;
+  KeyModifierMask pollActiveModifiers() const override;
+  int32_t pollActiveGroup() const override;
+  void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
 
-  virtual void setDraggingStarted(bool started)
+  void setDraggingStarted(bool started) override
   {
     m_draggingStarted = started;
   }
-  virtual bool isDraggingStarted();
-  virtual bool isFakeDraggingStarted()
+  bool isDraggingStarted() override;
+  bool isFakeDraggingStarted() override
   {
     return m_fakeDraggingStarted;
   }
-  virtual std::string &getDraggingFilename()
+  std::string &getDraggingFilename() override
   {
     return m_draggingFilename;
   }
-  virtual void clearDraggingFilename()
+  void clearDraggingFilename() override
   {
   }
 
   // IPlatformScreen overrides
-  virtual void enable() = 0;
-  virtual void disable() = 0;
-  virtual void enter() = 0;
-  virtual bool canLeave() = 0;
-  virtual void leave() = 0;
-  virtual bool setClipboard(ClipboardID, const IClipboard *) = 0;
-  virtual void checkClipboards() = 0;
-  virtual void openScreensaver(bool notify) = 0;
-  virtual void closeScreensaver() = 0;
-  virtual void screensaver(bool activate) = 0;
-  virtual void resetOptions() = 0;
-  virtual void setOptions(const OptionsList &options) = 0;
-  virtual void setSequenceNumber(uint32_t) = 0;
-  virtual bool isPrimary() const = 0;
+  void enable() override = 0;
+  void disable() override = 0;
+  void enter() override = 0;
+  bool canLeave() override = 0;
+  void leave() override = 0;
+  bool setClipboard(ClipboardID, const IClipboard *) override = 0;
+  void checkClipboards() override = 0;
+  void openScreensaver(bool notify) override = 0;
+  void closeScreensaver() override = 0;
+  void screensaver(bool activate) override = 0;
+  void resetOptions() override = 0;
+  void setOptions(const OptionsList &options) override = 0;
+  void setSequenceNumber(uint32_t) override = 0;
+  bool isPrimary() const override = 0;
 
-  virtual void fakeDraggingFiles(DragFileList fileList)
+  void fakeDraggingFiles(DragFileList fileList) override
   {
     throw std::runtime_error("fakeDraggingFiles not implemented");
   }
-  virtual const std::string &getDropTarget() const
+  const std::string &getDropTarget() const override
   {
     throw std::runtime_error("getDropTarget not implemented");
   }
@@ -123,7 +123,7 @@ protected:
   virtual IKeyState *getKeyState() const = 0;
 
   // IPlatformScreen overrides
-  virtual void handleSystemEvent(const Event &event, void *) = 0;
+  void handleSystemEvent(const Event &event, void *) override = 0;
 
   /*!
    * \brief mapClientScrollDirection

--- a/src/lib/deskflow/ProtocolUtil.h
+++ b/src/lib/deskflow/ProtocolUtil.h
@@ -102,5 +102,5 @@ class XIOReadMismatch : public XIO
 {
 public:
   // XBase overrides
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 };

--- a/src/lib/deskflow/Screen.h
+++ b/src/lib/deskflow/Screen.h
@@ -31,7 +31,7 @@ public:
   Screen(IPlatformScreen *platformScreen, IEventQueue *events);
   Screen(Screen const &) = delete;
   Screen(Screen &&) = delete;
-  virtual ~Screen();
+  ~Screen() override;
 
   Screen &operator&(Screen const &) = delete;
   Screen &operator&(Screen &&) = delete;
@@ -297,10 +297,10 @@ public:
   //@}
 
   // IScreen overrides
-  virtual void *getEventTarget() const;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const;
+  void *getEventTarget() const override;
+  bool getClipboard(ClipboardID id, IClipboard *) const override;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override;
+  void getCursorPos(int32_t &x, int32_t &y) const override;
 
   IPlatformScreen *getPlatformScreen()
   {

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -46,7 +46,7 @@ class ServerApp : public App
 
 public:
   ServerApp(IEventQueue *events);
-  virtual ~ServerApp();
+  ~ServerApp() override;
 
   //
   // IApp overrides

--- a/src/lib/deskflow/XDeskflow.h
+++ b/src/lib/deskflow/XDeskflow.h
@@ -50,7 +50,7 @@ public:
   //@}
 
 protected:
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   int m_major;
@@ -66,7 +66,7 @@ class XDuplicateClient : public XDeskflow
 {
 public:
   XDuplicateClient(const std::string &name);
-  virtual ~XDuplicateClient() throw()
+  ~XDuplicateClient() throw() override
   {
   }
 
@@ -79,7 +79,7 @@ public:
   //@}
 
 protected:
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   std::string m_name;
@@ -94,7 +94,7 @@ class XUnknownClient : public XDeskflow
 {
 public:
   XUnknownClient(const std::string &name);
-  virtual ~XUnknownClient() throw()
+  ~XUnknownClient() throw() override
   {
   }
 
@@ -107,7 +107,7 @@ public:
   //@}
 
 protected:
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   std::string m_name;
@@ -123,7 +123,7 @@ class XExitApp : public XDeskflow
 {
 public:
   XExitApp(int code);
-  virtual ~XExitApp() throw()
+  ~XExitApp() throw() override
   {
   }
 
@@ -131,7 +131,7 @@ public:
   int getCode() const throw();
 
 protected:
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   int m_code;

--- a/src/lib/deskflow/XScreen.h
+++ b/src/lib/deskflow/XScreen.h
@@ -37,7 +37,7 @@ public:
   trying to open the screen again.
   */
   XScreenUnavailable(double timeUntilRetry);
-  virtual ~XScreenUnavailable() throw();
+  ~XScreenUnavailable() throw() override;
 
   //! @name manipulators
   //@{
@@ -51,7 +51,7 @@ public:
   //@}
 
 protected:
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   double m_timeUntilRetry;

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -17,7 +17,7 @@ class AppUtilUnix : public AppUtil
 {
 public:
   AppUtilUnix(IEventQueue *events);
-  virtual ~AppUtilUnix();
+  ~AppUtilUnix() override;
 
   int run(int argc, char **argv) override;
   void startNode() override;

--- a/src/lib/gui/DataDownloader.h
+++ b/src/lib/gui/DataDownloader.h
@@ -18,7 +18,7 @@ class DataDownloader : public QObject
 
 public:
   explicit DataDownloader(QObject *parent = 0);
-  virtual ~DataDownloader();
+  ~DataDownloader() override;
 
   QByteArray data() const;
   void cancel();

--- a/src/lib/gui/ScreenSetupModel.h
+++ b/src/lib/gui/ScreenSetupModel.h
@@ -32,7 +32,7 @@ public:
   {
     return m_MimeType;
   }
-  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
   int rowCount() const
   {
     return m_NumRows;
@@ -41,25 +41,26 @@ public:
   {
     return m_NumColumns;
   }
-  int rowCount(const QModelIndex &) const
+  int rowCount(const QModelIndex &) const override
   {
     return rowCount();
   }
-  int columnCount(const QModelIndex &) const
+  int columnCount(const QModelIndex &) const override
   {
     return columnCount();
   }
-  Qt::DropActions supportedDropActions() const;
-  Qt::ItemFlags flags(const QModelIndex &index) const;
-  QStringList mimeTypes() const;
-  QMimeData *mimeData(const QModelIndexList &indexes) const;
+  Qt::DropActions supportedDropActions() const override;
+  Qt::ItemFlags flags(const QModelIndex &index) const override;
+  QStringList mimeTypes() const override;
+  QMimeData *mimeData(const QModelIndexList &indexes) const override;
   bool isFull() const;
 
 signals:
   void screensChanged();
 
 protected:
-  bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent);
+  bool
+  dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
   const Screen &screen(const QModelIndex &index) const
   {
     return screen(index.column(), index.row());

--- a/src/lib/gui/dialogs/FingerprintDialog.h
+++ b/src/lib/gui/dialogs/FingerprintDialog.h
@@ -30,7 +30,7 @@ public:
       QWidget *parent = nullptr, const QList<deskflow::FingerprintData> &fingerprints = {},
       FingerprintDialogMode mode = FingerprintDialogMode::Local
   );
-  ~FingerprintDialog() = default;
+  ~FingerprintDialog() override = default;
 
 signals:
   void requestLocalPrintsDialog();

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -25,7 +25,7 @@ class ServerConfigDialog : public QDialog
 
 public:
   ServerConfigDialog(QWidget *parent, ServerConfig &config);
-  ~ServerConfigDialog();
+  ~ServerConfigDialog() override;
   bool addClient(const QString &clientName);
 
 public slots:

--- a/src/lib/gui/widgets/FingerprintPreview.h
+++ b/src/lib/gui/widgets/FingerprintPreview.h
@@ -14,5 +14,5 @@ class FingerprintPreview : public QFrame
   Q_OBJECT
 public:
   explicit FingerprintPreview(QWidget *parent, const QList<deskflow::FingerprintData> &fingerprints = {});
-  ~FingerprintPreview() = default;
+  ~FingerprintPreview() override = default;
 };

--- a/src/lib/gui/widgets/KeySequenceWidget.h
+++ b/src/lib/gui/widgets/KeySequenceWidget.h
@@ -72,9 +72,9 @@ public:
   }
 
 protected:
-  void mousePressEvent(QMouseEvent *);
-  void keyPressEvent(QKeyEvent *);
-  bool event(QEvent *event);
+  void mousePressEvent(QMouseEvent *) override;
+  void keyPressEvent(QKeyEvent *) override;
+  bool event(QEvent *event) override;
   void appendToSequence(int key);
   void updateOutput();
   void startRecording();

--- a/src/lib/gui/widgets/TrashScreenWidget.h
+++ b/src/lib/gui/widgets/TrashScreenWidget.h
@@ -23,8 +23,8 @@ public:
   }
 
 public:
-  void dragEnterEvent(QDragEnterEvent *event);
-  void dropEvent(QDropEvent *event);
+  void dragEnterEvent(QDragEnterEvent *event) override;
+  void dropEvent(QDropEvent *event) override;
 
 signals:
   void screenRemoved();

--- a/src/lib/io/StreamFilter.h
+++ b/src/lib/io/StreamFilter.h
@@ -26,7 +26,7 @@ public:
   StreamFilter(IEventQueue *events, deskflow::IStream *stream, bool adoptStream = true);
   StreamFilter(StreamFilter const &) = delete;
   StreamFilter(StreamFilter &&) = delete;
-  virtual ~StreamFilter();
+  ~StreamFilter() override;
 
   StreamFilter &operator=(StreamFilter const &) = delete;
   StreamFilter &operator=(StreamFilter &&) = delete;
@@ -34,15 +34,15 @@ public:
   // IStream overrides
   // These all just forward to the underlying stream except getEventTarget.
   // Override as necessary.  getEventTarget returns a pointer to this.
-  virtual void close();
-  virtual uint32_t read(void *buffer, uint32_t n);
-  virtual void write(const void *buffer, uint32_t n);
-  virtual void flush();
-  virtual void shutdownInput();
-  virtual void shutdownOutput();
-  virtual void *getEventTarget() const;
-  virtual bool isReady() const;
-  virtual uint32_t getSize() const;
+  void close() override;
+  uint32_t read(void *buffer, uint32_t n) override;
+  void write(const void *buffer, uint32_t n) override;
+  void flush() override;
+  void shutdownInput() override;
+  void shutdownOutput() override;
+  void *getEventTarget() const override;
+  bool isReady() const override;
+  uint32_t getSize() const override;
 
   //! Get the stream
   /*!

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -51,17 +51,17 @@ public:
   // in VC++6.  it claims the methods are unused locals and warns
   // that it's removing them.  it's presumably tickled by inheriting
   // methods with identical signatures from both superclasses.
-  virtual void bind(const NetworkAddress &) = 0;
-  virtual void close();
-  virtual void *getEventTarget() const;
+  void bind(const NetworkAddress &) override = 0;
+  void close() override;
+  void *getEventTarget() const override;
 
   // IStream overrides
-  virtual uint32_t read(void *buffer, uint32_t n) = 0;
-  virtual void write(const void *buffer, uint32_t n) = 0;
-  virtual void flush() = 0;
-  virtual void shutdownInput() = 0;
-  virtual void shutdownOutput() = 0;
-  virtual bool isReady() const = 0;
+  uint32_t read(void *buffer, uint32_t n) override = 0;
+  void write(const void *buffer, uint32_t n) override = 0;
+  void flush() override = 0;
+  void shutdownInput() override = 0;
+  void shutdownOutput() override = 0;
+  bool isReady() const override = 0;
+  uint32_t getSize() const override = 0;
   virtual bool isFatal() const = 0;
-  virtual uint32_t getSize() const = 0;
 };

--- a/src/lib/net/IListenSocket.h
+++ b/src/lib/net/IListenSocket.h
@@ -34,7 +34,7 @@ public:
   //@}
 
   // ISocket overrides
-  virtual void bind(const NetworkAddress &) = 0;
-  virtual void close() = 0;
-  virtual void *getEventTarget() const = 0;
+  void bind(const NetworkAddress &) override = 0;
+  void close() override = 0;
+  void *getEventTarget() const override = 0;
 };

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -25,7 +25,7 @@ public:
   );
 
   // IListenSocket overrides
-  virtual IDataSocket *accept();
+  IDataSocket *accept() override;
 
 private:
   const SecurityLevel m_securityLevel;

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -36,7 +36,7 @@ public:
   );
   SecureSocket(SecureSocket const &) = delete;
   SecureSocket(SecureSocket &&) = delete;
-  ~SecureSocket();
+  ~SecureSocket() override;
 
   SecureSocket &operator=(SecureSocket const &) = delete;
   SecureSocket &operator=(SecureSocket &&) = delete;
@@ -45,7 +45,7 @@ public:
   void close() override;
 
   // IDataSocket overrides
-  virtual void connect(const NetworkAddress &) override;
+  void connect(const NetworkAddress &) override;
 
   ISocketMultiplexerJob *newJob() override;
   bool isFatal() const override

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -25,18 +25,18 @@ public:
   TCPListenSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family);
   TCPListenSocket(TCPListenSocket const &) = delete;
   TCPListenSocket(TCPListenSocket &&) = delete;
-  virtual ~TCPListenSocket();
+  ~TCPListenSocket() override;
 
   TCPListenSocket &operator=(TCPListenSocket const &) = delete;
   TCPListenSocket &operator=(TCPListenSocket &&) = delete;
 
   // ISocket overrides
-  virtual void bind(const NetworkAddress &);
-  virtual void close();
-  virtual void *getEventTarget() const;
+  void bind(const NetworkAddress &) override;
+  void close() override;
+  void *getEventTarget() const override;
 
   // IListenSocket overrides
-  virtual IDataSocket *accept();
+  IDataSocket *accept() override;
 
 protected:
   void setListeningJob();

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -33,28 +33,28 @@ public:
   TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, ArchSocket socket);
   TCPSocket(TCPSocket const &) = delete;
   TCPSocket(TCPSocket &&) = delete;
-  virtual ~TCPSocket();
+  ~TCPSocket() override;
 
   TCPSocket &operator=(TCPSocket const &) = delete;
   TCPSocket &operator=(TCPSocket &&) = delete;
 
   // ISocket overrides
-  virtual void bind(const NetworkAddress &);
-  virtual void close();
-  virtual void *getEventTarget() const;
+  void bind(const NetworkAddress &) override;
+  void close() override;
+  void *getEventTarget() const override;
 
   // IStream overrides
-  virtual uint32_t read(void *buffer, uint32_t n);
-  virtual void write(const void *buffer, uint32_t n);
-  virtual void flush();
-  virtual void shutdownInput();
-  virtual void shutdownOutput();
-  virtual bool isReady() const;
-  virtual bool isFatal() const;
-  virtual uint32_t getSize() const;
+  uint32_t read(void *buffer, uint32_t n) override;
+  void write(const void *buffer, uint32_t n) override;
+  void flush() override;
+  void shutdownInput() override;
+  void shutdownOutput() override;
+  bool isReady() const override;
+  bool isFatal() const override;
+  uint32_t getSize() const override;
 
   // IDataSocket overrides
-  virtual void connect(const NetworkAddress &);
+  void connect(const NetworkAddress &) override;
 
   virtual ISocketMultiplexerJob *newJob();
 

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -19,15 +19,15 @@ class TCPSocketFactory : public ISocketFactory
 {
 public:
   TCPSocketFactory(IEventQueue *events, SocketMultiplexer *socketMultiplexer);
-  virtual ~TCPSocketFactory();
+  ~TCPSocketFactory() override;
 
   // ISocketFactory overrides
-  virtual IDataSocket *create(
+  IDataSocket *create(
       IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
-  ) const;
-  virtual IListenSocket *createListen(
+  ) const override;
+  IListenSocket *createListen(
       IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
-  ) const;
+  ) const override;
 
 private:
   IEventQueue *m_events;

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -23,16 +23,16 @@ public:
   TSocketMultiplexerMethodJob(T *object, Method method, ArchSocket socket, bool readable, bool writeable);
   TSocketMultiplexerMethodJob(TSocketMultiplexerMethodJob const &) = delete;
   TSocketMultiplexerMethodJob(TSocketMultiplexerMethodJob &&) = delete;
-  virtual ~TSocketMultiplexerMethodJob();
+  ~TSocketMultiplexerMethodJob() override;
 
   TSocketMultiplexerMethodJob &operator=(TSocketMultiplexerMethodJob const &) = delete;
   TSocketMultiplexerMethodJob &operator=(TSocketMultiplexerMethodJob &&) = delete;
 
   // IJob overrides
-  virtual ISocketMultiplexerJob *run(bool readable, bool writable, bool error);
-  virtual ArchSocket getSocket() const;
-  virtual bool isReadable() const;
-  virtual bool isWritable() const;
+  ISocketMultiplexerJob *run(bool readable, bool writable, bool error) override;
+  ArchSocket getSocket() const override;
+  bool isReadable() const override;
+  bool isWritable() const override;
 
 private:
   T *m_object;

--- a/src/lib/net/XSocket.h
+++ b/src/lib/net/XSocket.h
@@ -32,7 +32,7 @@ public:
   };
 
   XSocketAddress(EError, const std::string &hostname, int port) throw();
-  virtual ~XSocketAddress() throw()
+  ~XSocketAddress() throw() override
   {
   }
 
@@ -50,7 +50,7 @@ public:
 
 protected:
   // XBase overrides
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   EError m_error;

--- a/src/lib/platform/EiEventQueueBuffer.h
+++ b/src/lib/platform/EiEventQueueBuffer.h
@@ -24,7 +24,7 @@ class EiEventQueueBuffer : public IEventQueueBuffer
 {
 public:
   EiEventQueueBuffer(EiScreen *screen, ei *ei, IEventQueue *events);
-  ~EiEventQueueBuffer();
+  ~EiEventQueueBuffer() override;
 
   // IEventQueueBuffer overrides
   void init() override

--- a/src/lib/platform/EiKeyState.h
+++ b/src/lib/platform/EiKeyState.h
@@ -21,7 +21,7 @@ class EiKeyState : public KeyState
 {
 public:
   EiKeyState(EiScreen *screen, IEventQueue *events);
-  ~EiKeyState();
+  ~EiKeyState() override;
 
   void init(int fd, std::size_t len);
   void init_default_keymap();

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -32,7 +32,7 @@ class EiScreen : public PlatformScreen
 {
 public:
   EiScreen(bool is_primary, IEventQueue *events, bool use_portal);
-  ~EiScreen();
+  ~EiScreen() override;
 
   // IScreen overrides
   void *getEventTarget() const override;

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -33,7 +33,7 @@ public:
   XWindowsClipboard(Display *, Window window, ClipboardID id);
   XWindowsClipboard(XWindowsClipboard const &) = delete;
   XWindowsClipboard(XWindowsClipboard &&) = delete;
-  virtual ~XWindowsClipboard();
+  ~XWindowsClipboard() override;
 
   XWindowsClipboard &operator=(XWindowsClipboard const &) = delete;
   XWindowsClipboard &operator=(XWindowsClipboard &&) = delete;
@@ -80,13 +80,13 @@ public:
   Atom getSelection() const;
 
   // IClipboard overrides
-  virtual bool empty();
-  virtual void add(EFormat, const std::string &data);
-  virtual bool open(Time) const;
-  virtual void close() const;
-  virtual Time getTime() const;
-  virtual bool has(EFormat) const;
-  virtual std::string get(EFormat) const;
+  bool empty() override;
+  void add(EFormat, const std::string &data) override;
+  bool open(Time) const override;
+  void close() const override;
+  Time getTime() const override;
+  bool has(EFormat) const override;
+  std::string get(EFormat) const override;
 
 private:
   // remove all converters from our list

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
@@ -14,14 +14,14 @@ class XWindowsClipboardAnyBitmapConverter : public IXWindowsClipboardConverter
 {
 public:
   XWindowsClipboardAnyBitmapConverter();
-  virtual ~XWindowsClipboardAnyBitmapConverter();
+  ~XWindowsClipboardAnyBitmapConverter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const = 0;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override = 0;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 protected:
   //! Convert from IClipboard format

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -14,14 +14,14 @@ class XWindowsClipboardBMPConverter : public IXWindowsClipboardConverter
 {
 public:
   XWindowsClipboardBMPConverter(Display *display);
-  virtual ~XWindowsClipboardBMPConverter();
+  ~XWindowsClipboardBMPConverter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 private:
   Atom m_atom;

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -17,14 +17,14 @@ public:
   \c name is converted to an atom and that is reported by getAtom().
   */
   XWindowsClipboardHTMLConverter(Display *display, const char *name);
-  virtual ~XWindowsClipboardHTMLConverter();
+  ~XWindowsClipboardHTMLConverter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 private:
   Atom m_atom;

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -17,14 +17,14 @@ public:
   \c name is converted to an atom and that is reported by getAtom().
   */
   XWindowsClipboardTextConverter(Display *display, const char *name);
-  virtual ~XWindowsClipboardTextConverter();
+  ~XWindowsClipboardTextConverter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 private:
   Atom m_atom;

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -17,14 +17,14 @@ public:
   \c name is converted to an atom and that is reported by getAtom().
   */
   XWindowsClipboardUCS2Converter(Display *display, const char *name);
-  virtual ~XWindowsClipboardUCS2Converter();
+  ~XWindowsClipboardUCS2Converter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 private:
   Atom m_atom;

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -17,14 +17,14 @@ public:
   \c name is converted to an atom and that is reported by getAtom().
   */
   XWindowsClipboardUTF8Converter(Display *display, const char *name, bool normalize = false);
-  virtual ~XWindowsClipboardUTF8Converter();
+  ~XWindowsClipboardUTF8Converter() override;
 
   // IXWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual Atom getAtom() const;
-  virtual int getDataSize() const;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  Atom getAtom() const override;
+  int getDataSize() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 private:
   Atom m_atom;

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -27,21 +27,21 @@ public:
   XWindowsEventQueueBuffer(Display *, Window, IEventQueue *events);
   XWindowsEventQueueBuffer(XWindowsEventQueueBuffer const &) = delete;
   XWindowsEventQueueBuffer(XWindowsEventQueueBuffer &&) = delete;
-  virtual ~XWindowsEventQueueBuffer();
+  ~XWindowsEventQueueBuffer() override;
 
   XWindowsEventQueueBuffer &operator=(XWindowsEventQueueBuffer const &) = delete;
   XWindowsEventQueueBuffer &operator=(XWindowsEventQueueBuffer &&) = delete;
 
   // IEventQueueBuffer overrides
-  virtual void init()
+  void init() override
   {
   }
-  virtual void waitForEvent(double timeout);
-  virtual Type getEvent(Event &event, uint32_t &dataID);
-  virtual bool addEvent(uint32_t dataID);
-  virtual bool isEmpty() const;
-  virtual EventQueueTimer *newTimer(double duration, bool oneShot) const;
-  virtual void deleteTimer(EventQueueTimer *) const;
+  void waitForEvent(double timeout) override;
+  Type getEvent(Event &event, uint32_t &dataID) override;
+  bool addEvent(uint32_t dataID) override;
+  bool isEmpty() const override;
+  EventQueueTimer *newTimer(double duration, bool oneShot) const override;
+  void deleteTimer(EventQueueTimer *) const override;
 
 private:
   void flush();

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -44,7 +44,7 @@ public:
 
   XWindowsKeyState(Display *, bool useXKB, IEventQueue *events);
   XWindowsKeyState(Display *, bool useXKB, IEventQueue *events, deskflow::KeyMap &keyMap);
-  ~XWindowsKeyState();
+  ~XWindowsKeyState() override;
 
   //! @name modifiers
   //@{
@@ -94,15 +94,15 @@ public:
   //@}
 
   // IKeyState overrides
-  virtual bool fakeCtrlAltDel();
-  virtual KeyModifierMask pollActiveModifiers() const;
-  virtual int32_t pollActiveGroup() const;
-  virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const;
+  bool fakeCtrlAltDel() override;
+  KeyModifierMask pollActiveModifiers() const override;
+  int32_t pollActiveGroup() const override;
+  void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
 
 protected:
   // KeyState overrides
-  virtual void getKeyMap(deskflow::KeyMap &keyMap);
-  virtual void fakeKey(const Keystroke &keystroke);
+  void getKeyMap(deskflow::KeyMap &keyMap) override;
+  void fakeKey(const Keystroke &keystroke) override;
 
 private:
   void init(Display *display, bool useXKB);

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -34,7 +34,7 @@ public:
       const char *displayName, bool isPrimary, bool disableXInitThreads, int mouseScrollDelta, IEventQueue *events,
       deskflow::ClientScrollDirection m_clientScrollDirection = deskflow::ClientScrollDirection::SERVER
   );
-  virtual ~XWindowsScreen() override;
+  ~XWindowsScreen() override;
 
   //! @name manipulators
   //@{

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -28,7 +28,7 @@ public:
   XWindowsScreenSaver(Display *, Window, void *eventTarget, IEventQueue *events);
   XWindowsScreenSaver(XWindowsScreenSaver const &) = delete;
   XWindowsScreenSaver(XWindowsScreenSaver &&) = delete;
-  virtual ~XWindowsScreenSaver();
+  ~XWindowsScreenSaver() override;
 
   XWindowsScreenSaver &operator=(XWindowsScreenSaver const &) = delete;
   XWindowsScreenSaver &operator=(XWindowsScreenSaver &&) = delete;
@@ -53,11 +53,11 @@ public:
   //@}
 
   // IScreenSaver overrides
-  virtual void enable();
-  virtual void disable();
-  virtual void activate();
-  virtual void deactivate();
-  virtual bool isActive() const;
+  void enable() override;
+  void disable() override;
+  void activate() override;
+  void deactivate() override;
+  bool isActive() const override;
 
 private:
   // find and set the running xscreensaver's window.  returns true iff

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -21,7 +21,7 @@ public:
   \c name is the name of the client.
   */
   BaseClientProxy(const std::string &name);
-  ~BaseClientProxy();
+  ~BaseClientProxy() override;
 
   //! @name manipulators
   //@{
@@ -54,33 +54,33 @@ public:
   //@}
 
   // IScreen
-  virtual void *getEventTarget() const = 0;
-  virtual bool getClipboard(ClipboardID id, IClipboard *) const = 0;
-  virtual void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const = 0;
-  virtual void getCursorPos(int32_t &x, int32_t &y) const = 0;
+  void *getEventTarget() const override = 0;
+  bool getClipboard(ClipboardID id, IClipboard *) const override = 0;
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override = 0;
+  void getCursorPos(int32_t &x, int32_t &y) const override = 0;
 
   // IClient overrides
-  virtual void enter(int32_t xAbs, int32_t yAbs, uint32_t seqNum, KeyModifierMask mask, bool forScreensaver) = 0;
-  virtual bool leave() = 0;
-  virtual void setClipboard(ClipboardID, const IClipboard *) = 0;
-  virtual void grabClipboard(ClipboardID) = 0;
-  virtual void setClipboardDirty(ClipboardID, bool) = 0;
-  virtual void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &) = 0;
-  virtual void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &lang) = 0;
-  virtual void keyUp(KeyID, KeyModifierMask, KeyButton) = 0;
-  virtual void mouseDown(ButtonID) = 0;
-  virtual void mouseUp(ButtonID) = 0;
-  virtual void mouseMove(int32_t xAbs, int32_t yAbs) = 0;
-  virtual void mouseRelativeMove(int32_t xRel, int32_t yRel) = 0;
-  virtual void mouseWheel(int32_t xDelta, int32_t yDelta) = 0;
-  virtual void screensaver(bool activate) = 0;
-  virtual void resetOptions() = 0;
-  virtual void setOptions(const OptionsList &options) = 0;
+  void enter(int32_t xAbs, int32_t yAbs, uint32_t seqNum, KeyModifierMask mask, bool forScreensaver) override = 0;
+  bool leave() override = 0;
+  void setClipboard(ClipboardID, const IClipboard *) override = 0;
+  void grabClipboard(ClipboardID) override = 0;
+  void setClipboardDirty(ClipboardID, bool) override = 0;
+  void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &) override = 0;
+  void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &lang) override = 0;
+  void keyUp(KeyID, KeyModifierMask, KeyButton) override = 0;
+  void mouseDown(ButtonID) override = 0;
+  void mouseUp(ButtonID) override = 0;
+  void mouseMove(int32_t xAbs, int32_t yAbs) override = 0;
+  void mouseRelativeMove(int32_t xRel, int32_t yRel) override = 0;
+  void mouseWheel(int32_t xDelta, int32_t yDelta) override = 0;
+  void screensaver(bool activate) override = 0;
+  void resetOptions() override = 0;
+  void setOptions(const OptionsList &options) override = 0;
   virtual void sendDragInfo(uint32_t fileCount, const char *info, size_t size) = 0;
   virtual void fileChunkSending(uint8_t mark, char *data, size_t dataSize) = 0;
   virtual std::string getSecureInputApp() const = 0;
   virtual void secureInputNotification(const std::string &app) const = 0;
-  virtual std::string getName() const;
+  std::string getName() const override;
   virtual deskflow::IStream *getStream() const = 0;
 
 private:

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -25,7 +25,7 @@ public:
   ClientProxy(const std::string &name, deskflow::IStream *adoptedStream);
   ClientProxy(ClientProxy const &) = delete;
   ClientProxy(ClientProxy &&) = delete;
-  ~ClientProxy();
+  ~ClientProxy() override;
 
   ClientProxy &operator=(ClientProxy const &) = delete;
   ClientProxy &operator=(ClientProxy &&) = delete;

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -22,7 +22,7 @@ public:
   ClientProxy1_0(const std::string &name, deskflow::IStream *adoptedStream, IEventQueue *events);
   ClientProxy1_0(ClientProxy1_0 const &) = delete;
   ClientProxy1_0(ClientProxy1_0 &&) = delete;
-  ~ClientProxy1_0();
+  ~ClientProxy1_0() override;
 
   ClientProxy1_0 &operator=(ClientProxy1_0 const &) = delete;
   ClientProxy1_0 &operator=(ClientProxy1_0 &&) = delete;

--- a/src/lib/server/ClientProxy1_1.h
+++ b/src/lib/server/ClientProxy1_1.h
@@ -14,10 +14,10 @@ class ClientProxy1_1 : public ClientProxy1_0
 {
 public:
   ClientProxy1_1(const std::string &name, deskflow::IStream *adoptedStream, IEventQueue *events);
-  ~ClientProxy1_1();
+  ~ClientProxy1_1() override;
 
   // IClient overrides
-  virtual void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &);
-  virtual void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &);
-  virtual void keyUp(KeyID, KeyModifierMask, KeyButton);
+  void keyDown(KeyID, KeyModifierMask, KeyButton, const std::string &) override;
+  void keyRepeat(KeyID, KeyModifierMask, int32_t count, KeyButton, const std::string &) override;
+  void keyUp(KeyID, KeyModifierMask, KeyButton) override;
 };

--- a/src/lib/server/ClientProxy1_2.h
+++ b/src/lib/server/ClientProxy1_2.h
@@ -16,8 +16,8 @@ class ClientProxy1_2 : public ClientProxy1_1
 {
 public:
   ClientProxy1_2(const std::string &name, deskflow::IStream *adoptedStream, IEventQueue *events);
-  ~ClientProxy1_2();
+  ~ClientProxy1_2() override;
 
   // IClient overrides
-  virtual void mouseRelativeMove(int32_t xRel, int32_t yRel);
+  void mouseRelativeMove(int32_t xRel, int32_t yRel) override;
 };

--- a/src/lib/server/ClientProxy1_4.h
+++ b/src/lib/server/ClientProxy1_4.h
@@ -16,7 +16,7 @@ class ClientProxy1_4 : public ClientProxy1_3
 {
 public:
   ClientProxy1_4(const std::string &name, deskflow::IStream *adoptedStream, Server *server, IEventQueue *events);
-  ~ClientProxy1_4();
+  ~ClientProxy1_4() override;
 
   //! @name accessors
   //@{
@@ -30,10 +30,10 @@ public:
   //@}
 
   // IClient overrides
-  virtual void keyDown(KeyID key, KeyModifierMask mask, KeyButton button, const std::string &);
-  virtual void keyRepeat(KeyID key, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang);
-  virtual void keyUp(KeyID key, KeyModifierMask mask, KeyButton button);
-  virtual void keepAlive();
+  void keyDown(KeyID key, KeyModifierMask mask, KeyButton button, const std::string &) override;
+  void keyRepeat(KeyID key, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang) override;
+  void keyUp(KeyID key, KeyModifierMask mask, KeyButton button) override;
+  void keepAlive() override;
 
   Server *m_server;
 };

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -21,14 +21,14 @@ public:
   ClientProxy1_5(const std::string &name, deskflow::IStream *adoptedStream, Server *server, IEventQueue *events);
   ClientProxy1_5(ClientProxy1_5 const &) = delete;
   ClientProxy1_5(ClientProxy1_5 &&) = delete;
-  ~ClientProxy1_5();
+  ~ClientProxy1_5() override;
 
   ClientProxy1_5 &operator=(ClientProxy1_5 const &) = delete;
   ClientProxy1_5 &operator=(ClientProxy1_5 &&) = delete;
 
-  virtual void sendDragInfo(uint32_t fileCount, const char *info, size_t size);
-  virtual void fileChunkSending(uint8_t mark, char *data, size_t dataSize);
-  virtual bool parseMessage(const uint8_t *code);
+  void sendDragInfo(uint32_t fileCount, const char *info, size_t size) override;
+  void fileChunkSending(uint8_t mark, char *data, size_t dataSize) override;
+  bool parseMessage(const uint8_t *code) override;
   void fileChunkReceived();
   void dragInfoReceived();
 

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -16,10 +16,10 @@ class ClientProxy1_6 : public ClientProxy1_5
 {
 public:
   ClientProxy1_6(const std::string &name, deskflow::IStream *adoptedStream, Server *server, IEventQueue *events);
-  ~ClientProxy1_6();
+  ~ClientProxy1_6() override;
 
-  virtual void setClipboard(ClipboardID id, const IClipboard *clipboard);
-  virtual bool recvClipboard();
+  void setClipboard(ClipboardID id, const IClipboard *clipboard) override;
+  bool recvClipboard() override;
 
 private:
   void handleClipboardSendingEvent(const Event &, void *);

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -549,11 +549,11 @@ class XConfigRead : public XBase
 public:
   XConfigRead(const ConfigReadContext &context, const std::string &);
   XConfigRead(const ConfigReadContext &context, const char *errorFmt, const std::string &arg);
-  virtual ~XConfigRead() throw();
+  ~XConfigRead() throw() override;
 
 protected:
   // XBase overrides
-  virtual std::string getWhat() const throw();
+  std::string getWhat() const throw() override;
 
 private:
   std::string m_error;

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -53,17 +53,17 @@ public:
   public:
     KeystrokeCondition(IEventQueue *events, IPlatformScreen::KeyInfo *);
     KeystrokeCondition(IEventQueue *events, KeyID key, KeyModifierMask mask);
-    virtual ~KeystrokeCondition();
+    ~KeystrokeCondition() override;
 
     KeyID getKey() const;
     KeyModifierMask getMask() const;
 
     // Condition overrides
-    virtual Condition *clone() const;
-    virtual std::string format() const;
-    virtual EFilterStatus match(const Event &);
-    virtual void enablePrimary(PrimaryClient *);
-    virtual void disablePrimary(PrimaryClient *);
+    Condition *clone() const override;
+    std::string format() const override;
+    EFilterStatus match(const Event &) override;
+    void enablePrimary(PrimaryClient *) override;
+    void disablePrimary(PrimaryClient *) override;
 
   private:
     uint32_t m_id;
@@ -78,15 +78,15 @@ public:
   public:
     MouseButtonCondition(IEventQueue *events, IPlatformScreen::ButtonInfo *);
     MouseButtonCondition(IEventQueue *events, ButtonID, KeyModifierMask mask);
-    virtual ~MouseButtonCondition();
+    ~MouseButtonCondition() override;
 
     ButtonID getButton() const;
     KeyModifierMask getMask() const;
 
     // Condition overrides
-    virtual Condition *clone() const;
-    virtual std::string format() const;
-    virtual EFilterStatus match(const Event &);
+    Condition *clone() const override;
+    std::string format() const override;
+    EFilterStatus match(const Event &) override;
 
   private:
     ButtonID m_button;
@@ -99,12 +99,12 @@ public:
   {
   public:
     ScreenConnectedCondition(IEventQueue *events, const std::string &screen);
-    virtual ~ScreenConnectedCondition();
+    ~ScreenConnectedCondition() override;
 
     // Condition overrides
-    virtual Condition *clone() const;
-    virtual std::string format() const;
-    virtual EFilterStatus match(const Event &);
+    Condition *clone() const override;
+    std::string format() const override;
+    EFilterStatus match(const Event &) override;
 
   private:
     std::string m_screen;
@@ -143,9 +143,9 @@ public:
     Mode getMode() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   private:
     Mode m_mode;
@@ -165,9 +165,9 @@ public:
     Mode getMode() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   private:
     Mode m_mode;
@@ -183,9 +183,9 @@ public:
     std::string getScreen() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   private:
     std::string m_screen;
@@ -201,9 +201,9 @@ public:
     EDirection getDirection() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   private:
     EDirection m_direction;
@@ -228,9 +228,9 @@ public:
     std::set<std::string> getScreens() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   private:
     Mode m_mode;
@@ -245,7 +245,7 @@ public:
     KeystrokeAction(IEventQueue *events, IPlatformScreen::KeyInfo *adoptedInfo, bool press);
     KeystrokeAction(KeystrokeAction const &) = delete;
     KeystrokeAction(KeystrokeAction &&) = delete;
-    ~KeystrokeAction();
+    ~KeystrokeAction() override;
 
     KeystrokeAction &operator=(KeystrokeAction const &) = delete;
     KeystrokeAction &operator=(KeystrokeAction &&) = delete;
@@ -255,9 +255,9 @@ public:
     bool isOnPress() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   protected:
     virtual const char *formatName() const;
@@ -275,7 +275,7 @@ public:
     MouseButtonAction(IEventQueue *events, IPlatformScreen::ButtonInfo *adoptedInfo, bool press);
     MouseButtonAction(MouseButtonAction const &) = delete;
     MouseButtonAction(MouseButtonAction &&) = delete;
-    ~MouseButtonAction();
+    ~MouseButtonAction() override;
 
     MouseButtonAction &operator=(MouseButtonAction const &) = delete;
     MouseButtonAction &operator=(MouseButtonAction &&) = delete;
@@ -284,9 +284,9 @@ public:
     bool isOnPress() const;
 
     // Action overrides
-    virtual Action *clone() const;
-    virtual std::string format() const;
-    virtual void perform(const Event &);
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
 
   protected:
     virtual const char *formatName() const;

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -27,7 +27,7 @@ public:
   \c name is the name of the server and \p screen is primary screen.
   */
   PrimaryClient(const std::string &name, deskflow::Screen *screen);
-  ~PrimaryClient();
+  ~PrimaryClient() override;
 
 #ifdef TEST_ENV
   PrimaryClient() : BaseClientProxy("")

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -125,7 +125,7 @@ public:
   );
   Server(Server const &) = delete;
   Server(Server &&) = delete;
-  ~Server();
+  ~Server() override;
 
   Server &operator=(Server const &) = delete;
   Server &operator=(Server &&) = delete;


### PR DESCRIPTION
 - remove `virtual` for `override` where applicable.