### PR TITLE
Tidy up macos code smells missed by sonarscan

### DIFF
--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -25,13 +25,13 @@ public:
   static bool isOwnedByDeskflow();
 
   // IClipboard overrides
-  virtual bool empty();
-  virtual void add(EFormat, const std::string &data);
-  virtual bool open(Time) const;
-  virtual void close() const;
-  virtual Time getTime() const;
-  virtual bool has(EFormat) const;
-  virtual std::string get(EFormat) const;
+  bool empty() override;
+  void add(EFormat, const std::string &data) override;
+  bool open(Time) const override;
+  void close() const override;
+  Time getTime() const override;
+  bool has(EFormat) const override;
+  std::string get(EFormat) const override;
 
   bool synchronize();
 

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
@@ -8,16 +8,6 @@
 #include "platform/OSXClipboardAnyBitmapConverter.h"
 #include <algorithm>
 
-OSXClipboardAnyBitmapConverter::OSXClipboardAnyBitmapConverter()
-{
-  // do nothing
-}
-
-OSXClipboardAnyBitmapConverter::~OSXClipboardAnyBitmapConverter()
-{
-  // do nothing
-}
-
 IClipboard::EFormat OSXClipboardAnyBitmapConverter::getFormat() const
 {
   return IClipboard::kBitmap;

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.h
@@ -13,14 +13,14 @@
 class OSXClipboardAnyBitmapConverter : public IOSXClipboardConverter
 {
 public:
-  OSXClipboardAnyBitmapConverter();
-  virtual ~OSXClipboardAnyBitmapConverter();
+  OSXClipboardAnyBitmapConverter() = default;
+  ~OSXClipboardAnyBitmapConverter() override = default;
 
   // IOSXClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual CFStringRef getOSXFormat() const = 0;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  CFStringRef getOSXFormat() const override = 0;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
 protected:
   //! Convert from IClipboard format

--- a/src/lib/platform/OSXClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.cpp
@@ -13,16 +13,6 @@
 // OSXClipboardAnyTextConverter
 //
 
-OSXClipboardAnyTextConverter::OSXClipboardAnyTextConverter()
-{
-  // do nothing
-}
-
-OSXClipboardAnyTextConverter::~OSXClipboardAnyTextConverter()
-{
-  // do nothing
-}
-
 IClipboard::EFormat OSXClipboardAnyTextConverter::getFormat() const
 {
   return IClipboard::kText;

--- a/src/lib/platform/OSXClipboardAnyTextConverter.h
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.h
@@ -13,14 +13,14 @@
 class OSXClipboardAnyTextConverter : public IOSXClipboardConverter
 {
 public:
-  OSXClipboardAnyTextConverter();
-  virtual ~OSXClipboardAnyTextConverter();
+  OSXClipboardAnyTextConverter() = default;
+  ~OSXClipboardAnyTextConverter() override = default;
 
   // IOSXClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-  virtual CFStringRef getOSXFormat() const = 0;
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  IClipboard::EFormat getFormat() const override;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
+  CFStringRef getOSXFormat() const override = 0;
 
 protected:
   //! Convert from IClipboard format

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -48,16 +48,6 @@ static void toLE(uint8_t *&dst, uint32_t src)
   dst += 4;
 }
 
-OSXClipboardBMPConverter::OSXClipboardBMPConverter()
-{
-  // do nothing
-}
-
-OSXClipboardBMPConverter::~OSXClipboardBMPConverter()
-{
-  // do nothing
-}
-
 IClipboard::EFormat OSXClipboardBMPConverter::getFormat() const
 {
   return IClipboard::kBitmap;

--- a/src/lib/platform/OSXClipboardBMPConverter.h
+++ b/src/lib/platform/OSXClipboardBMPConverter.h
@@ -13,17 +13,16 @@
 class OSXClipboardBMPConverter : public IOSXClipboardConverter
 {
 public:
-  OSXClipboardBMPConverter();
-  virtual ~OSXClipboardBMPConverter();
+  OSXClipboardBMPConverter() = default;
+  ~OSXClipboardBMPConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-
-  virtual CFStringRef getOSXFormat() const;
+  IClipboard::EFormat getFormat() const override;
+  CFStringRef getOSXFormat() const override;
 
   // OSXClipboardAnyBMPConverter overrides
-  virtual std::string fromIClipboard(const std::string &) const;
-  virtual std::string toIClipboard(const std::string &) const;
+  std::string fromIClipboard(const std::string &) const override;
+  std::string toIClipboard(const std::string &) const override;
 
   // generic encoding converter
   static std::string convertString(const std::string &data, CFStringEncoding fromEncoding, CFStringEncoding toEncoding);

--- a/src/lib/platform/OSXClipboardHTMLConverter.cpp
+++ b/src/lib/platform/OSXClipboardHTMLConverter.cpp
@@ -9,16 +9,6 @@
 
 #include "base/Unicode.h"
 
-OSXClipboardHTMLConverter::OSXClipboardHTMLConverter()
-{
-  // do nothing
-}
-
-OSXClipboardHTMLConverter::~OSXClipboardHTMLConverter()
-{
-  // do nothing
-}
-
 IClipboard::EFormat OSXClipboardHTMLConverter::getFormat() const
 {
   return IClipboard::kHTML;

--- a/src/lib/platform/OSXClipboardHTMLConverter.h
+++ b/src/lib/platform/OSXClipboardHTMLConverter.h
@@ -13,18 +13,17 @@
 class OSXClipboardHTMLConverter : public OSXClipboardAnyTextConverter
 {
 public:
-  OSXClipboardHTMLConverter();
-  virtual ~OSXClipboardHTMLConverter();
+  OSXClipboardHTMLConverter() = default;
+  ~OSXClipboardHTMLConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  virtual IClipboard::EFormat getFormat() const;
-
-  virtual CFStringRef getOSXFormat() const;
+  IClipboard::EFormat getFormat() const override;
+  CFStringRef getOSXFormat() const override;
 
 protected:
   // OSXClipboardAnyTextConverter overrides
-  virtual std::string doFromIClipboard(const std::string &) const;
-  virtual std::string doToIClipboard(const std::string &) const;
+  std::string doFromIClipboard(const std::string &) const override;
+  std::string doToIClipboard(const std::string &) const override;
 
   // generic encoding converter
   static std::string convertString(const std::string &data, CFStringEncoding fromEncoding, CFStringEncoding toEncoding);

--- a/src/lib/platform/OSXClipboardTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardTextConverter.cpp
@@ -13,16 +13,6 @@
 // OSXClipboardTextConverter
 //
 
-OSXClipboardTextConverter::OSXClipboardTextConverter()
-{
-  // do nothing
-}
-
-OSXClipboardTextConverter::~OSXClipboardTextConverter()
-{
-  // do nothing
-}
-
 CFStringRef OSXClipboardTextConverter::getOSXFormat() const
 {
   return CFSTR("public.plain-text");

--- a/src/lib/platform/OSXClipboardTextConverter.h
+++ b/src/lib/platform/OSXClipboardTextConverter.h
@@ -13,16 +13,16 @@
 class OSXClipboardTextConverter : public OSXClipboardAnyTextConverter
 {
 public:
-  OSXClipboardTextConverter();
-  virtual ~OSXClipboardTextConverter();
+  OSXClipboardTextConverter() = default;
+  ~OSXClipboardTextConverter() override = default;
 
   // IOSXClipboardAnyTextConverter overrides
-  virtual CFStringRef getOSXFormat() const;
+  CFStringRef getOSXFormat() const override;
 
 protected:
   // OSXClipboardAnyTextConverter overrides
-  virtual std::string doFromIClipboard(const std::string &) const;
-  virtual std::string doToIClipboard(const std::string &) const;
+  std::string doFromIClipboard(const std::string &) const override;
+  std::string doToIClipboard(const std::string &) const override;
 
   // generic encoding converter
   static std::string convertString(const std::string &data, CFStringEncoding fromEncoding, CFStringEncoding toEncoding);

--- a/src/lib/platform/OSXClipboardUTF16Converter.cpp
+++ b/src/lib/platform/OSXClipboardUTF16Converter.cpp
@@ -13,16 +13,6 @@
 // OSXClipboardUTF16Converter
 //
 
-OSXClipboardUTF16Converter::OSXClipboardUTF16Converter()
-{
-  // do nothing
-}
-
-OSXClipboardUTF16Converter::~OSXClipboardUTF16Converter()
-{
-  // do nothing
-}
-
 CFStringRef OSXClipboardUTF16Converter::getOSXFormat() const
 {
   return CFSTR("public.utf16-plain-text");

--- a/src/lib/platform/OSXClipboardUTF16Converter.h
+++ b/src/lib/platform/OSXClipboardUTF16Converter.h
@@ -13,14 +13,14 @@
 class OSXClipboardUTF16Converter : public OSXClipboardAnyTextConverter
 {
 public:
-  OSXClipboardUTF16Converter();
-  virtual ~OSXClipboardUTF16Converter();
+  OSXClipboardUTF16Converter() = default;
+  ~OSXClipboardUTF16Converter() override = default;
 
   // IOSXClipboardAnyTextConverter overrides
-  virtual CFStringRef getOSXFormat() const;
+  CFStringRef getOSXFormat() const override;
 
 protected:
   // OSXClipboardAnyTextConverter overrides
-  virtual std::string doFromIClipboard(const std::string &) const;
-  virtual std::string doToIClipboard(const std::string &) const;
+  std::string doFromIClipboard(const std::string &) const override;
+  std::string doToIClipboard(const std::string &) const override;
 };

--- a/src/lib/platform/OSXClipboardUTF8Converter.h
+++ b/src/lib/platform/OSXClipboardUTF8Converter.h
@@ -12,9 +12,12 @@
 class OSXClipboardUTF8Converter : public OSXClipboardAnyTextConverter
 {
 public:
-  virtual CFStringRef getOSXFormat() const;
+  OSXClipboardUTF8Converter() = default;
+  ~OSXClipboardUTF8Converter() override = default;
+
+  CFStringRef getOSXFormat() const override;
 
 private:
-  virtual std::string doFromIClipboard(const std::string &) const;
-  virtual std::string doToIClipboard(const std::string &) const;
+  std::string doFromIClipboard(const std::string &) const override;
+  std::string doToIClipboard(const std::string &) const override;
 };

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -29,11 +29,6 @@ OSXEventQueueBuffer::OSXEventQueueBuffer(IEventQueue *events) : m_eventQueue(eve
   // Initialization is now managed using modern constructs
 }
 
-OSXEventQueueBuffer::~OSXEventQueueBuffer()
-{
-  // No explicit clean-up needed as GCD and STL handle resource management
-}
-
 void OSXEventQueueBuffer::init()
 {
   // No initialization needed for GCD-based implementation

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -22,16 +22,16 @@ class OSXEventQueueBuffer : public IEventQueueBuffer
 {
 public:
   OSXEventQueueBuffer(IEventQueue *eventQueue);
-  virtual ~OSXEventQueueBuffer();
+  ~OSXEventQueueBuffer() override = default;
 
   // IEventQueueBuffer overrides
-  virtual void init() override;
-  virtual void waitForEvent(double timeout) override;
-  virtual Type getEvent(Event &event, uint32_t &dataID) override;
-  virtual bool addEvent(uint32_t dataID) override;
-  virtual bool isEmpty() const override;
-  virtual EventQueueTimer *newTimer(double duration, bool oneShot) const override;
-  virtual void deleteTimer(EventQueueTimer *timer) const override;
+  void init() override;
+  void waitForEvent(double timeout) override;
+  Type getEvent(Event &event, uint32_t &dataID) override;
+  bool addEvent(uint32_t dataID) override;
+  bool isEmpty() const override;
+  EventQueueTimer *newTimer(double duration, bool oneShot) const override;
+  void deleteTimer(EventQueueTimer *timer) const override;
 
 private:
   IEventQueue *m_eventQueue;

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -193,10 +193,6 @@ OSXKeyState::OSXKeyState(
   init();
 }
 
-OSXKeyState::~OSXKeyState()
-{
-}
-
 void OSXKeyState::init()
 {
   m_deadKeyState = 0;

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -29,7 +29,7 @@ public:
 
   OSXKeyState(IEventQueue *events, std::vector<std::string> layouts, bool isLangSyncEnabled);
   OSXKeyState(IEventQueue *events, deskflow::KeyMap &keyMap, std::vector<std::string> layouts, bool isLangSyncEnabled);
-  virtual ~OSXKeyState();
+  ~OSXKeyState() override = default;
 
   //! @name modifiers
   //@{
@@ -79,18 +79,18 @@ public:
   //@}
 
   // IKeyState overrides
-  virtual bool fakeCtrlAltDel();
-  virtual bool fakeMediaKey(KeyID id);
-  virtual KeyModifierMask pollActiveModifiers() const;
-  virtual int32_t pollActiveGroup() const;
-  virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const;
+  bool fakeCtrlAltDel() override;
+  bool fakeMediaKey(KeyID id) override;
+  KeyModifierMask pollActiveModifiers() const override;
+  int32_t pollActiveGroup() const override;
+  void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
 
   CGEventFlags getModifierStateAsOSXFlags() const;
 
 protected:
   // KeyState overrides
-  virtual void getKeyMap(deskflow::KeyMap &keyMap);
-  virtual void fakeKey(const Keystroke &keystroke);
+  void getKeyMap(deskflow::KeyMap &keyMap) override;
+  void fakeKey(const Keystroke &keystroke) override;
 
 private:
   class KeyResource;

--- a/src/lib/platform/OSXPowerManager.cpp
+++ b/src/lib/platform/OSXPowerManager.cpp
@@ -8,10 +8,6 @@
 #include "OSXPowerManager.h"
 #include "base/Log.h"
 
-OSXPowerManager::OSXPowerManager()
-{
-}
-
 OSXPowerManager::~OSXPowerManager()
 {
   enableSleep();

--- a/src/lib/platform/OSXPowerManager.h
+++ b/src/lib/platform/OSXPowerManager.h
@@ -12,7 +12,7 @@
 class OSXPowerManager
 {
 public:
-  OSXPowerManager();
+  OSXPowerManager() = default;
   ~OSXPowerManager();
 
   /**

--- a/src/lib/platform/OSXScreenSaver.h
+++ b/src/lib/platform/OSXScreenSaver.h
@@ -18,14 +18,14 @@ class OSXScreenSaver : public IScreenSaver
 {
 public:
   OSXScreenSaver(IEventQueue *events, void *eventTarget);
-  virtual ~OSXScreenSaver();
+  ~OSXScreenSaver();
 
   // IScreenSaver overrides
-  virtual void enable();
-  virtual void disable();
-  virtual void activate();
-  virtual void deactivate();
-  virtual bool isActive() const;
+  void enable() override;
+  void disable() override;
+  void activate() override;
+  void deactivate() override;
+  bool isActive() const override;
 
 private:
   void processLaunched(ProcessSerialNumber psn);

--- a/src/lib/platform/OSXUchrKeyResource.h
+++ b/src/lib/platform/OSXUchrKeyResource.h
@@ -19,12 +19,12 @@ public:
   OSXUchrKeyResource(const void *, uint32_t keyboardType);
 
   // KeyResource overrides
-  virtual bool isValid() const;
-  virtual uint32_t getNumModifierCombinations() const;
-  virtual uint32_t getNumTables() const;
-  virtual uint32_t getNumButtons() const;
-  virtual uint32_t getTableForModifier(uint32_t mask) const;
-  virtual KeyID getKey(uint32_t table, uint32_t button) const;
+  bool isValid() const override;
+  uint32_t getNumModifierCombinations() const override;
+  uint32_t getNumTables() const override;
+  uint32_t getNumButtons() const override;
+  uint32_t getTableForModifier(uint32_t mask) const override;
+  KeyID getKey(uint32_t table, uint32_t button) const override;
 
 private:
   using KeySequence = std::vector<KeyID>;


### PR DESCRIPTION
similar to #8564  get `override` and use of default constructors / deconstructors