### PR TITLE
Resolve `deprecated-enum-float-conversion` compiler warnings

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -54,10 +54,7 @@ enum
   kDeskflowMouseScrollAxisY = 'saxy'
 };
 
-enum
-{
-  kCarbonLoopWaitTimeout = 10
-};
+static const double kCarbonLoopWaitTimeout = 10.0;
 
 int getSecureInputEventPID();
 std::string getProcessName(int pid);


### PR DESCRIPTION
Observed on macOS Monterey 12.7.6 with cmake version 4.0.1, Homebrew clang version 20.1.4, Target: x86_64-apple-darwin21.6.0:

```
$ CXX="$(brew --prefix llvm)/bin/clang++" CC="$(brew --prefix llvm)/bin/clang" cmake -S . -B build-clang -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=/usr/local/Homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake -Wno-dev -DBUILD_TESTING=OFF -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -DBUILD_TESTS:BOOL=OFF -DCMAKE_INSTALL_DO_STRIP=1 -DSYSTEM_PUGIXML:BOOL=ON
...

$ CXX="$(brew --prefix llvm)/bin/clang++" CC="$(brew --prefix llvm)/bin/clang" cmake --build build-clang
...
[ 50%] Building CXX object src/lib/platform/CMakeFiles/platform.dir/OSXScreen.mm.o
cd /Users/samumbach/src/personal/deskflow/build-clang/src/lib/platform && /usr/local/opt/llvm/bin/clang++ -DHAVE_CONFIG_H -DNDEBUG -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DSYSAP
I_UNIX=1 -DWINAPI_CARBON=1 -D_THREAD_SAFE -I/Users/samumbach/src/personal/deskflow/build-clang/src/lib/platform/platform_autogen/include -I/Users/samumbach/src/personal/deskflow/src/.
/lib -I/Users/samumbach/src/personal/deskflow/build-clang/src/lib -I/System/Library/Frameworks -F/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/System/Library/Frameworks -isyst
em /usr/local/lib/QtCore.framework/Headers -iframework /usr/local/lib -isystem /usr/local/share/qt/mkspecs/macx-clang -isystem /usr/local/include -isystem /usr/local/lib/QtNetwork.fra
mework/Headers -isystem /usr/local/Cellar/openssl@3/3.5.0/include --sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk  -DGTEST_USE_OWN_TR1_TUPLE=1 -O3 -DNDEBUG -std=c++20
-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12 -fPIC -MD -MT src/lib/platform/CMakeFiles/platform.dir/OSXScreen.mm.o -MF CMakeFiles/platform.d
ir/OSXScreen.mm.o.d -o CMakeFiles/platform.dir/OSXScreen.mm.o -c /Users/samumbach/src/personal/deskflow/src/lib/platform/OSXScreen.mm
/Users/samumbach/src/personal/deskflow/src/lib/platform/OSXScreen.mm:1758:33: warning: arithmetic between floating-point type 'double' and enumeration type '(unnamed enum at /Users/samumbach/src/personal/deskflow/src/lib/platform/OSXScreen.mm:57:1)' is deprecated [-Wdeprecated-enum-float-conversion]
 1758 |   double timeout = ARCH->time() + kCarbonLoopWaitTimeout;
      |                    ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~
/Users/samumbach/src/personal/deskflow/src/lib/platform/OSXScreen.mm:1762:30: warning: arithmetic between floating-point type 'double' and enumeration type '(unnamed enum at /Users/samumbach/src/personal/deskflow/src/lib/platform/OSXScreen.mm:57:1)' is deprecated [-Wdeprecated-enum-float-conversion]
 1762 |       timeout = ARCH->time() + kCarbonLoopWaitTimeout;
      |                 ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
...
```

See also https://github.com/symless/synergy/pull/55.