### PR TITLE
More Sonar cleanup

### DIFF
--- a/src/lib/arch/ArchDaemonNone.cpp
+++ b/src/lib/arch/ArchDaemonNone.cpp
@@ -21,7 +21,7 @@ void ArchDaemonNone::uninstallDaemon(const char *)
   // do nothing
 }
 
-int ArchDaemonNone::daemonize(const char *name, DaemonFunc func)
+int ArchDaemonNone::daemonize(const char *name, DaemonFunc const &func)
 {
   // simply forward the call to func.  obviously, this doesn't
   // do any daemonizing.

--- a/src/lib/arch/ArchDaemonNone.h
+++ b/src/lib/arch/ArchDaemonNone.h
@@ -29,7 +29,7 @@ public:
       const char *name, const char *description, const char *pathname, const char *commandLine, const char *dependencies
   ) override;
   void uninstallDaemon(const char *name) override;
-  int daemonize(const char *name, DaemonFunc func) override;
+  int daemonize(const char *name, DaemonFunc const &func) override;
   bool canInstallDaemon(const char *name) override;
   bool isDaemonInstalled(const char *name) override;
   void installDaemon() override;

--- a/src/lib/arch/IArchDaemon.h
+++ b/src/lib/arch/IArchDaemon.h
@@ -88,7 +88,7 @@ public:
     \c ArchMiscWindows::daemonFailed() to indicate startup failure.
   </ul>
   */
-  virtual int daemonize(const char *name, DaemonFunc func) = 0;
+  virtual int daemonize(const char *name, DaemonFunc const &func) = 0;
 
   //! Check if user has permission to install the daemon
   /*!

--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -61,7 +61,7 @@ class IArchMultithread : public IInterface
 {
 public:
   //! Type of thread entry point
-  typedef void *(*ThreadFunc)(void *);
+  using ThreadFunc = void *(*)(void *);
   //! Type of thread identifier
   using ThreadID = unsigned int;
   //! Types of signals
@@ -78,7 +78,7 @@ public:
     kNUM_SIGNALS
   };
   //! Type of signal handler function
-  typedef void (*SignalFunc)(ESignal, void *userData);
+  using SignalFunc = void (*)(ESignal, void *userData);
 
   //! @name manipulators
   //@{

--- a/src/lib/arch/IArchString.cpp
+++ b/src/lib/arch/IArchString.cpp
@@ -55,8 +55,7 @@ int IArchString::convStringWCToMB(char *dst, const wchar_t *src, uint32_t n, boo
       len += mblen;
       ++scan;
     }
-    ptrdiff_t mblen = wctomb(dummy, L'\0');
-    if (mblen != -1) {
+    if (ptrdiff_t mblen = wctomb(dummy, L'\0'); mblen != -1) {
       len += mblen - 1;
     }
   } else {
@@ -72,8 +71,7 @@ int IArchString::convStringWCToMB(char *dst, const wchar_t *src, uint32_t n, boo
       }
       ++scan;
     }
-    ptrdiff_t mblen = wctomb(dst, L'\0');
-    if (mblen != -1) {
+    if (ptrdiff_t mblen = wctomb(dst, L'\0'); mblen != -1) {
       // don't include nul terminator
       dst += mblen - 1;
     }
@@ -104,8 +102,7 @@ int IArchString::convStringMBToWC(wchar_t *dst, const char *src, uint32_t n, boo
   if (dst == nullptr) {
     const char *scan = src;
     while (n > 0) {
-      ptrdiff_t mblen = mbtowc(&dummy, scan, n);
-      switch (mblen) {
+      switch (ptrdiff_t mblen = mbtowc(&dummy, scan, n); mblen) {
       case -2:
         // incomplete last character.  convert to unknown character.
         *errors = true;
@@ -140,8 +137,7 @@ int IArchString::convStringMBToWC(wchar_t *dst, const char *src, uint32_t n, boo
     wchar_t *dst0 = dst;
     const char *scan = src;
     while (n > 0) {
-      ptrdiff_t mblen = mbtowc(dst, scan, n);
-      switch (mblen) {
+      switch (ptrdiff_t mblen = mbtowc(dst, scan, n); mblen) {
       case -2:
         // incomplete character.  convert to unknown character.
         *errors = true;

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -74,8 +74,7 @@ int ArchDaemonUnix::daemonize(const char *name, DaemonFunc const &func)
   // NB: don't run chdir on apple; causes strange behaviour.
   // chdir to root so we don't keep mounted filesystems points busy
   // TODO: this is a bit of a hack - can we find a better solution?
-  int chdirErr = chdir("/");
-  if (chdirErr)
+  if (int chdirErr = chdir("/"); chdirErr)
     // NB: file logging actually isn't working at this point!
     LOG((CLOG_ERR "chdir error: %i", chdirErr));
 #endif
@@ -93,9 +92,7 @@ int ArchDaemonUnix::daemonize(const char *name, DaemonFunc const &func)
   open("/dev/null", O_RDONLY);
   open("/dev/null", O_RDWR);
 
-  int dupErr = dup(1);
-
-  if (dupErr < 0) {
+  if (int dupErr = dup(1); dupErr < 0) {
     // NB: file logging actually isn't working at this point!
     LOG((CLOG_ERR "dup error: %i", dupErr));
   }

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -44,7 +44,7 @@ bool alreadyDaemonized()
 
 #endif
 
-int ArchDaemonUnix::daemonize(const char *name, DaemonFunc func)
+int ArchDaemonUnix::daemonize(const char *name, DaemonFunc const &func)
 {
 #ifdef __APPLE__
   if (alreadyDaemonized())

--- a/src/lib/arch/unix/ArchDaemonUnix.h
+++ b/src/lib/arch/unix/ArchDaemonUnix.h
@@ -20,5 +20,5 @@ public:
   ~ArchDaemonUnix() override = default;
 
   // IArchDaemon overrides
-  int daemonize(const char *name, DaemonFunc func) override;
+  int daemonize(const char *name, DaemonFunc const &func) override;
 };

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -540,7 +540,8 @@ void ArchMultithreadPosix::startSignalHandler()
 {
   // set signal mask.  the main thread blocks these signals and
   // the signal handler thread will listen for them.
-  sigset_t sigset, oldsigset;
+  sigset_t sigset;
+  sigset_t oldsigset;
   setSignalSet(&sigset);
   pthread_sigmask(SIG_BLOCK, &sigset, &oldsigset);
 

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -204,8 +204,7 @@ bool ArchMultithreadPosix::waitCondVar(ArchCond cond, ArchMutex mutex, double ti
   // so we have to return to the caller.  since the caller will
   // always check for spurious wakeups the only drawback here is
   // performance:  we're waking up a lot more than desired.
-  static const double maxCancellationLatency = 0.1;
-  if (timeout < 0.0 || timeout > maxCancellationLatency) {
+  if (static const double maxCancellationLatency = 0.1; timeout < 0.0 || timeout > maxCancellationLatency) {
     timeout = maxCancellationLatency;
   }
 

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -404,8 +404,8 @@ void ArchNetworkBSD::throwErrorOnSocket(ArchSocket s)
 
   // get the error from the socket layer
   int err = 0;
-  auto size = static_cast<socklen_t>(sizeof(err));
-  if (getsockopt(s->m_fd, SOL_SOCKET, SO_ERROR, reinterpret_cast<optval_t *>(&err), &size) == -1) {
+  if (auto size = static_cast<socklen_t>(sizeof(err));
+      getsockopt(s->m_fd, SOL_SOCKET, SO_ERROR, reinterpret_cast<optval_t *>(&err), &size) == -1) {
     err = errno;
   }
 
@@ -545,8 +545,8 @@ std::vector<ArchNetAddress> ArchNetworkBSD::nameToAddr(const std::string &name)
   // done with static buffer
   ARCH->lockMutex(m_mutex);
   struct addrinfo *pResult = nullptr;
-  int ret = getaddrinfo(name.c_str(), nullptr, &hints, &pResult);
-  if (ret != 0) {
+
+  if (int ret = getaddrinfo(name.c_str(), nullptr, &hints, &pResult); ret != 0) {
     ARCH->unlockMutex(m_mutex);
     throwNameError(ret);
   }
@@ -585,9 +585,10 @@ std::string ArchNetworkBSD::addrToName(ArchNetAddress addr)
   ARCH->lockMutex(m_mutex);
   char host[1024];
   char service[20];
-  int ret =
-      getnameinfo(TYPED_ADDR(struct sockaddr, addr), addr->m_len, host, sizeof(host), service, sizeof(service), 0);
-  if (ret != 0) {
+
+  if (int ret =
+          getnameinfo(TYPED_ADDR(struct sockaddr, addr), addr->m_len, host, sizeof(host), service, sizeof(service), 0);
+      ret != 0) {
     ARCH->unlockMutex(m_mutex);
     throwNameError(ret);
   }

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -65,7 +65,6 @@ static in_addr_t inet_aton(const char *cp, struct in_addr *inp)
 
 void ArchNetworkBSD::Deps::sleep(double seconds)
 {
-  //
   ARCH->sleep(seconds);
 }
 

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -751,7 +751,7 @@ const int *ArchNetworkBSD::getUnblockPipeForThread(ArchThread thread)
   return unblockPipe;
 }
 
-void ArchNetworkBSD::throwError(int err)
+void ArchNetworkBSD::throwError(int err) const
 {
   switch (err) {
   case EINTR:
@@ -822,7 +822,7 @@ void ArchNetworkBSD::throwError(int err)
   }
 }
 
-void ArchNetworkBSD::throwNameError(int err)
+void ArchNetworkBSD::throwNameError(int err) const
 {
   static const char *s_msg[] = {
       "The specified host is unknown", "The requested name is valid but does not have an IP address",

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -55,6 +55,7 @@ class ArchNetAddressImpl
 public:
   ArchNetAddressImpl() : m_len(sizeof(m_addr))
   {
+    // do nothing
   }
 
 public:

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -123,8 +123,8 @@ private:
   const int *getUnblockPipe();
   const int *getUnblockPipeForThread(ArchThread);
   void setBlockingOnSocket(int fd, bool blocking);
-  void throwError(int);
-  void throwNameError(int);
+  void throwError(int) const;
+  void throwNameError(int) const;
 
 private:
   std::shared_ptr<Deps> m_pDeps;

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -15,6 +15,7 @@ class XArchEvalUnix : public XArchEval
 public:
   explicit XArchEvalUnix(int error) : m_error(error)
   {
+    // do nothing
   }
   ~XArchEvalUnix() noexcept override = default;
 

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -187,7 +187,7 @@ void ArchDaemonWindows::uninstallDaemon(const char *name)
   }
 }
 
-int ArchDaemonWindows::daemonize(const char *name, DaemonFunc func)
+int ArchDaemonWindows::daemonize(const char *name, DaemonFunc const &func)
 {
   assert(name != nullptr);
   assert(func != nullptr);

--- a/src/lib/arch/win32/ArchDaemonWindows.h
+++ b/src/lib/arch/win32/ArchDaemonWindows.h
@@ -74,7 +74,7 @@ public:
   void uninstallDaemon(const char *name) override;
   void installDaemon() override;
   void uninstallDaemon() override;
-  int daemonize(const char *name, DaemonFunc func) override;
+  int daemonize(const char *name, DaemonFunc const &func) override;
   bool canInstallDaemon(const char *name) override;
   bool isDaemonInstalled(const char *name) override;
   std::string commandLine() const

--- a/src/lib/base/Event.cpp
+++ b/src/lib/base/Event.cpp
@@ -33,6 +33,7 @@ Event::Event(EventTypes type, void *target, EventData *dataObject)
       m_flags(kNone),
       m_dataObject(dataObject)
 {
+  // do nothing
 }
 
 EventTypes Event::getType() const

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -88,7 +88,7 @@ void EventQueue::adoptBuffer(IEventQueueBuffer *buffer)
 
   // discard old buffer and old events
   delete m_buffer;
-  for (EventTable::iterator i = m_events.begin(); i != m_events.end(); ++i) {
+  for (auto i = m_events.begin(); i != m_events.end(); ++i) {
     Event::deleteData(i->second);
   }
   m_events.clear();
@@ -200,7 +200,7 @@ void EventQueue::addEventToBuffer(const Event &event)
   ArchMutexLock lock(m_mutex);
 
   // store the event's data locally
-  uint32_t eventID = saveEvent(event);
+  auto eventID = saveEvent(event);
 
   // add it
   if (!m_buffer->addEvent(eventID)) {

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -121,8 +121,8 @@ retry:
     // get time until next timer expires.  if there is a timer
     // and it'll expire before the client's timeout then use
     // that duration for our timeout instead.
-    double timerTimeout = getNextTimerTimeout();
-    if (timeout < 0.0 || (timerTimeout >= 0.0 && timerTimeout < timeLeft)) {
+    if (double timerTimeout = getNextTimerTimeout();
+        timeout < 0.0 || (timerTimeout >= 0.0 && timerTimeout < timeLeft)) {
       timeLeft = timerTimeout;
     }
 
@@ -253,8 +253,7 @@ void EventQueue::deleteTimer(EventQueueTimer *timer)
       break;
     }
   }
-  Timers::iterator index = m_timers.find(timer);
-  if (index != m_timers.end()) {
+  if (Timers::iterator index = m_timers.find(timer); index != m_timers.end()) {
     m_timers.erase(index);
   }
   m_buffer->deleteTimer(timer);
@@ -316,8 +315,7 @@ bool EventQueue::isEmpty() const
 IEventJob *EventQueue::getHandler(EventTypes type, void *target) const
 {
   ArchMutexLock lock(m_mutex);
-  HandlerTable::const_iterator index = m_handlers.find(target);
-  if (index != m_handlers.end()) {
+  if (HandlerTable::const_iterator index = m_handlers.find(target); index != m_handlers.end()) {
     const TypeHandlerTable &typeHandlers = index->second;
     TypeHandlerTable::const_iterator index2 = typeHandlers.find(type);
     if (index2 != typeHandlers.end()) {

--- a/src/lib/base/FinalAction.h
+++ b/src/lib/base/FinalAction.h
@@ -19,6 +19,7 @@ public:
 
   explicit FinalAction(Callable callable) noexcept : m_callable{callable}
   {
+    // do nothing
   }
 
   ~FinalAction() noexcept

--- a/src/lib/base/LogOutputters.cpp
+++ b/src/lib/base/LogOutputters.cpp
@@ -72,8 +72,9 @@ bool ConsoleLogOutputter::write(ELevel level, const char *msg)
   return true;
 }
 
-void ConsoleLogOutputter::flush()
+void ConsoleLogOutputter::flush() const
 {
+  // do nothing
 }
 
 //

--- a/src/lib/base/LogOutputters.h
+++ b/src/lib/base/LogOutputters.h
@@ -47,7 +47,7 @@ public:
   void close() override;
   void show(bool showIfEmpty) override;
   bool write(ELevel level, const char *message) override;
-  void flush();
+  void flush() const;
 };
 
 //! Write log to file

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -439,8 +439,7 @@ std::string Unicode::doUTF16ToUTF8(const uint8_t *data, uint32_t n, bool *errors
 
   // convert each character
   while (n > 0) {
-    uint32_t c = decode16(data, byteSwapped);
-    if (c < 0x0000d800 || c > 0x0000dfff) {
+    if (uint32_t c = decode16(data, byteSwapped); c < 0x0000d800 || c > 0x0000dfff) {
       toUTF8(dst, c, errors);
     } else if (n == 1) {
       // error -- missing second word
@@ -449,8 +448,7 @@ std::string Unicode::doUTF16ToUTF8(const uint8_t *data, uint32_t n, bool *errors
     } else if (c >= 0x0000d800 && c <= 0x0000dbff) {
       data += 2;
       --n;
-      uint32_t c2 = decode16(data, byteSwapped);
-      if (c2 < 0x0000dc00 || c2 > 0x0000dfff) {
+      if (uint32_t c2 = decode16(data, byteSwapped); c2 < 0x0000dc00 || c2 > 0x0000dfff) {
         // error -- [d800,dbff] not followed by [dc00,dfff]
         setError(errors);
         toUTF8(dst, s_replacement, nullptr);
@@ -644,8 +642,8 @@ uint32_t Unicode::fromUTF8(const uint8_t *&data, uint32_t &n)
   }
 
   // check for characters that didn't use the smallest possible encoding
-  static uint32_t s_minChar[] = {0, 0x00000000, 0x00000080, 0x00000800, 0x00010000, 0x00200000, 0x04000000};
-  if (c < s_minChar[size]) {
+  if (static uint32_t s_minChar[] = {0, 0x00000000, 0x00000080, 0x00000800, 0x00010000, 0x00200000, 0x04000000};
+      c < s_minChar[size]) {
     return s_invalid;
   }
 

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -403,7 +403,7 @@ std::string Unicode::doUCS4ToUTF8(const uint8_t *data, uint32_t n, bool *errors)
 
   // convert each character
   for (; n > 0; --n) {
-    uint32_t c = decode32(data, byteSwapped);
+    auto c = decode32(data, byteSwapped);
     toUTF8(dst, c, errors);
     data += 4;
   }
@@ -496,7 +496,7 @@ std::string Unicode::doUTF32ToUTF8(const uint8_t *data, uint32_t n, bool *errors
 
   // convert each character
   for (; n > 0; --n) {
-    uint32_t c = decode32(data, byteSwapped);
+    auto c = decode32(data, byteSwapped);
     if (c >= 0x00110000) {
       setError(errors);
       c = s_replacement;

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -45,6 +45,7 @@ public:
   public:
     FailInfo(const char *what) : m_retry(false), m_what(what)
     {
+      // do nothing
     }
     bool m_retry;
     std::string m_what;

--- a/src/lib/client/HelloBack.h
+++ b/src/lib/client/HelloBack.h
@@ -25,6 +25,7 @@ public:
         : m_invalidHello(std::move(invalidHello)),
           m_incompatible(std::move(incompatible))
     {
+      // do nothing
     }
     virtual ~Deps() = default;
 
@@ -51,6 +52,7 @@ public:
         m_majorVersion(majorVersion),
         m_minorVersion(minorVersion)
   {
+    // do nothing
   }
 
   /**

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -182,7 +182,8 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const uint8_t *code)
   }
 
   else if (memcmp(code, kMsgEIncompatible, 4) == 0) {
-    int32_t major, minor;
+    int32_t major;
+    int32_t minor;
     ProtocolUtil::readf(m_stream, kMsgEIncompatible + 4, &major, &minor);
     LOG((CLOG_ERR "server has incompatible version %d.%d", major, minor));
     m_client->refuseConnection("server has incompatible version");
@@ -498,7 +499,8 @@ KeyModifierMask ServerProxy::translateModifierMask(KeyModifierMask mask) const
 void ServerProxy::enter()
 {
   // parse
-  int16_t x, y;
+  int16_t x;
+  int16_t y;
   uint16_t mask;
   uint32_t seqNum;
   ProtocolUtil::readf(m_stream, kMsgCEnter + 4, &x, &y, &seqNum, &mask);
@@ -592,7 +594,10 @@ void ServerProxy::keyRepeat()
   flushCompressedMouse();
 
   // parse
-  uint16_t id, mask, count, button;
+  uint16_t id;
+  uint16_t mask;
+  uint16_t count;
+  uint16_t button;
   std::string lang;
   ProtocolUtil::readf(m_stream, kMsgDKeyRepeat + 4, &id, &mask, &count, &button, &lang);
   LOG(
@@ -617,7 +622,9 @@ void ServerProxy::keyUp()
   flushCompressedMouse();
 
   // parse
-  uint16_t id, mask, button;
+  uint16_t id;
+  uint16_t mask;
+  uint16_t button;
   ProtocolUtil::readf(m_stream, kMsgDKeyUp + 4, &id, &mask, &button);
   LOG((CLOG_DEBUG1 "recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button));
 
@@ -663,7 +670,8 @@ void ServerProxy::mouseMove()
 {
   // parse
   bool ignore;
-  int16_t x, y;
+  int16_t x;
+  int16_t y;
   ProtocolUtil::readf(m_stream, kMsgDMouseMove + 4, &x, &y);
 
   // note if we should ignore the move
@@ -695,7 +703,8 @@ void ServerProxy::mouseRelativeMove()
 {
   // parse
   bool ignore;
-  int16_t dx, dy;
+  int16_t dx;
+  int16_t dy;
   ProtocolUtil::readf(m_stream, kMsgDMouseRelMove + 4, &dx, &dy);
 
   // note if we should ignore the move
@@ -726,7 +735,8 @@ void ServerProxy::mouseWheel()
   flushCompressedMouse();
 
   // parse
-  int16_t xDelta, yDelta;
+  int16_t xDelta;
+  int16_t yDelta;
   ProtocolUtil::readf(m_stream, kMsgDMouseWheel + 4, &xDelta, &yDelta);
   LOG((CLOG_DEBUG2 "recv mouse wheel %+d,%+d", xDelta, yDelta));
 

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -112,8 +112,10 @@ private:
 
   bool m_compressMouse;
   bool m_compressMouseRelative;
-  int32_t m_xMouse, m_yMouse;
-  int32_t m_dxMouse, m_dyMouse;
+  int32_t m_xMouse;
+  int32_t m_yMouse;
+  int32_t m_dxMouse;
+  int32_t m_dyMouse;
 
   bool m_ignoreMouse;
 

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -103,7 +103,7 @@ private:
   void checkMissedLanguages() const;
 
 private:
-  typedef EResult (ServerProxy::*MessageParser)(const uint8_t *);
+  using MessageParser = EResult (ServerProxy::*)(const uint8_t *);
 
   Client *m_client;
   deskflow::IStream *m_stream;

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -135,7 +135,7 @@ void App::setupFileLogging()
   }
 }
 
-void App::loggingFilterWarning()
+void App::loggingFilterWarning() const
 {
   if (CLOG->getFilter() > CLOG->getConsoleMaxLevel()) {
     if (argsBase().m_logFile == nullptr) {

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -37,6 +37,7 @@ public:
   public:
     XNoEiSupport() : std::runtime_error("libei is not supported")
     {
+      // do nothing
     }
   };
 

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -80,7 +80,7 @@ public:
   int run(int argc, char **argv);
   int daemonMainLoop(int, const char **);
   void setupFileLogging();
-  void loggingFilterWarning();
+  void loggingFilterWarning() const;
   void initApp(int argc, const char **argv) override;
   void initApp(int argc, char **argv)
   {

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -218,9 +218,7 @@ bool ArgParser::isArg(
     int argi, int argc, const char *const *argv, const char *name1, const char *name2, int minRequiredParameters
 )
 {
-  const auto match1 = (name1 != nullptr && strcmp(argv[argi], name1) == 0);
-  const auto match2 = (name2 != nullptr && strcmp(argv[argi], name2) == 0);
-  if (match1 || match2) {
+  if ((name1 != nullptr && strcmp(argv[argi], name1) == 0) || (name2 != nullptr && strcmp(argv[argi], name2) == 0)) {
     // match.  check args left.
     if (argi + minRequiredParameters >= argc) {
       LOG((CLOG_PRINT "%s: missing arguments for `%s'" BYE, argsBase().m_pname, argv[argi], argsBase().m_pname));

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -143,7 +143,7 @@ bool ArgParser::parsePlatformArgs(
 #endif
 }
 
-bool ArgParser::parseGenericArgs(int argc, const char *const *argv, int &i)
+bool ArgParser::parseGenericArgs(int argc, const char *const *argv, int &i) const
 {
   if (isArg(i, argc, argv, "-a", "--address", 1)) {
     argsBase().m_deskflowAddress = argv[++i];
@@ -197,7 +197,7 @@ bool ArgParser::parseGenericArgs(int argc, const char *const *argv, int &i)
   return true;
 }
 
-bool ArgParser::parseDeprecatedArgs(int argc, const char *const *argv, int &i)
+bool ArgParser::parseDeprecatedArgs(int argc, const char *const *argv, int &i) const
 {
   static const std::vector<const char *> deprecatedArgs = {
       "--crypto-pass", "--res-w", "--res-h", "--prm-wc", "--prm-hc"
@@ -353,13 +353,13 @@ ArgParser::assembleCommand(std::vector<std::string> &argsArray, std::string igno
   return result;
 }
 
-void ArgParser::updateCommonArgs(const char *const *argv)
+void ArgParser::updateCommonArgs(const char *const *argv) const
 {
   argsBase().m_name = ARCH->getHostName();
   argsBase().m_pname = QFileInfo(argv[0]).fileName().toLocal8Bit().constData();
 }
 
-bool ArgParser::checkUnexpectedArgs()
+bool ArgParser::checkUnexpectedArgs() const
 {
 #if SYSAPI_WIN32
   // suggest that user installs as a windows service. when launched as

--- a/src/lib/deskflow/ArgParser.h
+++ b/src/lib/deskflow/ArgParser.h
@@ -26,9 +26,9 @@ public:
   bool parseServerArgs(deskflow::ServerArgs &args, int argc, const char *const *argv);
   bool parseClientArgs(deskflow::ClientArgs &args, int argc, const char *const *argv);
   bool parsePlatformArgs(deskflow::ArgsBase &argsBase, const int &argc, const char *const *argv, int &i, bool isServer);
-  bool parseGenericArgs(int argc, const char *const *argv, int &i);
-  bool parseDeprecatedArgs(int argc, const char *const *argv, int &i);
-  void setArgsBase(deskflow::ArgsBase &argsBase)
+  bool parseGenericArgs(int argc, const char *const *argv, int &i) const;
+  bool parseDeprecatedArgs(int argc, const char *const *argv, int &i) const;
+  void setArgsBase(deskflow::ArgsBase &argsBase) const
   {
     m_argsBase = &argsBase;
   }
@@ -49,8 +49,8 @@ public:
   }
 
 private:
-  void updateCommonArgs(const char *const *argv);
-  bool checkUnexpectedArgs();
+  void updateCommonArgs(const char *const *argv) const;
+  bool checkUnexpectedArgs() const;
 
 private:
   App *m_app;

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -66,6 +66,7 @@ ClientApp::ClientApp(IEventQueue *events)
       m_clientScreen(nullptr),
       m_serverAddress(nullptr)
 {
+  // do nothing
 }
 
 void ClientApp::parseArgs(int argc, const char *const *argv)

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -204,17 +204,18 @@ void ClientApp::updateStatus()
   updateStatus("");
 }
 
-void ClientApp::updateStatus(const std::string &msg)
+void ClientApp::updateStatus(const std::string &msg) const
 {
+  // do nothing
 }
 
-void ClientApp::resetRestartTimeout()
+void ClientApp::resetRestartTimeout() const
 {
   // retry time can nolonger be changed
   // s_retryTime = 0.0;
 }
 
-double ClientApp::nextRestartTimeout()
+double ClientApp::nextRestartTimeout() const
 {
   // retry at a constant rate (Issue 52)
   return RETRY_TIME;

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -36,6 +36,7 @@ public:
   const char *daemonInfo() const override;
   void loadConfig() override
   {
+    // do nothing
   }
   bool loadConfig(const std::string &pathname) override
   {

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -62,9 +62,9 @@ public:
   //
 
   void updateStatus();
-  void updateStatus(const std::string &msg);
-  void resetRestartTimeout();
-  double nextRestartTimeout();
+  void updateStatus(const std::string &msg) const;
+  void resetRestartTimeout() const;
+  double nextRestartTimeout() const;
   void handleScreenError(const Event &, void *);
   deskflow::Screen *openClientScreen();
   void closeClientScreen(deskflow::Screen *screen);

--- a/src/lib/deskflow/Config.cpp
+++ b/src/lib/deskflow/Config.cpp
@@ -20,6 +20,7 @@ namespace deskflow {
 
 Config::Config(const std::string &filename, const std::string &section) : m_filename(filename), m_section(section)
 {
+  // do nothing
 }
 
 const char *const *Config::argv() const

--- a/src/lib/deskflow/Config.h
+++ b/src/lib/deskflow/Config.h
@@ -28,6 +28,7 @@ public:
   public:
     explicit ParseError() : std::runtime_error("failed to parse config file")
     {
+      // do nothing
     }
   };
 
@@ -36,6 +37,7 @@ public:
   public:
     explicit NoConfigFilenameError() : std::runtime_error("no config file specified")
     {
+      // do nothing
     }
   };
 

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -41,6 +41,7 @@ void showHelp(int argc, char **argv) // NOSONAR - CLI args
 
 DaemonApp::DaemonApp(IEventQueue &events) : m_events(events)
 {
+  // do nothing
 }
 
 DaemonApp::~DaemonApp() = default;

--- a/src/lib/deskflow/DisplayInvalidException.h
+++ b/src/lib/deskflow/DisplayInvalidException.h
@@ -14,9 +14,11 @@ class DisplayInvalidException : public std::runtime_error
 public:
   DisplayInvalidException(const char *msg) : std::runtime_error(msg)
   {
+    // do nothing
   }
 
   DisplayInvalidException(std::string msg) : std::runtime_error(msg)
   {
+    // do nothing
   }
 };

--- a/src/lib/deskflow/IApp.h
+++ b/src/lib/deskflow/IApp.h
@@ -9,7 +9,7 @@
 
 #include "common/IInterface.h"
 
-typedef int (*StartupFunc)(int, char **);
+using StartupFunc = int (*)(int, char **);
 
 namespace deskflow {
 class ArgsBase;

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -17,6 +17,7 @@
 
 IKeyState::IKeyState(IEventQueue *events)
 {
+  // do nothing
 }
 
 //

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -30,6 +30,7 @@ public:
 
   IPlatformScreen(IEventQueue *events) : IKeyState(events)
   {
+    // do nothing
   }
 
   //! Enable screen

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -774,7 +774,8 @@ bool KeyMap::keysToRestoreModifiers(
   ModifierToKeys oldModifiers = activeModifiers;
 
   // get the pressed modifier buttons before and after
-  ButtonToKeyMap oldKeys, newKeys;
+  ButtonToKeyMap oldKeys;
+  ButtonToKeyMap newKeys;
   collectButtons(oldModifiers, oldKeys);
   collectButtons(desiredModifiers, newKeys);
 

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -41,7 +41,7 @@ void KeyMap::swap(KeyMap &x)
   m_modifierKeys.swap(x.m_modifierKeys);
   m_halfDuplex.swap(x.m_halfDuplex);
   m_halfDuplexMods.swap(x.m_halfDuplexMods);
-  int32_t tmp1 = m_numGroups;
+  auto tmp1 = m_numGroups;
   m_numGroups = x.m_numGroups;
   x.m_numGroups = tmp1;
   bool tmp2 = m_composeAcrossGroups;
@@ -57,7 +57,7 @@ void KeyMap::addKeyEntry(const KeyItem &item)
   }
 
   // resize number of groups for key
-  int32_t numGroups = item.m_group + 1;
+  auto numGroups = item.m_group + 1;
   if (getNumGroups() > numGroups) {
     numGroups = getNumGroups();
   }
@@ -105,7 +105,7 @@ void KeyMap::addKeyAliasEntry(
 
   // find a compatible source, preferably in the same group
   for (int32_t gd = 0, n = getNumGroups(); gd < n; ++gd) {
-    int32_t eg = getEffectiveGroup(group, gd);
+    auto eg = getEffectiveGroup(group, gd);
     const KeyItemList *sourceEntry = findCompatibleKey(sourceID, eg, sourceRequired, sourceSensitive);
     if (sourceEntry != nullptr && sourceEntry->size() == 1) {
       KeyMap::KeyItem targetItem = sourceEntry->back();
@@ -155,7 +155,7 @@ bool KeyMap::addKeyCombinationEntry(KeyID id, int32_t group, const KeyID *keys, 
 
     bool found = false;
     for (int32_t gd = 0; gd < n && !found; ++gd) {
-      int32_t eg = (group + gd) % getNumGroups();
+      const auto eg = (group + gd) % getNumGroups();
       const KeyEntryList &entries = groupTable[eg];
       for (size_t j = 0; j < entries.size(); ++j) {
         if (entries[j].size() == 1) {
@@ -301,7 +301,7 @@ void KeyMap::setLanguageData(std::vector<std::string> layouts)
 
 int32_t KeyMap::getLanguageGroupID(int32_t group, const std::string &lang) const
 {
-  int32_t id = group;
+  auto id = group;
 
   if (auto it = std::find(m_keyboardLayouts.begin(), m_keyboardLayouts.end(), lang); it != m_keyboardLayouts.end()) {
     id = static_cast<int>(std::distance(m_keyboardLayouts.begin(), it));
@@ -487,9 +487,9 @@ const KeyMap::KeyItem *KeyMap::mapCommandKey(
 
   // find the first key that generates this KeyID
   const KeyItem *keyItem = nullptr;
-  int32_t numGroups = getNumGroups();
+  const auto numGroups = getNumGroups();
   for (int32_t groupOffset = 0; groupOffset < numGroups; ++groupOffset) {
-    int32_t effectiveGroup = getEffectiveGroup(group, groupOffset);
+    const auto effectiveGroup = getEffectiveGroup(group, groupOffset);
     const KeyEntryList &entryList = keyGroupTable[effectiveGroup];
     for (size_t i = 0; i < entryList.size(); ++i) {
       if (entryList[i].size() != 1) {
@@ -525,7 +525,7 @@ const KeyMap::KeyItem *KeyMap::mapCommandKey(
   // make working copy of modifiers
   ModifierToKeys newModifiers = activeModifiers;
   KeyModifierMask newState = currentState;
-  int32_t newGroup = group;
+  auto newGroup = group;
 
   // don't try to change CapsLock
   desiredMask = (desiredMask & ~KeyModifierCapsLock) | (currentState & KeyModifierCapsLock);
@@ -560,7 +560,7 @@ KeyMap::getKeyItemList(const KeyMap::KeyGroupTable &keyGroupTable, int32_t group
 
   // find best key in any group, starting with the active group
   for (int32_t groupOffset = 0; groupOffset < getNumGroups(); ++groupOffset) {
-    auto effectiveGroup = getEffectiveGroup(group, groupOffset);
+    const auto effectiveGroup = getEffectiveGroup(group, groupOffset);
     auto keyIndex = findBestKey(keyGroupTable[effectiveGroup], desiredMask);
     if (keyIndex != -1) {
       LOG((CLOG_DEBUG1 "found key in group %d", effectiveGroup));
@@ -587,7 +587,7 @@ const KeyMap::KeyItem *KeyMap::mapCharacterKey(
   }
 
   // get keys to press for key
-  auto itemList = getKeyItemList(i->second, getLanguageGroupID(group, lang), desiredMask);
+  const auto itemList = getKeyItemList(i->second, getLanguageGroupID(group, lang), desiredMask);
   if (!itemList || itemList->empty()) {
     // no mapping for this keysym
     LOG((CLOG_DEBUG1 "no mapping for key %04x", id));
@@ -793,7 +793,7 @@ bool KeyMap::keysToRestoreModifiers(
 
   // press wanted keys
   for (auto i = desiredModifiers.begin(); i != desiredModifiers.end(); ++i) {
-    KeyButton button = i->second.m_button;
+    const KeyButton button = i->second.m_button;
     if (button != keyItem.m_button && oldKeys.count(button) == 0) {
       EKeystroke type = kKeystrokePress;
       if (i->second.m_lock) {
@@ -909,8 +909,8 @@ void KeyMap::addKeystrokes(
     Keystrokes &keystrokes
 ) const
 {
-  KeyButton button = keyItem.m_button;
-  uint32_t data = keyItem.m_client;
+  const auto button = keyItem.m_button;
+  const auto data = keyItem.m_client;
   switch (type) {
   case kKeystrokePress:
     keystrokes.push_back(Keystroke(button, true, false, data));

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -303,8 +303,7 @@ int32_t KeyMap::getLanguageGroupID(int32_t group, const std::string &lang) const
 {
   int32_t id = group;
 
-  auto it = std::find(m_keyboardLayouts.begin(), m_keyboardLayouts.end(), lang);
-  if (it != m_keyboardLayouts.end()) {
+  if (auto it = std::find(m_keyboardLayouts.begin(), m_keyboardLayouts.end(), lang); it != m_keyboardLayouts.end()) {
     id = static_cast<int>(std::distance(m_keyboardLayouts.begin(), it));
     LOG((CLOG_DEBUG1 "language %s has group id %d", lang.c_str(), id));
   } else {

--- a/src/lib/deskflow/KeyMap.h
+++ b/src/lib/deskflow/KeyMap.h
@@ -117,7 +117,7 @@ public:
   using ButtonToKeyMap = std::map<KeyButton, const KeyItem *>;
 
   //! Callback type for \c foreachKey
-  typedef void (*ForeachKeyCallback)(KeyID, int32_t group, KeyItem &, void *userData);
+  using ForeachKeyCallback = void (*)(KeyID, int32_t group, KeyItem &, void *userData);
 
   //! @name manipulators
   //@{

--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -1097,7 +1097,8 @@ void KeyState::updateModifierKeyState(
 )
 {
   // get the pressed modifier buttons before and after
-  deskflow::KeyMap::ButtonToKeyMap oldKeys, newKeys;
+  deskflow::KeyMap::ButtonToKeyMap oldKeys;
+  deskflow::KeyMap::ButtonToKeyMap newKeys;
   for (auto i = oldModifiers.begin(); i != oldModifiers.end(); ++i) {
     oldKeys.insert(std::make_pair(i->second.m_button, &i->second));
   }
@@ -1106,7 +1107,8 @@ void KeyState::updateModifierKeyState(
   }
 
   // get the modifier buttons that were pressed or released
-  deskflow::KeyMap::ButtonToKeyMap pressed, released;
+  deskflow::KeyMap::ButtonToKeyMap pressed;
+  deskflow::KeyMap::ButtonToKeyMap released;
   std::set_difference(
       oldKeys.begin(), oldKeys.end(), newKeys.begin(), newKeys.end(), std::inserter(released, released.end()),
       ButtonToKeyLess()

--- a/src/lib/deskflow/KeyState.h
+++ b/src/lib/deskflow/KeyState.h
@@ -72,7 +72,7 @@ public:
   int32_t pollActiveGroup() const override = 0;
   void pollPressedKeys(KeyButtonSet &pressedKeys) const override = 0;
 
-  int32_t getKeyState(KeyButton keyButton)
+  int32_t getKeyState(KeyButton keyButton) const
   {
     return m_keys[keyButton];
   }

--- a/src/lib/deskflow/PlatformScreen.cpp
+++ b/src/lib/deskflow/PlatformScreen.cpp
@@ -13,6 +13,7 @@ PlatformScreen::PlatformScreen(IEventQueue *events, deskflow::ClientScrollDirect
     : IPlatformScreen(events),
       m_clientScrollDirection(scrollDirection)
 {
+  // do nothing
 }
 
 void PlatformScreen::updateKeyMap()

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -353,13 +353,15 @@ public:
   The position of the upper-left corner of the screen.  This is
   typically 0,0.
   */
-  int32_t m_x, m_y;
+  int32_t m_x;
+  int32_t m_y;
 
   //! Screen size
   /*!
   The size of the screen in pixels.
   */
-  int32_t m_w, m_h;
+  int32_t m_w;
+  int32_t m_h;
 
   //! Obsolete (jump zone size)
   int32_t obsolete1;
@@ -368,5 +370,6 @@ public:
   /*!
   The current location of the mouse cursor.
   */
-  int32_t m_mx, m_my;
+  int32_t m_mx;
+  int32_t m_my;
 };

--- a/src/lib/deskflow/ProtocolUtil.cpp
+++ b/src/lib/deskflow/ProtocolUtil.cpp
@@ -75,7 +75,7 @@ void ProtocolUtil::writef(deskflow::IStream *stream, const char *fmt, ...)
 
   va_list args;
   va_start(args, fmt);
-  uint32_t size = getLength(fmt, args);
+  auto size = getLength(fmt, args);
   va_end(args);
   va_start(args, fmt);
   vwritef(stream, fmt, size, args);
@@ -138,7 +138,7 @@ void ProtocolUtil::vreadf(deskflow::IStream *stream, const char *fmt, va_list ar
     if (*fmt == '%') {
       // format specifier.  determine argument size.
       ++fmt;
-      uint32_t len = eatLength(&fmt);
+      auto len = eatLength(&fmt);
       switch (*fmt) {
       case 'i': {
         void *destination = va_arg(args, void *);
@@ -234,7 +234,7 @@ uint32_t ProtocolUtil::getLength(const char *fmt, va_list args)
     if (*fmt == '%') {
       // format specifier.  determine argument size.
       ++fmt;
-      uint32_t len = eatLength(&fmt);
+      auto len = eatLength(&fmt);
       switch (*fmt) {
       case 'i':
         assert(len == 1 || len == 2 || len == 4);
@@ -295,7 +295,7 @@ void ProtocolUtil::writef(std::vector<uint8_t> &buffer, const char *fmt, va_list
     if (*fmt == '%') {
       // format specifier.  determine argument size.
       ++fmt;
-      uint32_t len = eatLength(&fmt);
+      auto len = eatLength(&fmt);
       switch (*fmt) {
       case 'i': {
         const uint32_t v = va_arg(args, uint32_t);
@@ -475,31 +475,31 @@ uint32_t ProtocolUtil::read4BytesInt(deskflow::IStream *stream)
 
 void ProtocolUtil::readVector1ByteInt(deskflow::IStream *stream, std::vector<uint8_t> &destination)
 {
-  uint32_t size = readVectorSize(stream);
-  for (uint32_t i = 0; i < size; ++i) {
+  auto size = readVectorSize(stream);
+  for (auto i = 0; i < size; ++i) {
     destination.push_back(read1ByteInt(stream));
   }
 }
 
 void ProtocolUtil::readVector2BytesInt(deskflow::IStream *stream, std::vector<uint16_t> &destination)
 {
-  uint32_t size = readVectorSize(stream);
-  for (uint32_t i = 0; i < size; ++i) {
+  auto size = readVectorSize(stream);
+  for (auto i = 0; i < size; ++i) {
     destination.push_back(read2BytesInt(stream));
   }
 }
 
 void ProtocolUtil::readVector4BytesInt(deskflow::IStream *stream, std::vector<uint32_t> &destination)
 {
-  uint32_t size = readVectorSize(stream);
-  for (uint32_t i = 0; i < size; ++i) {
+  auto size = readVectorSize(stream);
+  for (auto i = 0; i < size; ++i) {
     destination.push_back(read4BytesInt(stream));
   }
 }
 
 uint32_t ProtocolUtil::readVectorSize(deskflow::IStream *stream)
 {
-  uint32_t size = read4BytesInt(stream);
+  auto size = read4BytesInt(stream);
 
   if (size > PROTOCOL_MAX_LIST_LENGTH) {
     LOG((CLOG_ERR "readVectorSize: vector length exceeds maximum allowed size: %u", size));

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -319,11 +319,7 @@ bool Screen::isOnScreen() const
 
 bool Screen::isLockedToScreen() const
 {
-  // check for pressed mouse buttons
-  // HACK: commented out as it breaks new drag drop feature
-  uint32_t buttonID = 0;
-
-  if (m_screen->isAnyMouseButtonDown(buttonID)) {
+  if (uint32_t buttonID = 0; m_screen->isAnyMouseButtonDown(buttonID)) {
     LOG((CLOG_DEBUG "locked by mouse buttonID: %d", buttonID));
     return true;
   }

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -225,7 +225,7 @@ void Screen::mouseMove(int32_t x, int32_t y)
   m_screen->fakeMouseMove(x, y);
 }
 
-void Screen::mouseRelativeMove(int32_t dx, int32_t dy)
+void Screen::mouseRelativeMove(int32_t dx, int32_t dy) const
 {
   assert(!m_isPrimary);
   m_screen->fakeMouseRelativeMove(dx, dy);
@@ -400,12 +400,12 @@ void Screen::disableSecondary()
   m_screen->closeScreensaver();
 }
 
-void Screen::enterPrimary()
+void Screen::enterPrimary() const
 {
   // do nothing
 }
 
-void Screen::enterSecondary(KeyModifierMask)
+void Screen::enterSecondary(KeyModifierMask) const
 {
   // do nothing
 }

--- a/src/lib/deskflow/Screen.h
+++ b/src/lib/deskflow/Screen.h
@@ -153,7 +153,7 @@ public:
   Synthesize mouse events to generate mouse motion by the relative
   amount \c xRel,yRel.
   */
-  void mouseRelativeMove(int32_t xRel, int32_t yRel);
+  void mouseRelativeMove(int32_t xRel, int32_t yRel) const;
 
   //! Notify of mouse wheel motion
   /*!
@@ -285,8 +285,8 @@ protected:
   void disablePrimary();
   void disableSecondary();
 
-  void enterPrimary();
-  void enterSecondary(KeyModifierMask toggleMask);
+  void enterPrimary() const;
+  void enterSecondary(KeyModifierMask toggleMask) const;
   void leavePrimary();
   void leaveSecondary();
 

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -638,8 +638,7 @@ int ServerApp::mainLoop()
   }
 
   // canonicalize the primary screen name
-  std::string primaryName = args().m_config->getCanonicalName(args().m_name);
-  if (primaryName.empty()) {
+  if (std::string primaryName = args().m_config->getCanonicalName(args().m_name); primaryName.empty()) {
     LOG((CLOG_CRIT "unknown screen name `%s'", args().m_name.c_str()));
     return kExitFailed;
   }

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -269,8 +269,9 @@ void ServerApp::updateStatus()
   updateStatus("");
 }
 
-void ServerApp::updateStatus(const std::string &msg)
+void ServerApp::updateStatus(const std::string &msg) const
 {
+  // do nothing
 }
 
 void ServerApp::closeClientListener(ClientListener *listen)
@@ -603,6 +604,7 @@ void ServerApp::handleNoClients(const Event &, void *)
 
 void ServerApp::handleScreenSwitched(const Event &e, void *)
 {
+  // do nothing
 }
 
 ISocketFactory *ServerApp::getSocketFactory() const

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -86,7 +86,7 @@ public:
   void closeServer(Server *server);
   void stopRetryTimer();
   void updateStatus();
-  void updateStatus(const std::string &msg);
+  void updateStatus(const std::string &msg) const;
   void closeClientListener(ClientListener *listen);
   void stopServer();
   void closePrimaryClient(PrimaryClient *primaryClient);

--- a/src/lib/deskflow/ipc/DaemonIpcServer.cpp
+++ b/src/lib/deskflow/ipc/DaemonIpcServer.cpp
@@ -22,6 +22,7 @@ DaemonIpcServer::DaemonIpcServer(QObject *parent, const QString &logFilename)
       m_logFilename(logFilename),
       m_server{new QLocalServer(this)} // NOSONAR - Qt memory
 {
+  // do nothing
 }
 
 DaemonIpcServer::~DaemonIpcServer()

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -25,6 +25,7 @@
 
 AppUtilUnix::AppUtilUnix(IEventQueue *events)
 {
+  // do nothing
 }
 
 int standardStartupStatic(int argc, char **argv)

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -118,8 +118,8 @@ std::string AppUtilUnix::getCurrentLanguageCode()
       continue;
     }
 
-    auto group = rawLayouts.substr(groupStartI, strI - groupStartI);
-    if (group.find("group", 0, 5) == std::string::npos && group.find("inet", 0, 4) == std::string::npos &&
+    if (auto group = rawLayouts.substr(groupStartI, strI - groupStartI);
+        group.find("group", 0, 5) == std::string::npos && group.find("inet", 0, 4) == std::string::npos &&
         group.find("pc", 0, 2) == std::string::npos) {
       if (nedeedGroupIndex == groupIdx) {
         result = group.substr(0, std::min(group.find('(', 0), group.find(':', 0)));

--- a/src/lib/deskflow/unix/X11LayoutsParser.cpp
+++ b/src/lib/deskflow/unix/X11LayoutsParser.cpp
@@ -41,12 +41,10 @@ bool X11LayoutsParser::readXMLConfigItemElem(const QDomNode &node, std::vector<L
   }
 
   langList.emplace_back();
-  auto nameElem = configItemElem.firstChildElement("name");
-  if (!nameElem.isNull())
+  if (auto nameElem = configItemElem.firstChildElement("name"); !nameElem.isNull())
     langList.back().name = nameElem.toElement().text().toStdString();
 
-  auto languageListElem = configItemElem.elementsByTagName("languageList");
-  if (!languageListElem.isEmpty()) {
+  if (auto languageListElem = configItemElem.elementsByTagName("languageList"); !languageListElem.isEmpty()) {
     for (int i = 0; i < languageListElem.count(); i++) {
       const auto isoElem = languageListElem.at(i).namedItem("iso639Id").toElement();
       langList.back().layoutBaseISO639_2.emplace_back(isoElem.text().toStdString());

--- a/src/lib/gui/Hotkey.cpp
+++ b/src/lib/gui/Hotkey.cpp
@@ -12,6 +12,7 @@
 
 Hotkey::Hotkey() : m_keySequence{}, m_actions{}
 {
+  // do nothing
 }
 
 QString Hotkey::text() const

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -405,8 +405,7 @@ void MainWindow::settingsChanged(const QString &key)
 
   if ((key == Settings::Security::Certificate) || (key == Settings::Security::KeySize) ||
       (key == Settings::Security::TlsEnabled) || (key == Settings::Security::CheckPeers)) {
-    const auto certificate = Settings::value(Settings::Security::Certificate).toString();
-    if (m_tlsUtility.isEnabled() && !QFile::exists(certificate)) {
+    if (m_tlsUtility.isEnabled() && !QFile::exists(Settings::value(Settings::Security::Certificate).toString())) {
       m_tlsUtility.generateCertificate();
     }
     updateSecurityIcon(m_lblSecurityStatus->isVisible());
@@ -1130,8 +1129,7 @@ bool MainWindow::regenerateLocalFingerprints()
     return false;
   }
 
-  TlsCertificate tls;
-  if (!tls.generateFingerprint(certificate)) {
+  if (TlsCertificate tls; !tls.generateFingerprint(certificate)) {
     return false;
   }
 

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -701,7 +701,7 @@ void MainWindow::applyConfig()
   updateModeControls(coreMode == Settings::CoreMode::Server);
 }
 
-void MainWindow::saveSettings()
+void MainWindow::saveSettings() const
 {
   if (ui->rbModeClient->isChecked()) {
     Settings::setValue(Settings::Core::CoreMode, Settings::CoreMode::Client);
@@ -1116,7 +1116,7 @@ void MainWindow::setHostName()
   applyConfig();
 }
 
-QString MainWindow::trustedFingerprintDatabase()
+QString MainWindow::trustedFingerprintDatabase() const
 {
   const bool isClient = m_coreProcess.mode() == CoreMode::Client;
   return isClient ? Settings::tlsTrustedServersDb() : Settings::tlsTrustedClientsDb();

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -142,7 +142,7 @@ private:
   void handleLogLine(const QString &line);
   void updateLocalFingerprint();
   void updateScreenName();
-  void saveSettings();
+  void saveSettings() const;
   void showConfigureServer(const QString &message);
   void restoreWindow();
   void setupControls();
@@ -159,7 +159,7 @@ private:
    * @brief trustedFingerprintDatabase get the FingerprintDatabase for the trusted clients or trusted servers.
    * @return The path to the trusted fingerprint file
    */
-  QString trustedFingerprintDatabase();
+  QString trustedFingerprintDatabase() const;
 
   // Generate prints if they are missing
   // Returns true if successful

--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -454,12 +454,12 @@ void ServerConfig::addClient(const QString &clientName)
   m_Screens.addScreenByPriority(Screen(clientName));
 }
 
-void ServerConfig::setConfigFile(const QString &configFile)
+void ServerConfig::setConfigFile(const QString &configFile) const
 {
   Settings::setValue(Settings::Server::ExternalConfigFile, configFile);
 }
 
-void ServerConfig::setUseExternalConfig(bool useExternalConfig)
+void ServerConfig::setUseExternalConfig(bool useExternalConfig) const
 {
   Settings::setValue(Settings::Server::ExternalConfig, useExternalConfig);
 }

--- a/src/lib/gui/ServerConfig.h
+++ b/src/lib/gui/ServerConfig.h
@@ -241,8 +241,8 @@ private:
   {
     m_ClipboardSharing = on;
   }
-  void setConfigFile(const QString &configFile);
-  void setUseExternalConfig(bool useExternalConfig);
+  void setConfigFile(const QString &configFile) const;
+  void setUseExternalConfig(bool useExternalConfig) const;
   size_t setClipboardSharingSize(size_t size);
   QList<bool> &switchCorners()
   {

--- a/src/lib/gui/core/ClientConnection.h
+++ b/src/lib/gui/core/ClientConnection.h
@@ -32,6 +32,7 @@ public:
       : m_pParent(parent),
         m_deps(deps)
   {
+    // do nothing
   }
 
   void handleLogLine(const QString &line);

--- a/src/lib/gui/core/CommandProcess.cpp
+++ b/src/lib/gui/core/CommandProcess.cpp
@@ -13,6 +13,7 @@ CommandProcess::CommandProcess(QString command, QStringList arguments, QString i
       m_Arguments(arguments),
       m_Input(input)
 {
+  // do nothing
 }
 
 QString CommandProcess::run()

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -514,8 +514,7 @@ bool CoreProcess::addServerArgs(QStringList &args, QString &app)
   // since it's not clear why (it is only needed for the server), this has now
   // been moved to server args.
   if (Settings::value(Settings::Security::TlsEnabled).toBool()) {
-    TlsUtility tlsUtility(this);
-    if (!tlsUtility.persistCertificate()) {
+    if (TlsUtility tlsUtility(this); !tlsUtility.persistCertificate()) {
       qCritical("failed to persist tls certificate");
       return false;
     }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -700,7 +700,7 @@ QString CoreProcess::requestDaemonLogPath()
   return logPath;
 }
 
-void CoreProcess::persistLogDir()
+void CoreProcess::persistLogDir() const
 {
   QDir(QFileInfo(Settings::value(Settings::Log::File).toString()).absolutePath()).mkpath(".");
 }

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -147,7 +147,7 @@ private:
   QString correctedInterface() const;
   QString correctedAddress() const;
   QString requestDaemonLogPath();
-  void persistLogDir();
+  void persistLogDir() const;
 
 #ifdef Q_OS_MAC
   void checkOSXNotification(const QString &line);

--- a/src/lib/gui/core/ServerConnection.cpp
+++ b/src/lib/gui/core/ServerConnection.cpp
@@ -62,9 +62,7 @@ void ServerConnection::handleLogLine(const QString &logLine)
     return;
   }
 
-  const auto client = message.getClientName();
-
-  if (m_receivedClients.contains(client)) {
+  if (const auto client = message.getClientName(); m_receivedClients.contains(client)) {
     qDebug("already got request, skipping new client prompt for: %s", qPrintable(client));
     return;
   }

--- a/src/lib/gui/core/ServerMessage.cpp
+++ b/src/lib/gui/core/ServerMessage.cpp
@@ -10,6 +10,7 @@ namespace deskflow::gui {
 
 ServerMessage::ServerMessage(const QString &message) : m_message(message), m_clientName(parseClientName(message))
 {
+  // do nothing
 }
 
 bool ServerMessage::isNewClientMessage() const

--- a/src/lib/gui/core/ServerMessage.cpp
+++ b/src/lib/gui/core/ServerMessage.cpp
@@ -40,10 +40,10 @@ const QString &ServerMessage::getClientName() const
 QString ServerMessage::parseClientName(const QString &line) const
 {
   QString clientName("Unknown");
-  auto nameStart = line.indexOf('"') + 1;
-  auto nameEnd = line.indexOf('"', nameStart);
 
-  if (nameEnd > nameStart) {
+  auto nameStart = line.indexOf('"') + 1;
+
+  if (auto nameEnd = line.indexOf('"', nameStart); nameEnd > nameStart) {
     clientName = line.mid(nameStart, nameEnd - nameStart);
   }
 

--- a/src/lib/gui/dialogs/AboutDialog.cpp
+++ b/src/lib/gui/dialogs/AboutDialog.cpp
@@ -45,7 +45,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent), ui{std::make_unique
   setMinimumSize(size());
 }
 
-void AboutDialog::copyVersionText()
+void AboutDialog::copyVersionText() const
 {
   QString infoString = QStringLiteral("Deskflow: %1 (%2)\nQt: %3\nSystem: %4")
                            .arg(kVersion, kVersionGitSha, qVersion(), QSysInfo::prettyProductName());

--- a/src/lib/gui/dialogs/AboutDialog.h
+++ b/src/lib/gui/dialogs/AboutDialog.h
@@ -23,7 +23,7 @@ public:
 
 private:
   std::unique_ptr<Ui::AboutDialog> ui;
-  void copyVersionText();
+  void copyVersionText() const;
 
   inline static const auto s_awesomeDevs = QStringList{
       // Chris is the ultimate creator, and the one who started it all in 2001.

--- a/src/lib/gui/dialogs/AddClientDialog.h
+++ b/src/lib/gui/dialogs/AddClientDialog.h
@@ -32,7 +32,7 @@ public:
   AddClientDialog(const QString &clientName, QWidget *parent = nullptr);
   ~AddClientDialog() override;
 
-  int addResult()
+  int addResult() const
   {
     return m_AddResult;
   }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -485,8 +485,7 @@ bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
   bool isAccepted = false;
   Screen newScreen(clientName);
 
-  ScreenSettingsDialog dlg(this, &newScreen, &model().m_Screens);
-  if (doSilent || dlg.exec() == QDialog::Accepted) {
+  if (ScreenSettingsDialog dlg(this, &newScreen, &model().m_Screens); doSilent || dlg.exec() == QDialog::Accepted) {
     model().addScreen(newScreen);
     isAccepted = true;
   }

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -54,7 +54,7 @@ SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfi
   initConnections();
 }
 
-void SettingsDialog::initConnections()
+void SettingsDialog::initConnections() const
 {
   connect(this, &SettingsDialog::shown, this, &SettingsDialog::showReadOnlyMessage, Qt::QueuedConnection);
 
@@ -281,7 +281,7 @@ void SettingsDialog::updateControls()
   updateTlsControls();
 }
 
-void SettingsDialog::updateRequestedKeySize()
+void SettingsDialog::updateRequestedKeySize() const
 {
   if (ui->comboTlsKeyLength->currentText() == Settings::value(Settings::Security::KeySize).toString())
     return;

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -34,7 +34,7 @@ signals:
   void shown();
 
 private:
-  void initConnections();
+  void initConnections() const;
   void regenCertificates();
   void browseCertificatePath();
   void browseLogPath();
@@ -56,7 +56,7 @@ private:
   void updateControls();
 
   /// @brief updates the setting vaule for key size.
-  void updateRequestedKeySize();
+  void updateRequestedKeySize() const;
 
   std::unique_ptr<Ui::SettingsDialog> ui;
   const IServerConfig &m_serverConfig;

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -25,6 +25,7 @@
 
 TlsCertificate::TlsCertificate(QObject *parent) : QObject(parent)
 {
+  // do nothing
 }
 
 bool TlsCertificate::generateCertificate(const QString &path, int keyLength)

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -88,14 +88,12 @@ bool TlsCertificate::isCertificateValid(const QString &path)
   }
   auto pubkeyFree = deskflow::finally([pubkey]() { EVP_PKEY_free(pubkey); });
 
-  auto type = EVP_PKEY_type(EVP_PKEY_id(pubkey));
-  if (type != EVP_PKEY_RSA && type != EVP_PKEY_DSA) {
+  if (auto type = EVP_PKEY_type(EVP_PKEY_id(pubkey)); type != EVP_PKEY_RSA && type != EVP_PKEY_DSA) {
     qWarning() << tr("public key in default certificate key file is not RSA or DSA");
     return false;
   }
 
-  auto bits = EVP_PKEY_bits(pubkey);
-  if (bits < 2048) {
+  if (EVP_PKEY_bits(pubkey) < 2048) {
     // We could have small keys in old barrier installations
     qWarning() << tr("public key in default certificate key file is too small");
     return false;

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -48,7 +48,7 @@ bool TlsCertificate::generateCertificate(const QString &path, int keyLength)
   return generateFingerprint(path);
 }
 
-bool TlsCertificate::generateFingerprint(const QString &certificateFilename)
+bool TlsCertificate::generateFingerprint(const QString &certificateFilename) const
 {
   qDebug("generating tls fingerprint");
   const std::string certPath = certificateFilename.toStdString();
@@ -57,12 +57,12 @@ bool TlsCertificate::generateFingerprint(const QString &certificateFilename)
   return db.write(Settings::tlsLocalDb());
 }
 
-int TlsCertificate::getCertKeyLength(const QString &path)
+int TlsCertificate::getCertKeyLength(const QString &path) const
 {
   return deskflow::getCertLength(path.toStdString());
 }
 
-bool TlsCertificate::isCertificateValid(const QString &path)
+bool TlsCertificate::isCertificateValid(const QString &path) const
 {
   OpenSSL_add_all_algorithms();
   ERR_load_crypto_strings();

--- a/src/lib/gui/tls/TlsCertificate.h
+++ b/src/lib/gui/tls/TlsCertificate.h
@@ -16,8 +16,8 @@ class TlsCertificate : public QObject
 public:
   explicit TlsCertificate(QObject *parent = nullptr);
 
-  bool isCertificateValid(const QString &path);
+  bool isCertificateValid(const QString &path) const;
   bool generateCertificate(const QString &path, int keyLength);
-  bool generateFingerprint(const QString &certificateFilename);
-  int getCertKeyLength(const QString &path);
+  bool generateFingerprint(const QString &certificateFilename) const;
+  int getCertKeyLength(const QString &path) const;
 };

--- a/src/lib/gui/tls/TlsUtility.cpp
+++ b/src/lib/gui/tls/TlsUtility.cpp
@@ -15,6 +15,7 @@ namespace deskflow::gui {
 
 TlsUtility::TlsUtility(QObject *parent) : QObject(parent)
 {
+  // do nothing
 }
 
 bool TlsUtility::isEnabled() const

--- a/src/lib/gui/validators/ComputerNameValidator.cpp
+++ b/src/lib/gui/validators/ComputerNameValidator.cpp
@@ -12,6 +12,7 @@ namespace validators {
 
 ComputerNameValidator::ComputerNameValidator(const QString &message) : IStringValidator(message)
 {
+  // do nothing
 }
 
 bool ComputerNameValidator::validate(const QString &input) const

--- a/src/lib/gui/validators/EmptyStringValidator.cpp
+++ b/src/lib/gui/validators/EmptyStringValidator.cpp
@@ -10,6 +10,7 @@ namespace validators {
 
 EmptyStringValidator::EmptyStringValidator(const QString &message) : IStringValidator(message)
 {
+  // do nothing
 }
 
 bool EmptyStringValidator::validate(const QString &input) const

--- a/src/lib/gui/validators/IStringValidator.cpp
+++ b/src/lib/gui/validators/IStringValidator.cpp
@@ -10,6 +10,7 @@ namespace validators {
 
 IStringValidator::IStringValidator(const QString &message) : m_Message(message)
 {
+  // do nothing
 }
 
 const QString &IStringValidator::getMessage() const

--- a/src/lib/gui/validators/ScreenDuplicationsValidator.cpp
+++ b/src/lib/gui/validators/ScreenDuplicationsValidator.cpp
@@ -15,6 +15,7 @@ ScreenDuplicationsValidator::ScreenDuplicationsValidator(
       m_defaultName(defaultName),
       m_pScreenList(pScreens)
 {
+  // do nothing
 }
 
 bool ScreenDuplicationsValidator::validate(const QString &input) const

--- a/src/lib/gui/validators/SpacesValidator.cpp
+++ b/src/lib/gui/validators/SpacesValidator.cpp
@@ -10,6 +10,7 @@ namespace validators {
 
 SpacesValidator::SpacesValidator(const QString &message) : IStringValidator(message)
 {
+  // do nothing
 }
 
 bool SpacesValidator::validate(const QString &input) const

--- a/src/lib/gui/widgets/NewScreenWidget.cpp
+++ b/src/lib/gui/widgets/NewScreenWidget.cpp
@@ -16,6 +16,7 @@
 
 NewScreenWidget::NewScreenWidget(QWidget *parent) : QLabel(parent)
 {
+  // do nothing
 }
 
 void NewScreenWidget::mousePressEvent(QMouseEvent *event)

--- a/src/lib/gui/widgets/TrashScreenWidget.h
+++ b/src/lib/gui/widgets/TrashScreenWidget.h
@@ -20,6 +20,7 @@ class TrashScreenWidget : public QLabel
 public:
   TrashScreenWidget(QWidget *parent) : QLabel(parent)
   {
+    // do nothing
   }
 
 public:

--- a/src/lib/mt/XThread.h
+++ b/src/lib/mt/XThread.h
@@ -21,6 +21,7 @@ public:
   //! \c result is the result of the thread
   XThreadExit(void *result) : m_result(result)
   {
+    // do nothing
   }
   ~XThreadExit() = default;
 

--- a/src/lib/net/Fingerprint.cpp
+++ b/src/lib/net/Fingerprint.cpp
@@ -52,10 +52,11 @@ Fingerprint Fingerprint::fromDbLine(const QString &line)
     result.data = QByteArray::fromHex(sLine.at(2).toLower().toLatin1());
   } else {
     // v1 fallback
-    const auto kSha1ColonCount = 19;
-    const auto kSha1HexCharCount = 40;
-    const auto kSha1ExpectedSize = kSha1HexCharCount + kSha1ColonCount;
-    if (line.size() != kSha1ExpectedSize || line.count(':') != kSha1ColonCount)
+    static const auto kSha1ColonCount = 19;
+    static const auto kSha1HexCharCount = 40;
+    static const auto kSha1ExpectedSize = kSha1HexCharCount + kSha1ColonCount;
+    const bool wrongSize = line.size() != kSha1ExpectedSize;
+    if (bool badColonCount = line.count(':') != kSha1ColonCount; wrongSize || badColonCount)
       return result;
     result.type = Fingerprint::Type::SHA1;
     auto l2 = line;

--- a/src/lib/net/FingerprintDatabase.cpp
+++ b/src/lib/net/FingerprintDatabase.cpp
@@ -87,7 +87,7 @@ void FingerprintDatabase::addTrusted(const Fingerprint &fingerprint)
   m_fingerprints.append(fingerprint);
 }
 
-bool FingerprintDatabase::isTrusted(const Fingerprint &fingerprint)
+bool FingerprintDatabase::isTrusted(const Fingerprint &fingerprint) const
 {
   return m_fingerprints.contains(fingerprint);
 }

--- a/src/lib/net/FingerprintDatabase.h
+++ b/src/lib/net/FingerprintDatabase.h
@@ -22,7 +22,7 @@ public:
 
   void clear();
   void addTrusted(const Fingerprint &fingerprint);
-  bool isTrusted(const Fingerprint &fingerprint);
+  bool isTrusted(const Fingerprint &fingerprint) const;
 
   const QList<Fingerprint> &fingerprints() const
   {

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -24,6 +24,7 @@ public:
   public:
     ConnectionFailedInfo(const char *what) : m_what(what)
     {
+      // do nothing
     }
     std::string m_what;
   };

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -34,11 +34,10 @@ NetworkAddress::NetworkAddress(const NetworkAddress &addr) : m_hostname(addr.m_h
 
 NetworkAddress::NetworkAddress(const std::string &hostname, int port) : m_hostname(hostname), m_port(port)
 {
-  // detect internet protocol version with colom count
-  auto isColomPredicate = [](char c) { return c == ':'; };
-  auto colomCount = std::count_if(m_hostname.begin(), m_hostname.end(), isColomPredicate);
+  // detect internet protocol version with colon count
+  auto isColon = [](char c) { return c == ':'; };
 
-  if (colomCount == 1) {
+  if (auto colonCount = std::count_if(m_hostname.begin(), m_hostname.end(), isColon); colonCount == 1) {
     // ipv4 with port part
     auto hostIt = m_hostname.find(':');
     try {
@@ -49,7 +48,7 @@ NetworkAddress::NetworkAddress(const std::string &hostname, int port) : m_hostna
 
     auto endHostnameIt = static_cast<int>(hostIt);
     m_hostname = m_hostname.substr(0, endHostnameIt > 0 ? endHostnameIt : 0);
-  } else if (colomCount > 1) {
+  } else if (colonCount > 1) {
     // ipv6 part
     if (m_hostname[0] == '[') {
       // ipv6 with port part

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -201,7 +201,7 @@ std::string NetworkAddress::getHostname() const
   return m_hostname;
 }
 
-void NetworkAddress::checkPort()
+void NetworkAddress::checkPort() const
 {
   // check port number
   if (m_port < 0 || m_port > 65535) {

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -105,7 +105,7 @@ public:
   //@}
 
 private:
-  void checkPort();
+  void checkPort() const;
 
 private:
   ArchNetAddress m_address = nullptr;

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -50,8 +50,7 @@ IDataSocket *SecureListenSocket::accept()
       certificateFilename = ArgParser::argsBase().m_tlsCertFile;
     }
 
-    bool loaded = socket->loadCertificates(certificateFilename);
-    if (!loaded) {
+    if (!socket->loadCertificates(certificateFilename)) {
       delete socket;
       return nullptr;
     }

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -29,6 +29,7 @@ SecureListenSocket::SecureListenSocket(
       m_securityLevel{securityLevel}
 
 {
+  // do nothing
 }
 
 IDataSocket *SecureListenSocket::accept()

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -65,6 +65,7 @@ SecureSocket::SecureSocket(
       m_fatal(false),
       m_securityLevel{securityLevel}
 {
+  // do nothing
 }
 
 SecureSocket::SecureSocket(
@@ -76,6 +77,7 @@ SecureSocket::SecureSocket(
       m_fatal(false),
       m_securityLevel{securityLevel}
 {
+  // do nothing
 }
 
 SecureSocket::~SecureSocket()

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -287,7 +287,7 @@ int SecureSocket::secureWrite(const void *buffer, int size, int &wrote)
   return wrote;
 }
 
-bool SecureSocket::isSecureReady()
+bool SecureSocket::isSecureReady() const
 {
   return m_secureReady;
 }
@@ -643,7 +643,7 @@ void SecureSocket::disconnect()
   sendEvent(EventTypes::StreamInputShutdown);
 }
 
-bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
+bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath) const
 {
   const auto cert = SSL_get_peer_certificate(m_ssl->m_ssl);
   const auto sha256 = deskflow::sslCertFingerprint(cert, Fingerprint::Type::SHA256);

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -57,7 +57,7 @@ public:
   {
     m_fatal = b;
   }
-  bool isSecureReady();
+  bool isSecureReady() const;
   void secureConnect();
   void secureAccept();
   int secureRead(void *buffer, int size, int &read);
@@ -77,7 +77,7 @@ private:
   bool showCertificate() const;
   void checkResult(int n, int &retry);
   void disconnect();
-  bool verifyCertFingerprint(const QString &FingerprintDatabasePath);
+  bool verifyCertFingerprint(const QString &FingerprintDatabasePath) const;
 
   ISocketMultiplexerJob *serviceConnect(ISocketMultiplexerJob *, bool, bool, bool);
 

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -54,9 +54,8 @@ Fingerprint sslCertFingerprint(X509 *cert, Fingerprint::Type type)
 
   unsigned char digest[EVP_MAX_MD_SIZE];
   unsigned int digestLength = 0;
-  int result = X509_digest(cert, digestForType(type), digest, &digestLength);
 
-  if (result <= 0) {
+  if (int result = X509_digest(cert, digestForType(type), digest, &digestLength); result <= 0) {
     throw std::runtime_error("failed to calculate fingerprint, digest result: " + std::to_string(result));
   }
 

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -77,8 +77,7 @@ void SocketMultiplexer::addSocket(ISocket *socket, ISocketMultiplexerJob *job)
   lockJobList();
 
   // insert/replace job
-  SocketJobMap::iterator i = m_socketJobMap.find(socket);
-  if (i == m_socketJobMap.end()) {
+  if (SocketJobMap::iterator i = m_socketJobMap.find(socket); i == m_socketJobMap.end()) {
     // we *must* put the job at the end so the order of jobs in
     // the list continue to match the order of jobs in pfds in
     // serviceThread().
@@ -86,8 +85,7 @@ void SocketMultiplexer::addSocket(ISocket *socket, ISocketMultiplexerJob *job)
     m_update = true;
     m_socketJobMap.insert(std::make_pair(socket, j));
   } else {
-    JobCursor j = i->second;
-    if (*j != job) {
+    if (JobCursor j = i->second; *j != job) {
       delete *j;
       *j = job;
     }
@@ -114,8 +112,7 @@ void SocketMultiplexer::removeSocket(ISocket *socket)
   // remove job.  rather than removing it from the map we put nullptr
   // in the list instead so the order of jobs in the list continues
   // to match the order of jobs in pfds in serviceThread().
-  SocketJobMap::iterator i = m_socketJobMap.find(socket);
-  if (i != m_socketJobMap.end()) {
+  if (SocketJobMap::iterator i = m_socketJobMap.find(socket); i != m_socketJobMap.end()) {
     if (*(i->second) != nullptr) {
       delete *(i->second);
       *(i->second) = nullptr;
@@ -157,8 +154,7 @@ void SocketMultiplexer::serviceThread(void *)
       JobCursor cursor = newCursor();
       JobCursor jobCursor = nextCursor(cursor);
       while (jobCursor != m_socketJobs.end()) {
-        ISocketMultiplexerJob *job = *jobCursor;
-        if (job != nullptr) {
+        if (ISocketMultiplexerJob *job = *jobCursor; job) {
           pfd.m_socket = job->getSocket();
           pfd.m_events = 0;
           if (job->isReadable()) {
@@ -203,10 +199,9 @@ void SocketMultiplexer::serviceThread(void *)
 
           // run job
           ISocketMultiplexerJob *job = *jobCursor;
-          ISocketMultiplexerJob *newJob = job->run(read, write, error);
 
           // save job, if different
-          if (newJob != job) {
+          if (ISocketMultiplexerJob *newJob = job->run(read, write, error); newJob != job) {
             Lock lock(m_mutex);
             delete job;
             *jobCursor = newJob;

--- a/src/lib/net/SslLogger.cpp
+++ b/src/lib/net/SslLogger.cpp
@@ -22,8 +22,7 @@ void showCipherStackDesc(STACK_OF(SSL_CIPHER) * stack)
     SSL_CIPHER_description(cipher, msg, sizeof(msg));
 
     // SSL puts a newline in the description
-    auto pos = strnlen(msg, sizeof(msg)) - 1;
-    if (msg[pos] == '\n') {
+    if (auto pos = strnlen(msg, sizeof(msg)) - 1; msg[pos] == '\n') {
       msg[pos] = '\0';
     }
 

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -122,8 +122,7 @@ uint32_t TCPSocket::read(void *buffer, uint32_t n)
 {
   // copy data directly from our input buffer
   Lock lock(&m_mutex);
-  uint32_t size = m_inputBuffer.getSize();
-  if (n > size) {
+  if (uint32_t size = m_inputBuffer.getSize(); n > size) {
     n = size;
   }
   if (buffer != nullptr && n != 0) {

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -79,11 +79,11 @@ protected:
 
   void setJob(ISocketMultiplexerJob *);
 
-  bool isReadable()
+  bool isReadable() const
   {
     return m_readable;
   }
-  bool isWritable()
+  bool isWritable() const
   {
     return m_writable;
   }

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -17,7 +17,7 @@ A socket multiplexer job class that invokes a member function.
 template <class T> class TSocketMultiplexerMethodJob : public ISocketMultiplexerJob
 {
 public:
-  typedef ISocketMultiplexerJob *(T::*Method)(ISocketMultiplexerJob *, bool, bool, bool);
+  using Method = ISocketMultiplexerJob *(T::*)(ISocketMultiplexerJob *, bool, bool, bool);
 
   //! run() invokes \c object->method(arg)
   TSocketMultiplexerMethodJob(T *object, Method method, ArchSocket socket, bool readable, bool writeable);

--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -62,8 +62,7 @@ void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
 
   int timeout = (timeout_in_ms < 0.0) ? -1 : static_cast<int>(1000.0 * timeout_in_ms);
 
-  int retval = poll(pfds, POLLFD_COUNT, timeout);
-  if (retval > 0) {
+  if (int retval = poll(pfds, POLLFD_COUNT, timeout); retval > 0) {
     if (pfds[EIFD].revents & POLLIN) {
       std::lock_guard lock(mutex_);
 

--- a/src/lib/platform/EiEventQueueBuffer.h
+++ b/src/lib/platform/EiEventQueueBuffer.h
@@ -29,6 +29,7 @@ public:
   // IEventQueueBuffer overrides
   void init() override
   {
+    // do nothing
   }
   void waitForEvent(double timeout_in_ms) override;
   Type getEvent(Event &event, uint32_t &dataID) override;

--- a/src/lib/platform/EiEventQueueBuffer.h
+++ b/src/lib/platform/EiEventQueueBuffer.h
@@ -41,7 +41,8 @@ private:
   ei *ei_;
   IEventQueue *events_;
   std::queue<std::pair<bool, uint32_t>> queue_;
-  int pipe_w_, pipe_r_;
+  int pipe_w_;
+  int pipe_r_;
 
   mutable std::mutex mutex_;
 };

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -50,9 +50,8 @@ void EiKeyState::init(int fd, size_t len)
 {
   auto buffer = std::make_unique<char[]>(len + 1);
   lseek(fd, 0, SEEK_SET);
-  auto sz = read(fd, buffer.get(), len);
 
-  if ((size_t)sz < len) {
+  if (auto sz = read(fd, buffer.get(), len); (size_t)sz < len) {
     LOG_WARN("failed to create xkb context: %s", strerror(errno));
     return;
   }
@@ -143,9 +142,8 @@ void EiKeyState::assign_generated_modifiers(std::uint32_t keycode, deskflow::Key
 {
   std::uint32_t mods_generates = 0;
   auto state = xkb_state_new(xkb_keymap_);
-  enum xkb_state_component changed = xkb_state_update_key(state, keycode, XKB_KEY_DOWN);
 
-  if (changed) {
+  if (enum xkb_state_component changed = xkb_state_update_key(state, keycode, XKB_KEY_DOWN); changed) {
     for (xkb_mod_index_t m = 0; m < xkb_keymap_num_mods(xkb_keymap_); m++) {
       if (xkb_state_mod_index_is_active(state, m, XKB_STATE_MODS_LOCKED))
         item.m_lock = true;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -30,9 +30,11 @@
 #include <unistd.h>
 #include <vector>
 
+// Values are in pixels
 struct ScrollRemainder
 {
-  double x, y; // scroll remainder in pixels
+  double x;
+  double y;
 };
 
 namespace deskflow {
@@ -624,7 +626,8 @@ void EiScreen::on_pointer_scroll_event(ei_event *event)
   dx += remainder->x;
   dy += remainder->y;
 
-  double x, y;
+  double x;
+  double y;
   double rx = modf(dx, &x);
   double ry = modf(dy, &y);
 

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -558,7 +558,7 @@ bool EiScreen::on_hotkey(KeyID keyid, bool is_pressed, KeyModifierMask mask)
 
 void EiScreen::on_key_event(ei_event *event)
 {
-  uint32_t keycode = ei_event_keyboard_get_key(event);
+  auto keycode = ei_event_keyboard_get_key(event);
   uint32_t keyval = keycode + 8;
   bool pressed = ei_event_keyboard_get_key_is_press(event);
   KeyID keyid = key_state_->map_key_from_keyval(keyval);
@@ -582,20 +582,20 @@ void EiScreen::on_button_event(ei_event *event)
 {
   assert(is_primary_);
 
-  ButtonID button = map_button_from_evdev(event);
+  auto buttonID = map_button_from_evdev(event);
   bool pressed = ei_event_button_get_is_press(event);
   KeyModifierMask mask = key_state_->pollActiveModifiers();
 
-  LOG_DEBUG1("event: button %s button=%d mask=0x%x", pressed ? "press" : "release", button, mask);
+  LOG_DEBUG1("event: button %s button=%d mask=0x%x", pressed ? "press" : "release", buttonID, mask);
 
-  if (button == kButtonNone) {
+  if (buttonID == kButtonNone) {
     LOG_DEBUG("event: button not recognized");
     return;
   }
 
   auto eventType = pressed ? EventTypes::PrimaryScreenButtonDown : EventTypes::PrimaryScreenButtonUp;
 
-  sendEvent(eventType, ButtonInfo::alloc(button, mask));
+  sendEvent(eventType, ButtonInfo::alloc(buttonID, mask));
 }
 
 void EiScreen::on_pointer_scroll_event(ei_event *event)
@@ -611,8 +611,8 @@ void EiScreen::on_pointer_scroll_event(ei_event *event)
 
   assert(is_primary_);
 
-  double dx = ei_event_scroll_get_dx(event);
-  double dy = ei_event_scroll_get_dy(event);
+  auto dx = ei_event_scroll_get_dx(event);
+  auto dy = ei_event_scroll_get_dy(event);
   struct ei_device *device = ei_event_get_device(event);
 
   LOG_DEBUG1("event: scroll (%.2f, %.2f)", dx, dy);
@@ -655,8 +655,8 @@ void EiScreen::on_pointer_scroll_discrete_event(ei_event *event)
 
   assert(is_primary_);
 
-  std::int32_t dx = ei_event_scroll_get_discrete_dx(event);
-  std::int32_t dy = ei_event_scroll_get_discrete_dy(event);
+  auto dx = ei_event_scroll_get_discrete_dx(event);
+  auto dy = ei_event_scroll_get_discrete_dy(event);
 
   LOG_DEBUG1("event: scroll discrete (%d, %d)", dx, dy);
 
@@ -670,8 +670,8 @@ void EiScreen::on_motion_event(ei_event *event)
 {
   assert(is_primary_);
 
-  double dx = ei_event_pointer_get_dx(event);
-  double dy = ei_event_pointer_get_dy(event);
+  auto dx = ei_event_pointer_get_dx(event);
+  auto dy = ei_event_pointer_get_dy(event);
 
   if (is_on_screen_) {
     LOG_DEBUG("event: motion on primary x=%i y=%i)", cursor_x_, cursor_y_);

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -459,8 +459,8 @@ void EiScreen::add_device(struct ei_device *device)
   if (!ei_keyboard_ && ei_device_has_capability(device, EI_DEVICE_CAP_KEYBOARD)) {
     ei_keyboard_ = ei_device_ref(device);
 
-    struct ei_keymap *keymap = ei_device_keyboard_get_keymap(device);
-    if (keymap && ei_keymap_get_type(keymap) == EI_KEYMAP_TYPE_XKB) {
+    if (auto keymap = ei_device_keyboard_get_keymap(device);
+        keymap && ei_keymap_get_type(keymap) == EI_KEYMAP_TYPE_XKB) {
       int fd = ei_keymap_get_fd(keymap);
       size_t len = ei_keymap_get_size(keymap);
       key_state_->init(fd, len);
@@ -516,9 +516,7 @@ void EiScreen::sendEvent(EventTypes type, void *data)
 
 ButtonID EiScreen::map_button_from_evdev(ei_event *event) const
 {
-  uint32_t button = ei_event_button_get_button(event);
-
-  switch (button) {
+  switch (ei_event_button_get_button(event)) {
   case 0x110:
     return kButtonLeft;
   case 0x111:
@@ -547,8 +545,7 @@ bool EiScreen::on_hotkey(KeyID keyid, bool is_pressed, KeyModifierMask mask)
   // Note: our mask (see on_key_event) only contains some modifiers
   // but we don't put a limitation on modifiers in the hotkeys. So some
   // key combinations may not work correctly, more effort is needed here.
-  auto id = it->second.find_by_mask(mask);
-  if (id != 0) {
+  if (auto id = it->second.find_by_mask(mask); id != 0) {
     EventTypes type = is_pressed ? EventTypes::PrimaryScreenHotkeyDown : EventTypes::PrimaryScreenHotkeyUp;
     sendEvent(type, HotKeyInfo::alloc(id));
     return true;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -855,10 +855,12 @@ std::string EiScreen::getSecureInputApp() const
 
 EiScreen::HotKeyItem::HotKeyItem(std::uint32_t mask, std::uint32_t id) : mask_(mask), id_(id)
 {
+  // Todo: Implement
 }
 
 EiScreen::HotKeySet::HotKeySet(KeyID key) : id_(key)
 {
+  // Todo: Implement
 }
 
 bool EiScreen::HotKeySet::remove_by_id(std::uint32_t id)

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -91,7 +91,7 @@ EiScreen::~EiScreen()
   delete portal_input_capture_;
 }
 
-void EiScreen::handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context)
+void EiScreen::handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context) const
 {
   switch (priority) {
   case EI_LOG_PRIORITY_DEBUG:
@@ -693,7 +693,7 @@ void EiScreen::on_motion_event(ei_event *event)
   }
 }
 
-void EiScreen::on_abs_motion_event(ei_event *event)
+void EiScreen::on_abs_motion_event(ei_event *event) const
 {
   assert(is_primary_);
 }

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -96,9 +96,9 @@ private:
   void on_pointer_scroll_event(ei_event *event);
   void on_pointer_scroll_discrete_event(ei_event *event);
   void on_motion_event(ei_event *event);
-  void on_abs_motion_event(ei_event *event);
+  void on_abs_motion_event(ei_event *event) const;
   bool on_hotkey(KeyID key, bool is_press, KeyModifierMask mask);
-  void handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context);
+  void handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context) const;
   void handle_connected_to_eis_event(const Event &event, void *);
   void handle_portal_session_closed(const Event &event, void *);
 

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -98,8 +98,7 @@ int PortalInputCapture::fake_eis_fd()
   };
   std::snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
 
-  auto result = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
-  if (result != 0) {
+  if (auto result = connect(fd, (struct sockaddr *)&addr, sizeof(addr)); result != 0) {
     LOG_DEBUG("faked eis fd failed: %s", strerror(errno));
   }
 

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -174,7 +174,10 @@ void PortalInputCapture::cb_set_pointer_barriers(GObject *object, GAsyncResult *
 
       for (auto elem = barriers_.begin(); elem != barriers_.end(); elem++) {
         if (*elem == it->data) {
-          int x1, x2, y1, y2;
+          int x1;
+          int x2;
+          int y1;
+          int y2;
 
           g_object_get(G_OBJECT(*elem), "x1", &x1, "x2", &x2, "y1", &y1, "y2", &y2, nullptr);
 
@@ -271,7 +274,8 @@ void PortalInputCapture::cb_activated(XdpInputCaptureSession *session, std::uint
   LOG_DEBUG("portal cb activated, id=%d", activation_id);
 
   if (options) {
-    gdouble x, y;
+    gdouble x;
+    gdouble y;
     if (g_variant_lookup(options, "cursor_position", "(dd)", &x, &y)) {
       screen_->warpCursor((int)x, (int)y);
     } else {
@@ -298,13 +302,18 @@ void PortalInputCapture::cb_zones_changed(XdpInputCaptureSession *session, GVari
 
   auto zones = xdp_input_capture_session_get_zones(session);
   while (zones != nullptr) {
-    guint w, h;
-    gint x, y;
+    guint w;
+    guint h;
+    gint x;
+    gint y;
     g_object_get(zones->data, "width", &w, "height", &h, "x", &x, "y", &y, nullptr);
 
     LOG_DEBUG("input capture zone, %dx%d@%d,%d", w, h, x, y);
 
-    int x1, x2, y1, y2;
+    int x1;
+    int x2;
+    int y1;
+    int y2;
 
     // Hardcoded behaviour: our pointer barriers are always at the edges of
     // all zones. Since the implementation is supposed to reject the ones in

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -73,12 +73,12 @@ PortalInputCapture::~PortalInputCapture()
   g_object_unref(portal_);
 }
 
-gboolean PortalInputCapture::timeout_handler()
+gboolean PortalInputCapture::timeout_handler() const
 {
   return true; // keep re-triggering
 }
 
-int PortalInputCapture::fake_eis_fd()
+int PortalInputCapture::fake_eis_fd() const
 {
   auto path = std::getenv("LIBEI_SOCKET");
 

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -34,7 +34,7 @@ public:
 
 private:
   void glib_thread(void *);
-  gboolean timeout_handler();
+  gboolean timeout_handler() const;
   gboolean init_input_capture_session();
   void cb_init_input_capture_session(GObject *object, GAsyncResult *res);
   void cb_set_pointer_barriers(GObject *object, GAsyncResult *res);
@@ -68,7 +68,7 @@ private:
     reinterpret_cast<PortalInputCapture *>(data)->cb_zones_changed(session, options);
   }
 
-  int fake_eis_fd();
+  int fake_eis_fd() const;
 
 private:
   EiScreen *screen_ = nullptr;

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -83,8 +83,7 @@ void PortalRemoteDesktop::cb_session_started(GObject *object, GAsyncResult *res)
 {
   g_autoptr(GError) error = nullptr;
   auto session = XDP_SESSION(object);
-  auto success = xdp_session_start_finish(session, res, &error);
-  if (!success) {
+  if (!xdp_session_start_finish(session, res, &error)) {
     LOG_ERR("failed to start portal remote desktop session, quitting: %s", error->message);
     g_main_loop_quit(glib_main_loop_);
     events_->addEvent(EventTypes::Quit);

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -49,7 +49,7 @@ PortalRemoteDesktop::~PortalRemoteDesktop()
   free(session_restore_token_);
 }
 
-gboolean PortalRemoteDesktop::timeout_handler()
+gboolean PortalRemoteDesktop::timeout_handler() const
 {
   return true; // keep re-triggering
 }

--- a/src/lib/platform/PortalRemoteDesktop.h
+++ b/src/lib/platform/PortalRemoteDesktop.h
@@ -23,7 +23,7 @@ public:
 
 private:
   void glib_thread(void *);
-  gboolean timeout_handler();
+  gboolean timeout_handler() const;
   gboolean init_remote_desktop_session();
   void cb_init_remote_desktop_session(GObject *object, GAsyncResult *res);
   void cb_session_started(GObject *object, GAsyncResult *res);

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -581,8 +581,7 @@ void XWindowsClipboard::motifUnlockClipboard() const
   LOG((CLOG_DEBUG1 "unlocked motif clipboard"));
 
   // fail if we don't own the lock
-  Window lockOwner = XGetSelectionOwner(m_display, m_atomMotifClipLock);
-  if (lockOwner != m_window) {
+  if (Window lockOwner = XGetSelectionOwner(m_display, m_atomMotifClipLock); lockOwner != m_window) {
     return;
   }
 
@@ -606,8 +605,8 @@ bool XWindowsClipboard::motifOwnsClipboard() const
   Atom target;
   int32_t format;
   std::string data;
-  Window root = RootWindow(m_display, DefaultScreen(m_display));
-  if (!XWindowsUtil::getWindowProperty(m_display, root, m_atomMotifClipHeader, &data, &target, &format, False)) {
+  if (Window root = RootWindow(m_display, DefaultScreen(m_display));
+      !XWindowsUtil::getWindowProperty(m_display, root, m_atomMotifClipHeader, &data, &target, &format, False)) {
     return false;
   }
 

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -119,7 +119,9 @@ std::string XWindowsClipboardAnyBitmapConverter::fromIClipboard(const std::strin
 std::string XWindowsClipboardAnyBitmapConverter::toIClipboard(const std::string &image) const
 {
   // convert to raw BMP data
-  uint32_t w, h, depth;
+  uint32_t w;
+  uint32_t h;
+  uint32_t depth;
   std::string rawBMP = doToIClipboard(image, w, h, depth);
   if (rawBMP.empty() || w == 0 || h == 0 || (depth != 24 && depth != 32)) {
     return std::string();

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -66,10 +66,9 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
   // clear out the pipe in preparation for waiting.
 
   char buf[16];
-  ssize_t read_response = read(m_pipefd[0], buf, 15);
 
   // with linux automake, warnings are treated as errors by default
-  if (read_response < 0) {
+  if (ssize_t read_response = read(m_pipefd[0], buf, 15); read_response < 0) {
     // todo: handle read response
   }
 

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -156,8 +156,12 @@ bool XWindowsKeyState::fakeCtrlAltDel()
 
 KeyModifierMask XWindowsKeyState::pollActiveModifiers() const
 {
-  Window root = DefaultRootWindow(m_display), window;
-  int xRoot, yRoot, xWindow, yWindow;
+  Window root = DefaultRootWindow(m_display);
+  Window window;
+  int xRoot;
+  int yRoot;
+  int xWindow;
+  int yWindow;
   unsigned int state = 0;
   if (XQueryPointer(m_display, root, &root, &window, &xRoot, &yRoot, &xWindow, &yWindow, &state) == False) {
     state = 0;
@@ -351,7 +355,8 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
   m_keyCodeFromKey.clear();
 
   // get the number of keycodes
-  int minKeycode, maxKeycode;
+  int minKeycode;
+  int maxKeycode;
   XDisplayKeycodes(m_display, &minKeycode, &maxKeycode);
   int numKeycodes = maxKeycode - minKeycode + 1;
 
@@ -437,7 +442,8 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
     // provide one keysym for keys sensitive to caps-lock.  if we
     // find that then fill in the missing keysym.
     if (keysyms[0] != NoSymbol && keysyms[1] == NoSymbol && keysyms[2] == NoSymbol && keysyms[3] == NoSymbol) {
-      KeySym lKeysym, uKeysym;
+      KeySym lKeysym;
+      KeySym uKeysym;
       XConvertCase(keysyms[0], &lKeysym, &uKeysym);
       if (lKeysym != uKeysym) {
         keysyms[0] = lKeysym;
@@ -445,7 +451,8 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
         item.m_sensitive |= KeyModifierCapsLock;
       }
     } else if (keysyms[0] != NoSymbol && keysyms[1] != NoSymbol) {
-      KeySym lKeysym, uKeysym;
+      KeySym lKeysym;
+      KeySym uKeysym;
       XConvertCase(keysyms[0], &lKeysym, &uKeysym);
       if (lKeysym != uKeysym && lKeysym == keysyms[0] && uKeysym == keysyms[1]) {
         item.m_sensitive |= KeyModifierCapsLock;
@@ -527,7 +534,8 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
       // add other ways to synthesize the key
       if ((j & 1) != 0) {
         // add capslock version of key is sensitive to capslock
-        KeySym lKeysym, uKeysym;
+        KeySym lKeysym;
+        KeySym uKeysym;
         XConvertCase(keysyms[j], &lKeysym, &uKeysym);
         if (lKeysym != uKeysym && lKeysym == keysyms[j - 1] && uKeysym == keysyms[j]) {
           item.m_required &= ~KeyModifierShift;
@@ -726,7 +734,8 @@ void XWindowsKeyState::updateKeysymMapXKB(deskflow::KeyMap &keyMap)
         if (type->num_levels == 1) {
           // if there are upper- and lowercase versions of the
           // keysym then add both.
-          KeySym lKeysym, uKeysym;
+          KeySym lKeysym;
+          KeySym uKeysym;
           XConvertCase(keysym, &lKeysym, &uKeysym);
           if (lKeysym != uKeysym) {
             if (j != -1) {

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -611,8 +611,7 @@ void XWindowsKeyState::updateKeysymMapXKB(deskflow::KeyMap &keyMap)
     }
 
     // note half-duplex keys
-    const XkbBehavior &b = m_xkb->server->behaviors[keycode];
-    if ((b.type & XkbKB_OpMask) == XkbKB_Lock) {
+    if (const XkbBehavior &b = m_xkb->server->behaviors[keycode]; (b.type & XkbKB_OpMask) == XkbKB_Lock) {
       keyMap.addHalfDuplexButton(item.m_button);
     }
 
@@ -697,8 +696,8 @@ void XWindowsKeyState::updateKeysymMapXKB(deskflow::KeyMap &keyMap)
         // record the modifier mask for this key.  don't bother
         // for keys that change the group.
         item.m_generates = 0;
-        uint32_t modifierBit = XWindowsUtil::getModifierBitForKeySym(keysym);
-        if (isModifier && modifierBit != kKeyModifierBitNone) {
+        if (uint32_t modifierBit = XWindowsUtil::getModifierBitForKeySym(keysym);
+            isModifier && modifierBit != kKeyModifierBitNone) {
           item.m_generates = (1u << modifierBit);
           for (int32_t j = 0; j < 8; ++j) {
             // skip modifiers this key doesn't generate
@@ -819,8 +818,7 @@ int XWindowsKeyState::getEffectiveGroup(KeyCode keycode, int group) const
   (void)keycode;
 #if HAVE_XKB_EXTENSION
   // get effective group for key
-  int numGroups = XkbKeyNumGroups(m_xkb, keycode);
-  if (group >= numGroups) {
+  if (int numGroups = XkbKeyNumGroups(m_xkb, keycode); group >= numGroups) {
     unsigned char groupInfo = XkbKeyGroupInfo(m_xkb, keycode);
     switch (XkbOutOfRangeGroupAction(groupInfo)) {
     case XkbClampIntoRange:

--- a/src/lib/platform/XWindowsPowerManager.cpp
+++ b/src/lib/platform/XWindowsPowerManager.cpp
@@ -19,9 +19,7 @@ namespace {
 
 bool sleepInhibitCall(bool state, XWindowsPowerManager::InhibitScreenServices serviceID)
 {
-  std::string error;
-
-  if (!XWindowsPowerManager::inhibitScreenCall(serviceID, state, error)) {
+  if (std::string error; !XWindowsPowerManager::inhibitScreenCall(serviceID, state, error)) {
     LOG((CLOG_DEBUG "dbus inhibit error %s", error.c_str()));
     return false;
   }

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -496,8 +496,12 @@ void XWindowsScreen::getShape(int32_t &x, int32_t &y, int32_t &w, int32_t &h) co
 
 void XWindowsScreen::getCursorPos(int32_t &x, int32_t &y) const
 {
-  Window root, window;
-  int mx, my, xWindow, yWindow;
+  Window root;
+  Window window;
+  int mx;
+  int my;
+  int xWindow;
+  int yWindow;
   unsigned int mask;
   if (XQueryPointer(m_display, m_root, &root, &window, &mx, &my, &xWindow, &yWindow, &mask)) {
     x = mx;
@@ -765,8 +769,12 @@ int32_t XWindowsScreen::getJumpZoneSize() const
 bool XWindowsScreen::isAnyMouseButtonDown(uint32_t &buttonID) const
 {
   // query the pointer to get the button state
-  Window root, window;
-  int xRoot, yRoot, xWindow, yWindow;
+  Window root;
+  Window window;
+  int xRoot;
+  int yRoot;
+  int xWindow;
+  int yWindow;
   if (unsigned int state;
       XQueryPointer(m_display, m_root, &root, &window, &xRoot, &yRoot, &xWindow, &yWindow, &state)) {
     return ((state & (Button1Mask | Button2Mask | Button3Mask | Button4Mask | Button5Mask)) != 0);
@@ -871,7 +879,9 @@ Display *XWindowsScreen::openDisplay(const char *displayName)
 
   // verify the availability of the XTest extension
   if (!m_isPrimary) {
-    int majorOpcode, firstEvent, firstError;
+    int majorOpcode;
+    int firstEvent;
+    int firstError;
     if (!XQueryExtension(display, XTestExtensionName, &majorOpcode, &firstEvent, &firstError)) {
       LOG((CLOG_ERR "the XTest extension is not available"));
       XCloseDisplay(display);
@@ -882,9 +892,11 @@ Display *XWindowsScreen::openDisplay(const char *displayName)
 #if HAVE_XKB_EXTENSION
   {
     m_xkb = false;
-    int major = XkbMajorVersion, minor = XkbMinorVersion;
+    int major = XkbMajorVersion;
+    int minor = XkbMinorVersion;
     if (XkbLibraryVersion(&major, &minor)) {
-      int opcode, firstError;
+      int opcode;
+      int firstError;
       if (XkbQueryExtension(display, &opcode, &m_xkbEventBase, &firstError, &major, &minor)) {
         m_xkb = true;
         XkbSelectEvents(display, XkbUseCoreKbd, XkbMapNotifyMask, XkbMapNotifyMask);
@@ -1222,7 +1234,8 @@ void XWindowsScreen::handleSystemEvent(const Event &event, void *)
     if (XGetEventData(m_display, cookie) && cookie->type == GenericEvent && cookie->extension == xi_opcode) {
       if (cookie->evtype == XI_RawMotion) {
         // Get current pointer's position
-        Window root, child;
+        Window root;
+        Window child;
         XMotionEvent xmotion;
         xmotion.type = MotionNotify;
         xmotion.send_event = False; // Raw motion
@@ -1564,8 +1577,9 @@ void XWindowsScreen::onMouseMove(const XMotionEvent &xmotion)
     // pixel) but the latter is a PITA.  to work around
     // it we only warp when the mouse has moved more
     // than s_size pixels from the center.
-    if (static const int32_t s_size = 32; xmotion.x_root - m_xCenter < -s_size || xmotion.x_root - m_xCenter > s_size ||
-                                          xmotion.y_root - m_yCenter < -s_size || xmotion.y_root - m_yCenter > s_size) {
+    static const int32_t s_size = 32;
+    if (xmotion.x_root - m_xCenter < -s_size || xmotion.x_root - m_xCenter > s_size ||
+        xmotion.y_root - m_yCenter < -s_size || xmotion.y_root - m_yCenter > s_size) {
       warpCursorNoFlush(m_xCenter, m_yCenter);
     }
 
@@ -1586,7 +1600,8 @@ Cursor XWindowsScreen::createBlankCursor() const
   // this seems just a bit more complicated than really necessary
 
   // get the closet cursor size to 1x1
-  unsigned int w = 0, h = 0;
+  unsigned int w = 0;
+  unsigned int h = 0;
   XQueryBestCursor(m_display, m_root, 1, 1, &w, &h);
   w = std::max(1u, w);
   h = std::max(1u, h);
@@ -1724,7 +1739,9 @@ void XWindowsScreen::doSelectEvents(Window w) const
   XSelectInput(m_display, w, mask);
 
   // recurse on child windows
-  Window rw, pw, *cw;
+  Window rw;
+  Window pw;
+  Window *cw;
   unsigned int nc;
   if (XQueryTree(m_display, w, &rw, &pw, &cw, &nc)) {
     for (unsigned int i = 0; i < nc; ++i) {
@@ -1980,7 +1997,8 @@ bool XWindowsScreen::HotKeyItem::operator<(const HotKeyItem &x) const
 
 bool XWindowsScreen::detectXI2()
 {
-  int event, error;
+  int event;
+  int error;
   return XQueryExtension(m_display, "XInputExtension", &xi_opcode, &event, &error);
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -282,9 +282,8 @@ void XWindowsScreen::enter()
   // actually cause physical hardware input to trigger it
   int dummy;
   CARD16 powerlevel;
-  BOOL enabled;
-  if (DPMSQueryExtension(m_display, &dummy, &dummy) && DPMSCapable(m_display) &&
-      DPMSInfo(m_display, &powerlevel, &enabled)) {
+  if (BOOL enabled; DPMSQueryExtension(m_display, &dummy, &dummy) && DPMSCapable(m_display) &&
+                    DPMSInfo(m_display, &powerlevel, &enabled)) {
     if (enabled && powerlevel != DPMSModeOn)
       DPMSForceLevel(m_display, DPMSModeOn);
   }
@@ -591,8 +590,7 @@ uint32_t XWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 
         // skip with error if we can't map remaining modifiers
         unsigned int modifiers2;
-        KeyModifierMask mask2 = (mask & ~s_hotKeyModifiers[j]);
-        if (!m_keyState->mapModifiersToX(mask2, modifiers2)) {
+        if (KeyModifierMask mask2 = (mask & ~s_hotKeyModifiers[j]); !m_keyState->mapModifiersToX(mask2, modifiers2)) {
           err = true;
           continue;
         }
@@ -769,8 +767,8 @@ bool XWindowsScreen::isAnyMouseButtonDown(uint32_t &buttonID) const
   // query the pointer to get the button state
   Window root, window;
   int xRoot, yRoot, xWindow, yWindow;
-  unsigned int state;
-  if (XQueryPointer(m_display, m_root, &root, &window, &xRoot, &yRoot, &xWindow, &yWindow, &state)) {
+  if (unsigned int state;
+      XQueryPointer(m_display, m_root, &root, &window, &xRoot, &yRoot, &xWindow, &yWindow, &state)) {
     return ((state & (Button1Mask | Button2Mask | Button3Mask | Button4Mask | Button5Mask)) != 0);
   }
 
@@ -1566,9 +1564,8 @@ void XWindowsScreen::onMouseMove(const XMotionEvent &xmotion)
     // pixel) but the latter is a PITA.  to work around
     // it we only warp when the mouse has moved more
     // than s_size pixels from the center.
-    static const int32_t s_size = 32;
-    if (xmotion.x_root - m_xCenter < -s_size || xmotion.x_root - m_xCenter > s_size ||
-        xmotion.y_root - m_yCenter < -s_size || xmotion.y_root - m_yCenter > s_size) {
+    if (static const int32_t s_size = 32; xmotion.x_root - m_xCenter < -s_size || xmotion.x_root - m_xCenter > s_size ||
+                                          xmotion.y_root - m_yCenter < -s_size || xmotion.y_root - m_yCenter > s_size) {
       warpCursorNoFlush(m_xCenter, m_yCenter);
     }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1642,7 +1642,7 @@ ClipboardID XWindowsScreen::getClipboardID(Atom selection) const
   return kClipboardEnd;
 }
 
-void XWindowsScreen::processClipboardRequest(Window requestor, Time time, Atom property)
+void XWindowsScreen::processClipboardRequest(Window requestor, Time time, Atom property) const
 {
   // check every clipboard until one returns success
   for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
@@ -1652,7 +1652,7 @@ void XWindowsScreen::processClipboardRequest(Window requestor, Time time, Atom p
   }
 }
 
-void XWindowsScreen::destroyClipboardRequest(Window requestor)
+void XWindowsScreen::destroyClipboardRequest(Window requestor) const
 {
   // check every clipboard until one returns success
   for (ClipboardID id = 0; id < kClipboardEnd; ++id) {

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -180,12 +180,16 @@ private:
   bool m_isOnScreen;
 
   // screen shape stuff
-  int32_t m_x, m_y;
-  int32_t m_w, m_h;
-  int32_t m_xCenter, m_yCenter;
+  int32_t m_x;
+  int32_t m_y;
+  int32_t m_w;
+  int32_t m_h;
+  int32_t m_xCenter;
+  int32_t m_yCenter;
 
   // last mouse position
-  int32_t m_xCursor, m_yCursor;
+  int32_t m_xCursor;
+  int32_t m_yCursor;
 
   // keyboard stuff
   XWindowsKeyState *m_keyState;

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -100,10 +100,10 @@ private:
   ClipboardID getClipboardID(Atom selection) const;
 
   // continue processing a selection request
-  void processClipboardRequest(Window window, Time time, Atom property);
+  void processClipboardRequest(Window window, Time time, Atom property) const;
 
   // terminate a selection request
-  void destroyClipboardRequest(Window window);
+  void destroyClipboardRequest(Window window) const;
 
   // X I/O error handler
   void onError();

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -406,8 +406,8 @@ void XWindowsScreenSaver::watchForXScreenSaver()
   // add every child of the root to the list of windows to watch
   Window root = DefaultRootWindow(m_display);
   Window rw, pw, *cw;
-  unsigned int nc;
-  if (XQueryTree(m_display, root, &rw, &pw, &cw, &nc)) {
+
+  if (unsigned int nc; XQueryTree(m_display, root, &rw, &pw, &cw, &nc)) {
     for (unsigned int i = 0; i < nc; ++i) {
       addWatchXScreenSaver(cw[i]);
     }

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -70,7 +70,8 @@ XWindowsScreenSaver::XWindowsScreenSaver(Display *display, Window window, void *
   // check for DPMS extension.  this is an alternative screen saver
   // that powers down the display.
 #if HAVE_X11_EXTENSIONS_DPMS_H
-  int eventBase, errorBase;
+  int eventBase;
+  int errorBase;
   if (DPMSQueryExtension(m_display, &eventBase, &errorBase)) {
     if (DPMSCapable(m_display)) {
       // we have DPMS
@@ -295,7 +296,9 @@ bool XWindowsScreenSaver::findXScreenSaver()
   if (m_xscreensaver == None) {
     // find top-level window xscreensaver window
     Window root = DefaultRootWindow(m_display);
-    Window rw, pw, *cw;
+    Window rw;
+    Window pw;
+    Window *cw;
     unsigned int nc;
     if (XQueryTree(m_display, root, &rw, &pw, &cw, &nc)) {
       for (unsigned int i = 0; i < nc; ++i) {
@@ -405,7 +408,9 @@ void XWindowsScreenSaver::watchForXScreenSaver()
 
   // add every child of the root to the list of windows to watch
   Window root = DefaultRootWindow(m_display);
-  Window rw, pw, *cw;
+  Window rw;
+  Window pw;
+  Window *cw;
 
   if (unsigned int nc; XQueryTree(m_display, root, &rw, &pw, &cw, &nc)) {
     for (unsigned int i = 0; i < nc; ++i) {

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1748,8 +1748,7 @@ KeyID XWindowsUtil::mapKeySymToKeyID(KeySym k)
 
   default: {
     // lookup character in table
-    KeySymMap::const_iterator index = s_keySymToUCS4.find(k);
-    if (index != s_keySymToUCS4.end()) {
+    if (KeySymMap::const_iterator index = s_keySymToUCS4.find(k); index != s_keySymToUCS4.end()) {
       return static_cast<KeyID>(index->second);
     }
 

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -23,7 +23,7 @@
 class XWindowsUtil
 {
 public:
-  typedef std::vector<KeySym> KeySyms;
+  using KeySyms = std::vector<KeySym>;
 
   //! Get property
   /*!
@@ -120,7 +120,7 @@ public:
   {
   public:
     //! Error handler type
-    typedef void (*ErrorHandler)(Display *, XErrorEvent *, void *userData);
+    using ErrorHandler = void (*)(Display *, XErrorEvent *, void *userData);
 
     /*!
     Ignore X11 errors.
@@ -151,7 +151,7 @@ public:
     static void saveHandler(Display *, XErrorEvent *, void *);
 
   private:
-    typedef int (*XErrorHandler)(Display *, XErrorEvent *);
+    using XErrorHandler = int (*)(Display *, XErrorEvent *);
 
     Display *m_display;
     ErrorHandler m_handler;
@@ -174,7 +174,7 @@ private:
   static void initKeyMaps();
 
 private:
-  typedef std::map<KeySym, uint32_t> KeySymMap;
+  using KeySymMap = std::map<KeySym, uint32_t>;
 
   static KeySymMap s_keySymToUCS4;
 };

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -85,5 +85,6 @@ public:
 
 private:
   std::string m_name;
-  int32_t m_x, m_y;
+  int32_t m_x;
+  int32_t m_y;
 };

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -180,8 +180,7 @@ void ClientListener::handleUnknownClient(const Event &, void *vclient)
   assert(m_newClients.count(unknownClient) == 1);
 
   // get the real client proxy and install it
-  auto client = unknownClient->orphanClientProxy();
-  if (client) {
+  if (auto client = unknownClient->orphanClientProxy(); client) {
     // handshake was successful
     m_waitingClients.push_back(client);
     m_events->addEvent(Event(EventTypes::ClientListenerAccepted, this));

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -18,6 +18,7 @@
 
 ClientProxy::ClientProxy(const std::string &name, deskflow::IStream *stream) : BaseClientProxy(name), m_stream(stream)
 {
+  // do nothing
 }
 
 ClientProxy::~ClientProxy()

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -25,7 +25,7 @@ ClientProxy::~ClientProxy()
   delete m_stream;
 }
 
-void ClientProxy::close(const char *msg)
+void ClientProxy::close(const char *msg) const
 {
   LOG((CLOG_DEBUG1 "send close \"%s\" to \"%s\"", msg, getName().c_str()));
   ProtocolUtil::writef(getStream(), msg);

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -37,7 +37,7 @@ public:
   /*!
   Ask the client to disconnect, using \p msg as the reason.
   */
-  void close(const char *msg);
+  void close(const char *msg) const;
 
   //@}
   //! @name accessors

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -379,7 +379,13 @@ void ClientProxy1_0::setOptions(const OptionsList &options)
 bool ClientProxy1_0::recvInfo()
 {
   // parse the message
-  int16_t x, y, w, h, dummy1, mx, my;
+  int16_t x;
+  int16_t y;
+  int16_t w;
+  int16_t h;
+  int16_t dummy1;
+  int16_t mx;
+  int16_t my;
   if (!ProtocolUtil::readf(getStream(), kMsgDInfo + 4, &x, &y, &w, &h, &dummy1, &mx, &my)) {
     return false;
   }

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -92,7 +92,7 @@ protected:
   ClientClipboard m_clipboard[kClipboardEnd];
 
 private:
-  typedef bool (ClientProxy1_0::*MessageParser)(const uint8_t *);
+  using MessageParser = bool (ClientProxy1_0::*)(const uint8_t *);
 
   ClientInfo m_info;
   double m_heartbeatAlarm;

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -49,12 +49,12 @@ bool ClientProxy1_5::parseMessage(const uint8_t *code)
   return true;
 }
 
-void ClientProxy1_5::fileChunkReceived()
+void ClientProxy1_5::fileChunkReceived() const
 {
   // do nothing
 }
 
-void ClientProxy1_5::dragInfoReceived()
+void ClientProxy1_5::dragInfoReceived() const
 {
   // do nothing
 }

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -29,8 +29,8 @@ public:
   void sendDragInfo(uint32_t fileCount, const char *info, size_t size) override;
   void fileChunkSending(uint8_t mark, char *data, size_t dataSize) override;
   bool parseMessage(const uint8_t *code) override;
-  void fileChunkReceived();
-  void dragInfoReceived();
+  void fileChunkReceived() const;
+  void dragInfoReceived() const;
 
 private:
   IEventQueue *m_events;

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -57,9 +57,7 @@ bool ClientProxy1_6::recvClipboard()
   ClipboardID id;
   uint32_t seq;
 
-  int r = ClipboardChunk::assemble(getStream(), dataCached, id, seq);
-
-  if (r == kStart) {
+  if (int r = ClipboardChunk::assemble(getStream(), dataCached, id, seq); r == kStart) {
     size_t size = ClipboardChunk::getExpectedSize();
     LOG((CLOG_DEBUG "receiving clipboard %d size=%d", id, size));
   } else if (r == kFinish) {

--- a/src/lib/server/ClientProxy1_7.cpp
+++ b/src/lib/server/ClientProxy1_7.cpp
@@ -19,6 +19,7 @@ ClientProxy1_7::ClientProxy1_7(const std::string &name, deskflow::IStream *strea
     : ClientProxy1_6(name, stream, server, events),
       m_events(events)
 {
+  // do nothing
 }
 
 void ClientProxy1_7::secureInputNotification(const std::string &app) const

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -219,7 +219,8 @@ void ClientProxyUnknown::handleData(const Event &, void *)
     }
 
     // parse the reply to hello
-    int16_t major, minor;
+    int16_t major;
+    int16_t minor;
     if (std::string protocolName; !ProtocolUtil::readf(m_stream, kMsgHelloBack, &protocolName, &major, &minor, &name)) {
       throw XBadClient();
     }

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -213,16 +213,14 @@ void ClientProxyUnknown::handleData(const Event &, void *)
 
   try {
     // limit the maximum length of the hello
-    uint32_t n = m_stream->getSize();
-    if (n > kMaxHelloLength) {
+    if (uint32_t n = m_stream->getSize(); n > kMaxHelloLength) {
       LOG((CLOG_DEBUG1 "hello reply too long"));
       throw XBadClient();
     }
 
     // parse the reply to hello
     int16_t major, minor;
-    std::string protocolName;
-    if (!ProtocolUtil::readf(m_stream, kMsgHelloBack, &protocolName, &major, &minor, &name)) {
+    if (std::string protocolName; !ProtocolUtil::readf(m_stream, kMsgHelloBack, &protocolName, &major, &minor, &name)) {
       throw XBadClient();
     }
 

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -421,7 +421,8 @@ Config::getNeighbor(const std::string &srcName, EDirection srcSide, float positi
   }
 
   // find edge
-  const CellEdge *srcEdge, *dstEdge;
+  const CellEdge *srcEdge;
+  const CellEdge *dstEdge;
   if (!index->second.getLink(srcSide, position, srcEdge, dstEdge)) {
     // no neighbor
     return "";
@@ -639,8 +640,10 @@ void Config::readSectionOptions(ConfigReadContext &s)
     //   values       := valueAndArgs[,valueAndArgs]...
     //   valueAndArgs := <value>[(arg[,...])]
     std::string::size_type i = 0;
-    std::string name, value;
-    ConfigReadContext::ArgList nameArgs, valueArgs;
+    std::string name;
+    std::string value;
+    ConfigReadContext::ArgList nameArgs;
+    ConfigReadContext::ArgList valueArgs;
     s.parseNameWithArgs("name", line, "=", i, name, nameArgs);
     ++i;
     s.parseNameWithArgs("value", line, ",;\n", i, value, valueArgs);
@@ -843,8 +846,12 @@ void Config::readSectionLinks(ConfigReadContext &s)
       // in the range [0,100] and start < end.  if not given the
       // interval is taken to be (0,100).
       std::string::size_type i = 0;
-      std::string side, dstScreen, srcArgString, dstArgString;
-      ConfigReadContext::ArgList srcArgs, dstArgs;
+      std::string side;
+      std::string dstScreen;
+      std::string srcArgString;
+      std::string dstArgString;
+      ConfigReadContext::ArgList srcArgs;
+      ConfigReadContext::ArgList dstArgs;
       s.parseNameWithArgs("link", line, "=", i, side, srcArgs);
       ++i;
       s.parseNameWithArgs("screen", line, "", i, dstScreen, dstArgs);

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1647,8 +1647,7 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
 
   // options section
   s << "section: options" << std::endl;
-  const Config::ScreenOptions *options = config.getOptions("");
-  if (options != nullptr && options->size() > 0) {
+  if (const Config::ScreenOptions *options = config.getOptions(""); options && options->size() > 0) {
     for (auto option = options->begin(); option != options->end(); ++option) {
       const char *name = Config::getOptionName(option->first);
       std::string value = Config::getOptionValue(option->first, option->second);

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -148,9 +148,11 @@ public:
   public:
     explicit const_iterator() : m_i()
     {
+      // do nothing
     }
     explicit const_iterator(const internal_const_iterator &i) : m_i(i)
     {
+      // do nothing
     }
     const_iterator(const const_iterator &src) = default;
     ~const_iterator() = default;

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -160,11 +160,11 @@ public:
       m_i = i.m_i;
       return *this;
     }
-    std::string operator*()
+    std::string operator*() const
     {
       return m_i->first;
     }
-    const std::string *operator->()
+    const std::string *operator->() const
     {
       return &(m_i->first);
     }

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -870,7 +870,8 @@ bool InputFilter::operator==(const InputFilter &x) const
 
   // compare rule lists.  the easiest way to do that is to format each
   // rule into a string, sort the strings, then compare the results.
-  std::vector<std::string> aList, bList;
+  std::vector<std::string> aList;
+  std::vector<std::string> bList;
   for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {
     aList.push_back(i->format());
   }

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -73,8 +73,7 @@ InputFilter::EFilterStatus InputFilter::KeystrokeCondition::match(const Event &e
   EFilterStatus status;
 
   // check for hotkey events
-  EventTypes type = event.getType();
-  if (type == EventTypes::PrimaryScreenHotkeyDown) {
+  if (EventTypes type = event.getType(); type == EventTypes::PrimaryScreenHotkeyDown) {
     status = kActivate;
   } else if (type == EventTypes::PrimaryScreenHotkeyUp) {
     status = kDeactivate;
@@ -83,8 +82,7 @@ InputFilter::EFilterStatus InputFilter::KeystrokeCondition::match(const Event &e
   }
 
   // check if it's our hotkey
-  auto *kinfo = static_cast<IPlatformScreen::HotKeyInfo *>(event.getData());
-  if (kinfo->m_id != m_id) {
+  if (auto *kinfo = static_cast<IPlatformScreen::HotKeyInfo *>(event.getData()); kinfo->m_id != m_id) {
     return kNoMatch;
   }
 
@@ -150,8 +148,7 @@ InputFilter::EFilterStatus InputFilter::MouseButtonCondition::match(const Event 
   EFilterStatus status;
 
   // check for hotkey events
-  EventTypes type = event.getType();
-  if (type == EventTypes::PrimaryScreenButtonDown) {
+  if (EventTypes type = event.getType(); type == EventTypes::PrimaryScreenButtonDown) {
     status = kActivate;
   } else if (type == EventTypes::PrimaryScreenButtonUp) {
     status = kDeactivate;
@@ -161,8 +158,8 @@ InputFilter::EFilterStatus InputFilter::MouseButtonCondition::match(const Event 
 
   // check if it's the right button and modifiers.  ignore modifiers
   // that cannot be combined with a mouse button.
-  auto *minfo = static_cast<IPlatformScreen::ButtonInfo *>(event.getData());
-  if (minfo->m_button != m_button || (minfo->m_mask & ~s_ignoreMask) != m_mask) {
+  if (auto *minfo = static_cast<IPlatformScreen::ButtonInfo *>(event.getData());
+      minfo->m_button != m_button || (minfo->m_mask & ~s_ignoreMask) != m_mask) {
     return kNoMatch;
   }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -399,7 +399,10 @@ void Server::switchScreen(BaseClientProxy *dst, int32_t x, int32_t y, bool forSc
 {
   assert(dst != nullptr);
 
-  int32_t dx, dy, dw, dh;
+  int32_t dx;
+  int32_t dy;
+  int32_t dw;
+  int32_t dh;
   dst->getShape(dx, dy, dw, dh);
 
   // any of these conditions seem to trigger when the portal permission dialog
@@ -515,7 +518,8 @@ void Server::jumpToScreen(BaseClientProxy *newScreen)
   m_active->setJumpCursorPos(m_x, m_y);
 
   // get the last cursor position on the target screen
-  int32_t x, y;
+  int32_t x;
+  int32_t y;
   newScreen->getJumpCursorPos(x, y);
 
   switchScreen(newScreen, x, y, false);
@@ -523,7 +527,10 @@ void Server::jumpToScreen(BaseClientProxy *newScreen)
 
 float Server::mapToFraction(BaseClientProxy *client, EDirection dir, int32_t x, int32_t y) const
 {
-  int32_t sx, sy, sw, sh;
+  int32_t sx;
+  int32_t sy;
+  int32_t sw;
+  int32_t sh;
   client->getShape(sx, sy, sw, sh);
   switch (dir) {
   case kLeft:
@@ -543,7 +550,10 @@ float Server::mapToFraction(BaseClientProxy *client, EDirection dir, int32_t x, 
 
 void Server::mapToPixel(BaseClientProxy *client, EDirection dir, float f, int32_t &x, int32_t &y) const
 {
-  int32_t sx, sy, sw, sh;
+  int32_t sx;
+  int32_t sy;
+  int32_t sw;
+  int32_t sh;
   client->getShape(sx, sy, sw, sh);
   switch (dir) {
   case kLeft:
@@ -627,7 +637,10 @@ BaseClientProxy *Server::mapToNeighbor(BaseClientProxy *src, EDirection srcSide,
   }
 
   // get the source screen's size
-  int32_t dx, dy, dw, dh;
+  int32_t dx;
+  int32_t dy;
+  int32_t dw;
+  int32_t dh;
   BaseClientProxy *lastGoodScreen = src;
   lastGoodScreen->getShape(dx, dy, dw, dh);
 
@@ -727,7 +740,10 @@ void Server::avoidJumpZone(BaseClientProxy *dst, EDirection dir, int32_t &x, int
   }
 
   const std::string dstName(getName(dst));
-  int32_t dx, dy, dw, dh;
+  int32_t dx;
+  int32_t dy;
+  int32_t dw;
+  int32_t dh;
   dst->getShape(dx, dy, dw, dh);
   float t = mapToFraction(dst, dir, x, y);
   int32_t z = getJumpZoneSize(dst);
@@ -887,7 +903,10 @@ void Server::armSwitchTwoTap(int32_t x, int32_t y)
     } else if (!m_switchTwoTapArmed) {
       // still time for a double tap.  see if we left the tap
       // zone and, if so, arm the two tap.
-      int32_t ax, ay, aw, ah;
+      int32_t ax;
+      int32_t ay;
+      int32_t aw;
+      int32_t ah;
       m_active->getShape(ax, ay, aw, ah);
       int32_t tapZone = m_primaryClient->getJumpZoneSize();
       if (tapZone < m_switchTwoTapZone) {
@@ -967,7 +986,10 @@ uint32_t Server::getCorner(BaseClientProxy *client, int32_t x, int32_t y, int32_
   assert(client != nullptr);
 
   // get client screen shape
-  int32_t ax, ay, aw, ah;
+  int32_t ax;
+  int32_t ay;
+  int32_t aw;
+  int32_t ah;
   client->getShape(ax, ay, aw, ah);
 
   // check for x,y on the left or right
@@ -1015,7 +1037,10 @@ void Server::stopRelativeMoves()
 {
   if (m_relativeMoves && m_active != m_primaryClient) {
     // warp to the center of the active client so we know where we are
-    int32_t ax, ay, aw, ah;
+    int32_t ax;
+    int32_t ay;
+    int32_t aw;
+    int32_t ah;
     m_active->getShape(ax, ay, aw, ah);
     m_x = ax + (aw >> 1);
     m_y = ay + (ah >> 1);
@@ -1138,7 +1163,8 @@ void Server::handleShapeChanged(const Event &, void *vclient)
   LOG((CLOG_DEBUG "screen \"%s\" shape changed", getName(client).c_str()));
 
   // update jump coordinate
-  int32_t x, y;
+  int32_t x;
+  int32_t y;
   client->getCursorPos(x, y);
   client->setJumpCursorPos(x, y);
 
@@ -1336,7 +1362,8 @@ void Server::handleSwitchInDirectionEvent(const Event &event, void *)
   auto *info = static_cast<SwitchInDirectionInfo *>(event.getData());
 
   // jump to screen in chosen direction from center of this screen
-  int32_t x = m_x, y = m_y;
+  int32_t x = m_x;
+  int32_t y = m_y;
   BaseClientProxy *newScreen = getNeighbor(m_active, info->m_direction, x, y);
   if (newScreen == nullptr) {
     LOG((CLOG_DEBUG1 "no neighbor %s", Config::dirName(info->m_direction)));
@@ -1488,7 +1515,10 @@ void Server::onScreensaver(bool activated)
     if (m_activeSaver != nullptr && m_activeSaver != m_primaryClient) {
       // check position
       BaseClientProxy *screen = m_activeSaver;
-      int32_t x, y, w, h;
+      int32_t x;
+      int32_t y;
+      int32_t w;
+      int32_t h;
       screen->getShape(x, y, w, h);
       int32_t zoneSize = getJumpZoneSize(screen);
       if (m_xSaver < x + zoneSize) {
@@ -1616,12 +1646,16 @@ bool Server::onMouseMovePrimary(int32_t x, int32_t y)
   m_y = y;
 
   // get screen shape
-  int32_t ax, ay, aw, ah;
+  int32_t ax;
+  int32_t ay;
+  int32_t aw;
+  int32_t ah;
   m_active->getShape(ax, ay, aw, ah);
   int32_t zoneSize = getJumpZoneSize(m_active);
 
   // clamp position to screen
-  int32_t xc = x, yc = y;
+  int32_t xc = x;
+  int32_t yc = y;
   if (xc < ax + zoneSize) {
     xc = ax;
   } else if (xc >= ax + aw - zoneSize) {
@@ -1637,7 +1671,8 @@ bool Server::onMouseMovePrimary(int32_t x, int32_t y)
   // when the cursor is in a corner, there may be a screen either
   // horizontally or vertically.  check both directions.
   EDirection dirh = kNoDirection, dirv = kNoDirection;
-  int32_t xh = x, yv = y;
+  int32_t xh = x;
+  int32_t yv = y;
   if (x < ax + zoneSize) {
     xh -= zoneSize;
     dirh = kLeft;
@@ -1660,7 +1695,8 @@ bool Server::onMouseMovePrimary(int32_t x, int32_t y)
 
   // check both horizontally and vertically
   EDirection dirs[] = {dirh, dirv};
-  int32_t xs[] = {xh, x}, ys[] = {y, yv};
+  int32_t xs[] = {xh, x};
+  int32_t ys[] = {y, yv};
   for (int i = 0; i < 2; ++i) {
     EDirection dir = dirs[i];
     if (dir == kNoDirection) {
@@ -1737,7 +1773,10 @@ void Server::onMouseMoveSecondary(int32_t dx, int32_t dy)
   m_y += dy;
 
   // get screen shape
-  int32_t ax, ay, aw, ah;
+  int32_t ax;
+  int32_t ay;
+  int32_t aw;
+  int32_t ah;
   m_active->getShape(ax, ay, aw, ah);
 
   // find direction of neighbor and get the neighbor
@@ -1745,7 +1784,8 @@ void Server::onMouseMoveSecondary(int32_t dx, int32_t dy)
   BaseClientProxy *newScreen;
   do {
     // clamp position to screen
-    int32_t xc = m_x, yc = m_y;
+    int32_t xc = m_x;
+    int32_t yc = m_y;
     if (xc < ax) {
       xc = ax;
     } else if (xc >= ax + aw) {
@@ -1886,7 +1926,8 @@ bool Server::addClient(BaseClientProxy *client)
   m_clients.insert(std::make_pair(name, client));
 
   // initialize client data
-  int32_t x, y;
+  int32_t x;
+  int32_t y;
   client->getCursorPos(x, y);
   client->setJumpCursorPos(x, y);
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1062,7 +1062,7 @@ void Server::sendOptions(BaseClientProxy *client) const
   if (options != nullptr) {
     // convert options to a more convenient form for sending
     optionsList.reserve(2 * options->size());
-    for (Config::ScreenOptions::const_iterator index = options->begin(); index != options->end(); ++index) {
+    for (auto index = options->begin(); index != options->end(); ++index) {
       optionsList.push_back(index->first);
       optionsList.push_back(static_cast<uint32_t>(index->second));
     }

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -599,8 +599,7 @@ BaseClientProxy *Server::getNeighbor(BaseClientProxy *src, EDirection dir, int32
 
     // look up neighbor cell.  if the screen is connected and
     // ready then we can stop.
-    ClientList::const_iterator index = m_clients.find(dstName);
-    if (index != m_clients.end()) {
+    if (ClientList::const_iterator index = m_clients.find(dstName); index != m_clients.end()) {
       LOG((CLOG_DEBUG2 "\"%s\" is on %s of \"%s\" at %f", dstName.c_str(), Config::dirName(dir), srcName.c_str(), t));
       mapToPixel(index->second, dir, tTmp, x, y);
       return index->second;
@@ -843,9 +842,8 @@ bool Server::isSwitchOkay(
   }
 
   // check for optional needed modifiers
-  KeyModifierMask mods = this->m_primaryClient->getToggleMask();
-
-  if (!preventSwitch && ((this->m_switchNeedsShift && ((mods & KeyModifierShift) != KeyModifierShift)) ||
+  if (KeyModifierMask mods = this->m_primaryClient->getToggleMask();
+      !preventSwitch && ((this->m_switchNeedsShift && ((mods & KeyModifierShift) != KeyModifierShift)) ||
                          (this->m_switchNeedsControl && ((mods & KeyModifierControl) != KeyModifierControl)) ||
                          (this->m_switchNeedsAlt && ((mods & KeyModifierAlt) != KeyModifierAlt)))) {
     LOG((CLOG_DEBUG1 "need modifiers to switch"));
@@ -1687,8 +1685,7 @@ bool Server::onMouseMovePrimary(int32_t x, int32_t y)
 void Server::onMouseMoveSecondary(int32_t dx, int32_t dy)
 {
   LOG((CLOG_DEBUG2 "onMouseMoveSecondary initial %+d,%+d", dx, dy));
-  const char *envVal = std::getenv("DESKFLOW_MOUSE_ADJUSTMENT");
-  if (envVal != nullptr) {
+  if (const char *envVal = std::getenv("DESKFLOW_MOUSE_ADJUSTMENT"); envVal) {
     try {
       double multiplier = std::stod(envVal);                               // Convert to double
       auto adjustedDx = static_cast<int32_t>(std::round(dx * multiplier)); // Apply multiplier and round
@@ -2004,8 +2001,7 @@ void Server::removeOldClient(BaseClientProxy *client)
 
 void Server::forceLeaveClient(BaseClientProxy *client)
 {
-  BaseClientProxy *active = (m_activeSaver != nullptr) ? m_activeSaver : m_active;
-  if (active == client) {
+  if (BaseClientProxy *active = (m_activeSaver != nullptr) ? m_activeSaver : m_active; active == client) {
     // record new position (center of primary screen)
     m_primaryClient->getCursorCenter(m_x, m_y);
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -383,14 +383,17 @@ private:
 
   // current mouse position (in absolute screen coordinates) on
   // whichever screen is active
-  int32_t m_x, m_y;
+  int32_t m_x;
+  int32_t m_y;
 
   // last mouse deltas.  this is needed to smooth out double tap
   // on win32 which reports bogus mouse motion at the edge of
   // the screen when using low level hooks, synthesizing motion
   // in the opposite direction the mouse actually moved.
-  int32_t m_xDelta, m_yDelta;
-  int32_t m_xDelta2, m_yDelta2;
+  int32_t m_xDelta;
+  int32_t m_yDelta;
+  int32_t m_xDelta2;
+  int32_t m_yDelta2;
 
   // current configuration
   ServerConfig *m_config;
@@ -403,7 +406,8 @@ private:
 
   // state saved when screen saver activates
   BaseClientProxy *m_activeSaver;
-  int32_t m_xSaver, m_ySaver;
+  int32_t m_xSaver;
+  int32_t m_ySaver;
 
   // common state for screen switch tests.  all tests are always
   // trying to reach the same screen in the same direction.
@@ -413,7 +417,8 @@ private:
   // state for delayed screen switching
   double m_switchWaitDelay;
   EventQueueTimer *m_switchWaitTimer;
-  int32_t m_switchWaitX, m_switchWaitY;
+  int32_t m_switchWaitX;
+  int32_t m_switchWaitY;
 
   // state for double-tap screen switching
   double m_switchTwoTapDelay;


### PR DESCRIPTION
 Fix more sonar issues
  - Daemon and subclasses should pass `const & func`
  - Use C++17 style if / switch initilizers where we can 
  - more Const methods
  - start to use even more `auto` / `const auto`
  - replace use of `typedef` with `using`
  - minor typo fix from `colom` to `colon`
  - Define only one var per line
  - Add more `// do nothing` for empty methods.