### PR TITLE
ei: Drain all events sitting in our pipe

### DIFF
--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -81,8 +81,12 @@ void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
     // and potentially testCancel
     if (pfds[PIPEFD].revents & POLLIN) {
       char buf[64];
-      auto result = read(pipe_r_, buf, sizeof(buf)); // discard
-      LOG_DEBUG2("event queue read result: %d", result);
+      ssize_t total = 0;
+      ssize_t result;
+      while ((result = read(pipe_r_, buf, sizeof(buf)) > 0)) {
+        total += result;
+      }
+      LOG_DEBUG2("event queue read result: %d (total drained: %zd)", result, total);
     }
   }
   Thread::testCancel();


### PR DESCRIPTION
If we're starved for resources, we may end up with more than 64 notifications in our pipe before we get to actually read them. Those notifications are just that though, so let's drain them.

Seen in https://github.com/deskflow/deskflow/pull/8503#issuecomment-2841702394