### PR TITLE
chore: Silence two compiler signedness warnings

### DIFF
--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -56,7 +56,7 @@ std::string vformat(const char *fmt, va_list args)
           index.push_back(i);
           pos.push_back(static_cast<size_t>((scan - 1) - fmt));
           width.push_back(static_cast<size_t>((end - scan) + 2));
-          if (i > maxIndex) {
+          if (static_cast<size_t>(i) > maxIndex) {
             maxIndex = i;
           }
           scan = end;
@@ -74,7 +74,7 @@ std::string vformat(const char *fmt, va_list args)
   std::vector<size_t> length;
   value.push_back("%");
   length.push_back(1);
-  for (int i = 0; i < maxIndex; ++i) {
+  for (size_t i = 0; i < maxIndex; ++i) {
     const char *arg = va_arg(args, const char *);
     size_t len = strnlen(arg, SIZE_MAX);
     value.push_back(arg);


### PR DESCRIPTION
Both trigger:
  warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]

In the first hunk we already checked for i < 0 so casting to size_t is fine. In the second hunk we don't use i so we can pick the right type.