### PR TITLE
fix: lockup if first run message is up and a client connects

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -286,7 +286,10 @@ void MainWindow::connectSlots()
   connect(&m_coreProcess, &CoreProcess::starting, this, &MainWindow::coreProcessStarting, Qt::DirectConnection);
   connect(&m_coreProcess, &CoreProcess::error, this, &MainWindow::coreProcessError);
   connect(&m_coreProcess, &CoreProcess::logLine, this, &MainWindow::handleLogLine);
-  connect(&m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged);
+  connect(
+      &m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged,
+      Qt::QueuedConnection
+  );
   connect(&m_coreProcess, &CoreProcess::connectionStateChanged, this, &MainWindow::coreConnectionStateChanged);
   connect(&m_coreProcess, &CoreProcess::secureSocket, this, &MainWindow::secureSocket);
   connect(


### PR DESCRIPTION
 Fix a possible crash if the first server run dialog is up when a new client and the fingerprint is dealt with and screen added the app would freeze w/ the first server run dialog showing.. (this allows you to close it)

shown in https://github.com/deskflow/deskflow/issues/8599

1. Have working config (server with clients connected)
1. Clear settings (on the server only let the client continue to connect)
1. Start server (do not touch the first time server message box)
1. See 'Server is running' and fingerprint dialogs at the same time (fingerprint dialog appears in front and no freeze)
1. Accept the fingerprints and add the screen to the server config (you must fully connect the client, accept it etc)
1. If the new server dialog is open still the app will freeze.
