### PR TITLE
ci: Simplify our `Install Dependencies` action

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -27,10 +27,9 @@ runs:
 
   steps:
     - name: Install Depends
+      if: ${{ runner.os != 'Windows' }}
       run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            echo "Window not supported yet"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
             brew install googletest openssl --quiet
           elif [ "$RUNNER_OS" == "Linux" ]; then
             if [ ${{inputs.like}} == "debian" ]; then

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -31,7 +31,7 @@ runs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             echo "Window not supported yet"
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install cmake googletest ninja openssl --quiet
+            brew install googletest openssl --quiet
           elif [ "$RUNNER_OS" == "Linux" ]; then
             if [ ${{inputs.like}} == "debian" ]; then
               apt update -qqq > /dev/null

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -78,13 +78,6 @@ runs:
         cache: true
         cache-key-prefix: ${{matrix.target.os}}-${{inputs.qt-version}}
 
-    # Install Ninja with an action instead of using Chocolatey, as it's more
-    # reliable and faster. The Ninja install action is pretty good as it
-    # downloads directly from the `ninja-build` GitHub project releases.
-    - name: Install Ninja
-      if: ${{ runner.os == 'Windows' }}
-      uses: seanmiddleditch/gha-setup-ninja@master
-
     - name: Build and cache vcpkg
       if: ${{ runner.os == 'Windows' }}
       id: vcpkg


### PR DESCRIPTION
Simplifies the install dependencies action a bit:
   - remove the ninja install action as ninja is part of the runners now
   - remove cmake / ninja install from mac os runs as they are part of the runner for mac os also 
   - Do do the `Install Depends` step on windows its was empty anyway 