### PR TITLE
Deskflow-gui add `reset` option

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -55,13 +55,13 @@ int main(int argc, char *argv[])
   // Add Command Line Options
   auto helpOption = QCommandLineOption("help", "Display Help on the command line");
   auto versionOption = QCommandLineOption("version", "Display version information");
-  auto noResetOption = QCommandLineOption("no-reset", "Prevent settings reset if DESKFLOW_RESET_ALL is set");
+  auto resetOption = QCommandLineOption("reset", "Reset all settings");
 
   QCommandLineParser parser;
   parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
   parser.addOption(helpOption);
   parser.addOption(versionOption);
-  parser.addOption(noResetOption);
+  parser.addOption(resetOption);
   parser.parse(QCoreApplication::arguments());
 
   const auto header = QStringLiteral("%1: %2\n").arg(kAppName, kDisplayVersion);
@@ -132,8 +132,7 @@ int main(int argc, char *argv[])
 #endif
 
   // --no-reset
-  const auto resetEnvVar = QVariant(qEnvironmentVariable("DESKFLOW_RESET_ALL")).toBool();
-  if (resetEnvVar && !parser.isSet(noResetOption)) {
+  if (parser.isSet(resetOption)) {
     diagnostic::clearSettings(false);
   }
 

--- a/src/lib/gui/Diagnostic.cpp
+++ b/src/lib/gui/Diagnostic.cpp
@@ -19,8 +19,9 @@ void restart()
   QString program = QCoreApplication::applicationFilePath();
   QStringList arguments = QCoreApplication::arguments();
 
-  // prevent infinite reset loop when env var set.
-  arguments << "--no-reset";
+  // look for and remove --reset option if found
+  if (int resetIndex = arguments.indexOf("--reset"); resetIndex != -1)
+    arguments.remove(resetIndex);
 
   qInfo("launching new process: %s", qPrintable(program));
   QProcess::startDetached(program, arguments);


### PR DESCRIPTION
 Remove the use of the environmental variable `DESKFLOW_RESET_ALL` and reset instead when --reset is passed as an option.