### PR TITLE
Better detect windows Arm64 on both CI and local builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,14 @@ set(REQUIRED_LIBPORTAL_VERSION 0.8)
 set(REQUIRED_QT_VERSION 6.7.0)
 
 if (WIN32)
+  # VSCMD_ARG_TGT_ARCH is set on CI
   if ("$ENV{VSCMD_ARG_TGT_ARCH}" STREQUAL "")
-    set (BUILD_ARCHITECTURE x64)
+    # NOT on CI
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]64")
+      set(BUILD_ARCHITECTURE arm64)
+    else()
+      set(BUILD_ARCHITECTURE x64)
+    endif()
   else()
     set (BUILD_ARCHITECTURE $ENV{VSCMD_ARG_TGT_ARCH})
   endif()


### PR DESCRIPTION
 When testing locally with win arm64 the detection was incorrect. I have adjusted the check to look for the CI's ENV var then try to use the CMAKE_SYSTEM_PROCESSOR when detecting the cpu type on windows