### PR TITLE
build(vcpkg): Set `github-binarycache` on `vcpkg-action`

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -94,6 +94,7 @@ runs:
         extra-args: --classic
         triplet: x64-windows-release
         token: ${{ github.token }}
+        github-binarycache: true
 
     - name: Install Wix
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
I wonder if we should be setting `github-binarycache`?

Both examples in the readme say to set it:
https://github.com/johnwason/vcpkg-action

And it appears to be reccomended:
```
    # "Use vcpkg built-in GitHub binary caching if "true". If not specified, will use the dry-run based file cache."
    # Recommended set to "true"
    github-binarycache: ''
```