### PR TITLE
fix: Disable the save button when config not writable

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -252,6 +252,8 @@ void SettingsDialog::updateControls()
   const bool serviceChecked = ui->groupService->isChecked();
   const bool logToFile = ui->cbLogToFile->isChecked();
 
+  ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(writable);
+
   ui->sbPort->setEnabled(writable);
   ui->lineInterface->setEnabled(writable);
   ui->comboLogLevel->setEnabled(writable);


### PR DESCRIPTION
Todo:
- [x] Test