### PR TITLE
Do not use SHA1

### DIFF
--- a/src/lib/common/Constants.h.in
+++ b/src/lib/common/Constants.h.in
@@ -34,7 +34,6 @@ const auto kDebugBuild = false;
 #endif
 
 const auto kTlsDirName = "tls";
-const auto kTlsDbSize = 2;
 const auto kTlsCertificateFilename = "@CMAKE_PROJECT_NAME@.pem";
 const auto kTlsFingerprintLocalFilename = "local-fingerprint";
 const auto kTlsFingerprintTrustedServersFilename = "trusted-servers";

--- a/src/lib/gui/dialogs/FingerprintDialog.cpp
+++ b/src/lib/gui/dialogs/FingerprintDialog.cpp
@@ -13,13 +13,11 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-FingerprintDialog::FingerprintDialog(
-    QWidget *parent, const QList<Fingerprint> &fingerprints, FingerprintDialogMode mode
-)
+FingerprintDialog::FingerprintDialog(QWidget *parent, const Fingerprint &fingerprint, FingerprintDialogMode mode)
     : QDialog(parent),
       m_lblHeader{new QLabel(this)},
       m_lblFooter{new QLabel(this)},
-      m_fingerprintPreview{new FingerprintPreview(this, fingerprints)},
+      m_fingerprintPreview{new FingerprintPreview(this, fingerprint)},
       m_buttonBox{new QDialogButtonBox(this)}
 {
   setWindowIcon(QIcon::fromTheme("fingerprint"));

--- a/src/lib/gui/dialogs/FingerprintDialog.h
+++ b/src/lib/gui/dialogs/FingerprintDialog.h
@@ -27,7 +27,7 @@ class FingerprintDialog : public QDialog
 
 public:
   explicit FingerprintDialog(
-      QWidget *parent = nullptr, const QList<Fingerprint> &fingerprints = {},
+      QWidget *parent = nullptr, const Fingerprint &fingerprint = {},
       FingerprintDialogMode mode = FingerprintDialogMode::Local
   );
   ~FingerprintDialog() override = default;

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -52,18 +52,9 @@ bool TlsCertificate::generateFingerprint(const QString &certificateFilename)
 {
   qDebug("generating tls fingerprint");
   const std::string certPath = certificateFilename.toStdString();
-  try {
-    FingerprintDatabase db;
-    db.addTrusted(deskflow::pemFileCertFingerprint(certPath, Fingerprint::Type::SHA1));
-    db.addTrusted(deskflow::pemFileCertFingerprint(certPath, Fingerprint::Type::SHA256));
-    db.write(Settings::tlsLocalDb());
-
-    qDebug("tls fingerprint generated");
-    return true;
-  } catch (const std::exception &e) {
-    qCritical() << "failed to find tls fingerprint: " << e.what();
-    return false;
-  }
+  FingerprintDatabase db;
+  db.addTrusted(deskflow::pemFileCertFingerprint(certPath, Fingerprint::Type::SHA256));
+  return db.write(Settings::tlsLocalDb());
 }
 
 int TlsCertificate::getCertKeyLength(const QString &path)

--- a/src/lib/gui/widgets/FingerprintPreview.h
+++ b/src/lib/gui/widgets/FingerprintPreview.h
@@ -13,6 +13,10 @@ class FingerprintPreview : public QFrame
 {
   Q_OBJECT
 public:
-  explicit FingerprintPreview(QWidget *parent, const QList<Fingerprint> &fingerprints = {});
+  explicit FingerprintPreview(QWidget *parent, const Fingerprint &fingerprint = {});
   ~FingerprintPreview() override = default;
+
+private:
+  QLayout *emptyLayout();
+  QLayout *sha256Layout(const Fingerprint &fingerprint = {});
 };

--- a/src/lib/net/FingerprintDatabase.cpp
+++ b/src/lib/net/FingerprintDatabase.cpp
@@ -48,29 +48,30 @@ void FingerprintDatabase::readStream(QTextStream &in)
   }
 }
 
-void FingerprintDatabase::write(const QString &path)
+bool FingerprintDatabase::write(const QString &path)
 {
   QFile file(path);
   if (!file.open(QIODevice::WriteOnly))
-    return;
+    return false;
   QTextStream out(&file);
-  writeStream(out);
+  return (writeStream(out));
 }
 
-void FingerprintDatabase::writeStream(QTextStream &out)
+bool FingerprintDatabase::writeStream(QTextStream &out)
 {
   // Make sure the stream has somewhere to write
   if (!out.device() && !out.string())
-    return;
+    return false;
 
   if (out.device()) {
     if (!out.device()->isWritable())
-      return;
+      return false;
   }
 
   for (const auto &fingerprint : std::as_const(m_fingerprints)) {
     out << fingerprint.toDbLine() << "\n";
   }
+  return true;
 }
 
 void FingerprintDatabase::clear()

--- a/src/lib/net/FingerprintDatabase.h
+++ b/src/lib/net/FingerprintDatabase.h
@@ -15,10 +15,10 @@ class FingerprintDatabase
 {
 public:
   void read(const QString &path);
-  void write(const QString &path);
+  bool write(const QString &path);
 
   void readStream(QTextStream &in);
-  void writeStream(QTextStream &out);
+  bool writeStream(QTextStream &out);
 
   void clear();
   void addTrusted(const Fingerprint &fingerprint);

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -645,23 +645,14 @@ void SecureSocket::disconnect()
 
 bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
 {
-  Fingerprint sha1;
-  Fingerprint sha256;
-  try {
-    auto cert = SSL_get_peer_certificate(m_ssl->m_ssl);
-    sha1 = deskflow::sslCertFingerprint(cert, Fingerprint::Type::SHA1);
-    sha256 = deskflow::sslCertFingerprint(cert, Fingerprint::Type::SHA256);
-  } catch (const std::exception &e) {
-    LOG((CLOG_ERR "%s", e.what()));
-    return false;
-  }
+  const auto cert = SSL_get_peer_certificate(m_ssl->m_ssl);
+  const auto sha256 = deskflow::sslCertFingerprint(cert, Fingerprint::Type::SHA256);
 
-  // Gui Must Parse these two lines, DO NOT CHANGE
-  LOG(
-      (CLOG_NOTE "peer fingerprint: (SHA1) %s (SHA256) %s",
-       deskflow::formatSSLFingerprint(sha1.data).toStdString().c_str(),
-       deskflow::formatSSLFingerprint(sha256.data).toStdString().c_str())
-  );
+  if (!sha256.isValid())
+    return false;
+
+  // Gui Must Parse this line, DO NOT CHANGE
+  LOG((CLOG_NOTE "peer fingerprint: %s", deskflow::formatSSLFingerprint(sha256.data, false).toStdString().c_str()));
 
   QFile file(FingerprintDatabasePath);
 


### PR DESCRIPTION
Remove most support for SHA1

No Longer:
 - Write SHA1 hash to localDB
 - Send a SHA1 when sending peer fingerprints.
- Preview SHA1 in the Fingerprint preview

We still support SHA1 As a valid digest type in fingerprint. We can recognize them but don't use them anymore.