### PR TITLE
fix settings modifiers initilization, move initization to header

### DIFF
--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -15,18 +15,7 @@ using enum ScreenConfig::Fix;
 
 Screen::Screen(const QString &name)
 {
-  init();
   setName(name);
-}
-
-void Screen::init()
-{
-  m_Name.clear();
-  m_Aliases.clear();
-  m_SwitchCornerSize = 0;
-  m_Modifiers.fill(0, static_cast<int>(NumModifiers));
-  m_SwitchCorners.fill(false, static_cast<int>(NumSwitchCorners));
-  m_Fixes.fill(false, static_cast<int>(NumFixes));
 }
 
 void Screen::loadSettings(QSettingsProxy &settings)

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -115,8 +115,6 @@ public:
   bool operator==(const Screen &screen) const;
 
 protected:
-  void init();
-
   QStringList &aliases()
   {
     return m_Aliases;
@@ -160,12 +158,12 @@ protected:
 
 private:
   QPixmap m_Pixmap = QIcon::fromTheme("video-display").pixmap(QSize(96, 96));
-  QString m_Name;
-  QStringList m_Aliases;
-  QList<int> m_Modifiers;
-  QList<bool> m_SwitchCorners;
+  QString m_Name = {};
+  QStringList m_Aliases = {};
+  QList<int> m_Modifiers = {0, 1, 2, 3, 4, 5};
+  QList<bool> m_SwitchCorners = {false, false, false, false};
   int m_SwitchCornerSize = 0;
-  QList<bool> m_Fixes;
+  QList<bool> m_Fixes{false, false, false, false};
   bool m_Swapped = false;
   bool m_isServer = false;
 };

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
@@ -79,8 +79,6 @@ void ScreenSettingsDialog::accept()
     return;
   }
 
-  m_pScreen->init();
-
   m_pScreen->setName(ui_->m_pLineEditName->text());
 
   for (int i = 0; i < ui_->m_pListAliases->count(); i++) {


### PR DESCRIPTION
fixes: #8587

My mistake there was a small error i missed at review time in https://github.com/deskflow/deskflow/pull/8580 that initialized our modifiers to 0.
This fixes that initialization moves them to the header and removes the now no needed init() method