### PR TITLE
Sonar cleanup 2

### DIFF
--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -599,7 +599,7 @@ void ArchMultithreadPosix::insert(ArchThreadImpl *thread)
   m_threadList.push_back(thread);
 }
 
-void ArchMultithreadPosix::erase(ArchThreadImpl *thread)
+void ArchMultithreadPosix::erase(const ArchThreadImpl *thread)
 {
   for (auto index = m_threadList.begin(); index != m_threadList.end(); ++index) {
     if (*index == thread) {

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -84,7 +84,7 @@ private:
   ArchThreadImpl *find(pthread_t thread);
   ArchThreadImpl *findNoRef(pthread_t thread);
   void insert(ArchThreadImpl *thread);
-  void erase(ArchThreadImpl *thread);
+  void erase(const ArchThreadImpl *thread);
 
   void refThread(ArchThreadImpl *rep);
   void testCancelThreadImpl(ArchThreadImpl *rep);

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -298,16 +298,16 @@ void EventQueue::removeHandlers(void *target)
     if (index != m_handlers.end()) {
       // copy to handlers array and clear table for target
       TypeHandlerTable &typeHandlers = index->second;
-      for (auto index2 = typeHandlers.begin(); index2 != typeHandlers.end(); ++index2) {
-        handlers.push_back(index2->second);
+      for (const auto &[key, value] : typeHandlers) {
+        handlers.push_back(value);
       }
       typeHandlers.clear();
     }
   }
 
   // delete handlers
-  for (auto index = handlers.begin(); index != handlers.end(); ++index) {
-    delete *index;
+  for (auto index : handlers) {
+    delete index;
   }
 }
 

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -101,10 +101,8 @@ void EventQueue::adoptBuffer(IEventQueueBuffer *buffer)
   }
 }
 
-bool EventQueue::getEvent(Event &event, double timeout)
+bool EventQueue::processEvent(Event &event, double timeout, Stopwatch &timer)
 {
-  Stopwatch timer(true);
-retry:
   // if no events are waiting then handle timers and then wait
   while (m_buffer->isEmpty()) {
     // handle timers first
@@ -139,7 +137,7 @@ retry:
       // don't want to fail if client isn't expecting that
       // so if getEvent() fails with an infinite timeout
       // then just try getting another event.
-      goto retry;
+      processEvent(event, timeout, timer);
     }
     return false;
 
@@ -156,6 +154,12 @@ retry:
     assert(0 && "invalid event type");
     return false;
   }
+}
+
+bool EventQueue::getEvent(Event &event, double timeout)
+{
+  Stopwatch timer(true);
+  return processEvent(event, timeout, timer);
 }
 
 bool EventQueue::dispatchEvent(const Event &event)

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -58,6 +58,15 @@ private:
   double getNextTimerTimeout() const;
   void addEventToBuffer(const Event &event);
 
+  //!
+  //! \brief processEvent Internal event proccessing
+  //! \param event - event to process
+  //! \param timeout - Timeout to stop
+  //! \param timer - StopWatch to use
+  //! \return true if handled
+  //!
+  bool processEvent(Event &event, double timeout, Stopwatch &timer);
+
 private:
   class Timer
   {

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -265,7 +265,7 @@ int Log::getFilter() const
   return m_maxPriority;
 }
 
-void Log::output(ELevel priority, char *msg)
+void Log::output(ELevel priority, const char *msg)
 {
   assert(priority >= -1 && priority < g_numPriority);
   assert(msg != nullptr);

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -24,7 +24,7 @@ static const char *g_priority[] = {"FATAL",  "ERROR",  "WARNING", "NOTE",   "INF
                                    "DEBUG1", "DEBUG2", "DEBUG3",  "DEBUG4", "DEBUG5"};
 
 // number of priorities
-static const int g_numPriority = (int)(sizeof(g_priority) / sizeof(g_priority[0]));
+static const int g_numPriority = 11;
 
 // if NDEBUG (not debug) is not specified, i.e. you're building in debug,
 // then set default log level to DEBUG, otherwise the max level is INFO.

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -121,7 +121,7 @@ public:
   //@}
 
 private:
-  void output(ELevel priority, char *msg);
+  void output(ELevel priority, const char *msg);
 
 private:
   using OutputterList = std::list<ILogOutputter *>;

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -27,8 +27,8 @@ LOGC() provide convenient access.
 class Log
 {
 public:
-  Log(bool singleton = true);
-  Log(Log *src);
+  explicit Log(bool singleton = true);
+  explicit Log(Log *src);
   Log(Log const &) = delete;
   Log(Log &&) = delete;
   ~Log();

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -162,7 +162,7 @@ bool CaselessCmp::operator()(const std::string &a, const std::string &b) const
   return less(a, b);
 }
 
-bool CaselessCmp::less(const std::string &a, const std::string &b)
+bool CaselessCmp::less(const std::string_view &a, const std::string_view &b)
 {
   return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), &deskflow::string::CaselessCmp::cmpLess);
 }

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -67,7 +67,7 @@ public:
   bool operator()(const std::string &a, const std::string &b) const;
 
   //! Returns true iff \c a is lexicographically less than \c b
-  static bool less(const std::string &a, const std::string &b);
+  static bool less(const std::string_view &a, const std::string_view &b);
 
   //! Returns true iff \c a is lexicographically equal to \c b
   static bool equal(const std::string &a, const std::string &b);

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -226,7 +226,7 @@ std::string Unicode::UCS2ToUTF8(const std::string &src, bool *errors)
   return doUCS2ToUTF8(reinterpret_cast<const uint8_t *>(src.data()), n, errors);
 }
 
-std::string Unicode::UCS4ToUTF8(const std::string &src, bool *errors)
+std::string Unicode::UCS4ToUTF8(const std::string_view &src, bool *errors)
 {
   // default to success
   resetError(errors);
@@ -236,7 +236,7 @@ std::string Unicode::UCS4ToUTF8(const std::string &src, bool *errors)
   return doUCS4ToUTF8(reinterpret_cast<const uint8_t *>(src.data()), n, errors);
 }
 
-std::string Unicode::UTF16ToUTF8(const std::string &src, bool *errors)
+std::string Unicode::UTF16ToUTF8(const std::string_view &src, bool *errors)
 {
   // default to success
   resetError(errors);
@@ -246,7 +246,7 @@ std::string Unicode::UTF16ToUTF8(const std::string &src, bool *errors)
   return doUTF16ToUTF8(reinterpret_cast<const uint8_t *>(src.data()), n, errors);
 }
 
-std::string Unicode::UTF32ToUTF8(const std::string &src, bool *errors)
+std::string Unicode::UTF32ToUTF8(const std::string_view &src, bool *errors)
 {
   // default to success
   resetError(errors);

--- a/src/lib/base/Unicode.h
+++ b/src/lib/base/Unicode.h
@@ -81,21 +81,21 @@ public:
   Convert from UCS-4 to UTF-8.  If errors is not nullptr then *errors is
   set to true iff any character could not be decoded.
   */
-  static std::string UCS4ToUTF8(const std::string &, bool *errors = nullptr);
+  static std::string UCS4ToUTF8(const std::string_view &, bool *errors = nullptr);
 
   //! Convert from UTF-16 to UTF-8
   /*!
   Convert from UTF-16 to UTF-8.  If errors is not nullptr then *errors is
   set to true iff any character could not be decoded.
   */
-  static std::string UTF16ToUTF8(const std::string &, bool *errors = nullptr);
+  static std::string UTF16ToUTF8(const std::string_view &, bool *errors = nullptr);
 
   //! Convert from UTF-32 to UTF-8
   /*!
   Convert from UTF-32 to UTF-8.  If errors is not nullptr then *errors is
   set to true iff any character could not be decoded.
   */
-  static std::string UTF32ToUTF8(const std::string &, bool *errors = nullptr);
+  static std::string UTF32ToUTF8(const std::string_view &, bool *errors = nullptr);
 
   //! Convert from the current locale encoding to UTF-8
   /*!

--- a/src/lib/base/XBase.h
+++ b/src/lib/base/XBase.h
@@ -20,7 +20,7 @@ public:
   //! Use getWhat() as the result of what()
   XBase();
   //! Use \c msg as the result of what()
-  XBase(const std::string &msg);
+  explicit XBase(const std::string &msg);
   ~XBase() throw() override = default;
 
   //! Reason for exception

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -43,7 +43,7 @@ public:
   class FailInfo
   {
   public:
-    FailInfo(const char *what) : m_retry(false), m_what(what)
+    explicit FailInfo(const char *what) : m_retry(false), m_what(what)
     {
       // do nothing
     }

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -232,7 +232,7 @@ bool ArgParser::isArg(
   return false;
 }
 
-void ArgParser::splitCommandString(std::string &command, std::vector<std::string> &argv)
+void ArgParser::splitCommandString(const std::string &command, std::vector<std::string> &argv)
 {
   if (command.empty()) {
     return;
@@ -276,7 +276,7 @@ void ArgParser::splitCommandString(std::string &command, std::vector<std::string
   argv.push_back(subString);
 }
 
-bool ArgParser::searchDoubleQuotes(std::string &command, size_t &left, size_t &right, size_t startPos)
+bool ArgParser::searchDoubleQuotes(const std::string &command, size_t &left, size_t &right, size_t startPos)
 {
   bool result = false;
   left = std::string::npos;

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -232,7 +232,7 @@ bool ArgParser::isArg(
   return false;
 }
 
-void ArgParser::splitCommandString(const std::string &command, std::vector<std::string> &argv)
+void ArgParser::splitCommandString(const std::string_view &command, std::vector<std::string> &argv)
 {
   if (command.empty()) {
     return;
@@ -256,10 +256,10 @@ void ArgParser::splitCommandString(const std::string &command, std::vector<std::
     }
 
     if (!ignoreThisSpace) {
-      std::string subString = command.substr(startPos, space - startPos);
+      auto subString = command.substr(startPos, space - startPos);
 
       removeDoubleQuotes(subString);
-      argv.push_back(subString);
+      argv.push_back(std::string{subString.begin(), subString.end()});
     }
 
     // find next space
@@ -271,12 +271,12 @@ void ArgParser::splitCommandString(const std::string &command, std::vector<std::
     }
   }
 
-  std::string subString = command.substr(startPos, command.size());
+  auto subString = command.substr(startPos, command.size());
   removeDoubleQuotes(subString);
-  argv.push_back(subString);
+  argv.push_back(std::string{subString.begin(), subString.end()});
 }
 
-bool ArgParser::searchDoubleQuotes(const std::string &command, size_t &left, size_t &right, size_t startPos)
+bool ArgParser::searchDoubleQuotes(const std::string_view &command, size_t &left, size_t &right, size_t startPos)
 {
   bool result = false;
   left = std::string::npos;
@@ -298,7 +298,7 @@ bool ArgParser::searchDoubleQuotes(const std::string &command, size_t &left, siz
   return result;
 }
 
-void ArgParser::removeDoubleQuotes(std::string &arg)
+void ArgParser::removeDoubleQuotes(std::string_view &arg)
 {
   // if string is surrounded by double quotes, remove them
   if (arg[0] == '\"' && arg[arg.size() - 1] == '\"') {

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -259,7 +259,7 @@ void ArgParser::splitCommandString(const std::string_view &command, std::vector<
       auto subString = command.substr(startPos, space - startPos);
 
       removeDoubleQuotes(subString);
-      argv.push_back(std::string{subString.begin(), subString.end()});
+      argv.emplace_back(subString);
     }
 
     // find next space
@@ -273,7 +273,7 @@ void ArgParser::splitCommandString(const std::string_view &command, std::vector<
 
   auto subString = command.substr(startPos, command.size());
   removeDoubleQuotes(subString);
-  argv.push_back(std::string{subString.begin(), subString.end()});
+  argv.emplace_back(subString);
 }
 
 bool ArgParser::searchDoubleQuotes(const std::string_view &command, size_t &left, size_t &right, size_t startPos)

--- a/src/lib/deskflow/ArgParser.h
+++ b/src/lib/deskflow/ArgParser.h
@@ -36,9 +36,9 @@ public:
   static bool isArg(
       int argi, int argc, const char *const *argv, const char *name1, const char *name2, int minRequiredParameters = 0
   );
-  static void splitCommandString(const std::string &command, std::vector<std::string> &argv);
-  static bool searchDoubleQuotes(const std::string &command, size_t &left, size_t &right, size_t startPos = 0);
-  static void removeDoubleQuotes(std::string &arg);
+  static void splitCommandString(const std::string_view &command, std::vector<std::string> &argv);
+  static bool searchDoubleQuotes(const std::string_view &command, size_t &left, size_t &right, size_t startPos = 0);
+  static void removeDoubleQuotes(std::string_view &arg);
   static const char **getArgv(std::vector<std::string> &argsArray);
   static std::string
   assembleCommand(std::vector<std::string> &argsArray, std::string ignoreArg = "", int parametersRequired = 0);

--- a/src/lib/deskflow/ArgParser.h
+++ b/src/lib/deskflow/ArgParser.h
@@ -36,8 +36,8 @@ public:
   static bool isArg(
       int argi, int argc, const char *const *argv, const char *name1, const char *name2, int minRequiredParameters = 0
   );
-  static void splitCommandString(std::string &command, std::vector<std::string> &argv);
-  static bool searchDoubleQuotes(std::string &command, size_t &left, size_t &right, size_t startPos = 0);
+  static void splitCommandString(const std::string &command, std::vector<std::string> &argv);
+  static bool searchDoubleQuotes(const std::string &command, size_t &left, size_t &right, size_t startPos = 0);
   static void removeDoubleQuotes(std::string &arg);
   static const char **getArgv(std::vector<std::string> &argsArray);
   static std::string

--- a/src/lib/deskflow/ArgParser.h
+++ b/src/lib/deskflow/ArgParser.h
@@ -21,7 +21,7 @@ class ArgParser
 {
 
 public:
-  ArgParser(App *app);
+  explicit ArgParser(App *app);
 
   bool parseServerArgs(deskflow::ServerArgs &args, int argc, const char *const *argv);
   bool parseClientArgs(deskflow::ClientArgs &args, int argc, const char *const *argv);

--- a/src/lib/deskflow/Chunk.h
+++ b/src/lib/deskflow/Chunk.h
@@ -12,7 +12,7 @@
 class Chunk : public EventData
 {
 public:
-  Chunk(size_t size);
+  explicit Chunk(size_t size);
   Chunk(Chunk const &) = delete;
   Chunk(Chunk &&) = delete;
   ~Chunk() override;

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -64,8 +64,6 @@ public:
 
   void updateStatus();
   void updateStatus(const std::string &msg) const;
-  void resetRestartTimeout() const;
-  double nextRestartTimeout() const;
   void handleScreenError(const Event &, void *);
   deskflow::Screen *openClientScreen();
   void closeClientScreen(deskflow::Screen *screen);

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -23,7 +23,7 @@ class ISocketFactory;
 class ClientApp : public App
 {
 public:
-  ClientApp(IEventQueue *events);
+  explicit ClientApp(IEventQueue *events);
   ~ClientApp() override = default;
 
   //

--- a/src/lib/deskflow/ClipboardChunk.h
+++ b/src/lib/deskflow/ClipboardChunk.h
@@ -21,7 +21,7 @@ class IStream;
 class ClipboardChunk : public Chunk
 {
 public:
-  ClipboardChunk(size_t size);
+  explicit ClipboardChunk(size_t size);
 
   static ClipboardChunk *start(ClipboardID id, uint32_t sequence, const std::string &size);
   static ClipboardChunk *data(ClipboardID id, uint32_t sequence, const std::string &data);

--- a/src/lib/deskflow/DisplayInvalidException.h
+++ b/src/lib/deskflow/DisplayInvalidException.h
@@ -12,12 +12,12 @@
 class DisplayInvalidException : public std::runtime_error
 {
 public:
-  DisplayInvalidException(const char *msg) : std::runtime_error(msg)
+  explicit DisplayInvalidException(const char *msg) : std::runtime_error(msg)
   {
     // do nothing
   }
 
-  DisplayInvalidException(std::string msg) : std::runtime_error(msg)
+  explicit DisplayInvalidException(std::string msg) : std::runtime_error(msg)
   {
     // do nothing
   }

--- a/src/lib/deskflow/IClipboard.cpp
+++ b/src/lib/deskflow/IClipboard.cpp
@@ -13,7 +13,7 @@
 // IClipboard
 //
 
-void IClipboard::unmarshall(IClipboard *clipboard, const std::string &data, Time time)
+void IClipboard::unmarshall(IClipboard *clipboard, const std::string_view &data, Time time)
 {
   assert(clipboard != nullptr);
 

--- a/src/lib/deskflow/IClipboard.h
+++ b/src/lib/deskflow/IClipboard.h
@@ -131,7 +131,7 @@ public:
   Extract marshalled clipboard data and store it in \p clipboard.
   Sets the clipboard time to \c time.
   */
-  static void unmarshall(IClipboard *clipboard, const std::string &data, Time time);
+  static void unmarshall(IClipboard *clipboard, const std::string_view &data, Time time);
 
   //! Copy clipboard
   /*!

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -105,15 +105,15 @@ std::string IKeyState::KeyInfo::join(const std::set<std::string> &destinations)
   // which makes searching easy.  the string is empty if there are no
   // destinations and "*" means all destinations.
   std::string screens;
-  for (auto i = destinations.begin(); i != destinations.end(); ++i) {
-    if (*i == "*") {
+  for (const auto &i : destinations) {
+    if (i == "*") {
       screens = "*";
       break;
     } else {
       if (screens.empty()) {
         screens = ":";
       }
-      screens += *i;
+      screens += i;
       screens += ":";
     }
   }

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -15,7 +15,7 @@
 // IKeyState
 //
 
-IKeyState::IKeyState(IEventQueue *events)
+IKeyState::IKeyState(const IEventQueue *events)
 {
   // do nothing
 }

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -72,7 +72,7 @@ bool IKeyState::KeyInfo::isDefault(const char *screens)
   return (screens == nullptr || screens[0] == '\0');
 }
 
-bool IKeyState::KeyInfo::contains(const char *screens, const std::string &name)
+bool IKeyState::KeyInfo::contains(const char *screens, const std::string_view &name)
 {
   // special cases
   if (isDefault(screens)) {

--- a/src/lib/deskflow/IKeyState.h
+++ b/src/lib/deskflow/IKeyState.h
@@ -23,7 +23,7 @@ to synthesize key events.
 class IKeyState : public IInterface
 {
 public:
-  explicit IKeyState(IEventQueue *events);
+  explicit IKeyState(const IEventQueue *events);
 
   enum
   {

--- a/src/lib/deskflow/IKeyState.h
+++ b/src/lib/deskflow/IKeyState.h
@@ -39,7 +39,7 @@ public:
     static KeyInfo *alloc(const KeyInfo &);
 
     static bool isDefault(const char *screens);
-    static bool contains(const char *screens, const std::string &name);
+    static bool contains(const char *screens, const std::string_view &name);
     static bool equal(const KeyInfo *, const KeyInfo *);
     static std::string join(const std::set<std::string> &destinations);
     static void split(const char *screens, std::set<std::string> &);

--- a/src/lib/deskflow/IKeyState.h
+++ b/src/lib/deskflow/IKeyState.h
@@ -23,7 +23,7 @@ to synthesize key events.
 class IKeyState : public IInterface
 {
 public:
-  IKeyState(IEventQueue *events);
+  explicit IKeyState(IEventQueue *events);
 
   enum
   {

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -28,7 +28,7 @@ public:
   //! @name manipulators
   //@{
 
-  explicit IPlatformScreen(IEventQueue *events) : IKeyState(events)
+  explicit IPlatformScreen(const IEventQueue *events) : IKeyState(events)
   {
     // do nothing
   }

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -28,7 +28,7 @@ public:
   //! @name manipulators
   //@{
 
-  IPlatformScreen(IEventQueue *events) : IKeyState(events)
+  explicit IPlatformScreen(IEventQueue *events) : IKeyState(events)
   {
     // do nothing
   }

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -95,7 +95,7 @@ public:
 
   //! Close screen saver
   /*!
-  // Close the screen saver.  Stop reporting screen saver activation
+  Close the screen saver.  Stop reporting screen saver activation
   and deactivation and, if the screen saver was disabled by
   openScreensaver(), enable the screen saver.
   */

--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -756,8 +756,8 @@ void KeyState::updateKeyState()
   // get the current keyboard state
   KeyButtonSet keysDown;
   pollPressedKeys(keysDown);
-  for (auto i = keysDown.begin(); i != keysDown.end(); ++i) {
-    m_keys[*i] = 1;
+  for (const auto &key : keysDown) {
+    m_keys[key] = 1;
   }
 
   // get the current modifier state
@@ -872,9 +872,9 @@ bool KeyState::fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyB
   if (localID != oldLocalID) {
     // replace key up with previous KeyButton but leave key down
     // alone so it uses the new KeyButton.
-    for (auto index = keys.begin(); index != keys.end(); ++index) {
-      if (index->m_type == Keystroke::kButton && index->m_data.m_button.m_button == localID) {
-        index->m_data.m_button.m_button = oldLocalID;
+    for (auto &key : keys) {
+      if (key.m_type == Keystroke::kButton && key.m_data.m_button.m_button == localID) {
+        key.m_data.m_button.m_button = oldLocalID;
         break;
       }
     }
@@ -1099,11 +1099,11 @@ void KeyState::updateModifierKeyState(
   // get the pressed modifier buttons before and after
   deskflow::KeyMap::ButtonToKeyMap oldKeys;
   deskflow::KeyMap::ButtonToKeyMap newKeys;
-  for (auto i = oldModifiers.begin(); i != oldModifiers.end(); ++i) {
-    oldKeys.insert(std::make_pair(i->second.m_button, &i->second));
+  for (const auto &[modifier, keyItem] : oldModifiers) {
+    oldKeys.insert(std::make_pair(keyItem.m_button, &keyItem));
   }
-  for (auto i = newModifiers.begin(); i != newModifiers.end(); ++i) {
-    newKeys.insert(std::make_pair(i->second.m_button, &i->second));
+  for (const auto &[modifier, keyItem] : newModifiers) {
+    newKeys.insert(std::make_pair(keyItem.m_button, &keyItem));
   }
 
   // get the modifier buttons that were pressed or released

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -269,7 +269,7 @@ void ServerApp::updateStatus()
   updateStatus("");
 }
 
-void ServerApp::updateStatus(const std::string &msg) const
+void ServerApp::updateStatus(const std::string_view &msg) const
 {
   // do nothing
 }

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -86,7 +86,7 @@ public:
   void closeServer(Server *server);
   void stopRetryTimer();
   void updateStatus();
-  void updateStatus(const std::string &msg) const;
+  void updateStatus(const std::string_view &msg) const;
   void closeClientListener(ClientListener *listen);
   void stopServer();
   void closePrimaryClient(PrimaryClient *primaryClient);

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -45,7 +45,7 @@ class ServerApp : public App
   using ServerConfig = deskflow::server::Config;
 
 public:
-  ServerApp(IEventQueue *events);
+  explicit ServerApp(IEventQueue *events);
   ~ServerApp() override = default;
 
   //

--- a/src/lib/deskflow/StreamChunker.cpp
+++ b/src/lib/deskflow/StreamChunker.cpp
@@ -23,7 +23,7 @@ using namespace std;
 static const size_t g_chunkSize = 512 * 1024; // 512kb
 
 void StreamChunker::sendClipboard(
-    std::string &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events, void *eventTarget
+    const std::string &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events, void *eventTarget
 )
 {
   // send first message (data size)

--- a/src/lib/deskflow/StreamChunker.cpp
+++ b/src/lib/deskflow/StreamChunker.cpp
@@ -23,7 +23,7 @@ using namespace std;
 static const size_t g_chunkSize = 512 * 1024; // 512kb
 
 void StreamChunker::sendClipboard(
-    const std::string &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events, void *eventTarget
+    const std::string_view &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events, void *eventTarget
 )
 {
   // send first message (data size)
@@ -42,7 +42,7 @@ void StreamChunker::sendClipboard(
       chunkSize = size - sentLength;
     }
 
-    std::string chunk(data.substr(sentLength, chunkSize).c_str(), chunkSize);
+    std::string chunk(data.substr(sentLength, chunkSize).data(), chunkSize);
     ClipboardChunk *dataChunk = ClipboardChunk::data(id, sequence, chunk);
 
     events->addEvent(Event(EventTypes::ClipboardSending, eventTarget, dataChunk));

--- a/src/lib/deskflow/StreamChunker.h
+++ b/src/lib/deskflow/StreamChunker.h
@@ -16,6 +16,7 @@ class StreamChunker
 {
 public:
   static void sendClipboard(
-      std::string &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events, void *eventTarget
+      const std::string_view &data, size_t size, ClipboardID id, uint32_t sequence, IEventQueue *events,
+      void *eventTarget
   );
 };

--- a/src/lib/deskflow/XDeskflow.h
+++ b/src/lib/deskflow/XDeskflow.h
@@ -65,7 +65,7 @@ a client that is already connected.
 class XDuplicateClient : public XDeskflow
 {
 public:
-  XDuplicateClient(const std::string &name);
+  explicit XDuplicateClient(const std::string &name);
   ~XDuplicateClient() throw() override = default;
 
   //! @name accessors
@@ -91,7 +91,7 @@ unknown to the server.
 class XUnknownClient : public XDeskflow
 {
 public:
-  XUnknownClient(const std::string &name);
+  explicit XUnknownClient(const std::string &name);
   ~XUnknownClient() throw() override = default;
 
   //! @name accessors
@@ -118,7 +118,7 @@ exit(int).
 class XExitApp : public XDeskflow
 {
 public:
-  XExitApp(int code);
+  explicit XExitApp(int code);
   ~XExitApp() throw() override = default;
 
   //! Get the exit code

--- a/src/lib/deskflow/XScreen.h
+++ b/src/lib/deskflow/XScreen.h
@@ -36,7 +36,7 @@ public:
   \c timeUntilRetry is the suggested time the caller should wait until
   trying to open the screen again.
   */
-  XScreenUnavailable(double timeUntilRetry);
+  explicit XScreenUnavailable(double timeUntilRetry);
   ~XScreenUnavailable() throw() override = default;
 
   //! @name manipulators

--- a/src/lib/deskflow/languages/LanguageManager.cpp
+++ b/src/lib/deskflow/languages/LanguageManager.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-std::string vectorToString(const std::vector<std::string> &vector, const std::string &delimiter = "")
+std::string vectorToString(const std::vector<std::string> &vector, const std::string_view &delimiter = "")
 {
   std::string string;
   for (const auto &item : vector) {
@@ -34,12 +34,13 @@ LanguageManager::LanguageManager(const std::vector<std::string> &localLanguages)
   LOG((CLOG_INFO "local languages: %s", vectorToString(m_localLanguages, ", ").c_str()));
 }
 
-void LanguageManager::setRemoteLanguages(const std::string &remoteLanguages)
+void LanguageManager::setRemoteLanguages(const std::string_view &remoteLanguages)
 {
   m_remoteLanguages.clear();
   if (!remoteLanguages.empty()) {
     for (size_t i = 0; i <= remoteLanguages.size() - 2; i += 2) {
-      m_remoteLanguages.push_back(remoteLanguages.substr(i, 2));
+      auto rLangs = remoteLanguages.substr(i, 2);
+      m_remoteLanguages.push_back(std::string{rLangs.begin(), rLangs.end()});
     }
   }
   LOG((CLOG_INFO "remote languages: %s", vectorToString(m_remoteLanguages, ", ").c_str()));

--- a/src/lib/deskflow/languages/LanguageManager.cpp
+++ b/src/lib/deskflow/languages/LanguageManager.cpp
@@ -40,7 +40,7 @@ void LanguageManager::setRemoteLanguages(const std::string_view &remoteLanguages
   if (!remoteLanguages.empty()) {
     for (size_t i = 0; i <= remoteLanguages.size() - 2; i += 2) {
       auto rLangs = remoteLanguages.substr(i, 2);
-      m_remoteLanguages.push_back(std::string{rLangs.begin(), rLangs.end()});
+      m_remoteLanguages.emplace_back(rLangs);
     }
   }
   LOG((CLOG_INFO "remote languages: %s", vectorToString(m_remoteLanguages, ", ").c_str()));

--- a/src/lib/deskflow/languages/LanguageManager.h
+++ b/src/lib/deskflow/languages/LanguageManager.h
@@ -27,7 +27,7 @@ public:
    * @brief setRemoteLanguages sets remote languages
    * @param remoteLanguages is a string with sericalized languages
    */
-  void setRemoteLanguages(const std::string &remoteLanguages);
+  void setRemoteLanguages(const std::string_view &remoteLanguages);
 
   /**
    * @brief getRemoteLanguages getter for remote languages

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -23,7 +23,7 @@
 #include "base/LogOutputters.h"
 #include "common/Constants.h"
 
-AppUtilUnix::AppUtilUnix(IEventQueue *events)
+AppUtilUnix::AppUtilUnix(const IEventQueue *events)
 {
   // do nothing
 }

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -16,7 +16,7 @@ class IEventQueue;
 class AppUtilUnix : public AppUtil
 {
 public:
-  explicit AppUtilUnix(IEventQueue *events);
+  explicit AppUtilUnix(const IEventQueue *events);
   ~AppUtilUnix() override = default;
 
   int run(int argc, char **argv) override;

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -16,7 +16,7 @@ class IEventQueue;
 class AppUtilUnix : public AppUtil
 {
 public:
-  AppUtilUnix(IEventQueue *events);
+  explicit AppUtilUnix(IEventQueue *events);
   ~AppUtilUnix() override = default;
 
   int run(int argc, char **argv) override;

--- a/src/lib/deskflow/unix/X11LayoutsParser.cpp
+++ b/src/lib/deskflow/unix/X11LayoutsParser.cpp
@@ -95,7 +95,7 @@ std::vector<X11LayoutsParser::Lang> X11LayoutsParser::getAllLanguageData(const s
 void X11LayoutsParser::appendVectorUniq(const std::vector<std::string> &source, std::vector<std::string> &dst)
 {
   for (const auto &elem : source) {
-    if (std::find_if(dst.begin(), dst.end(), [elem](const std::string &s) { return s == elem; }) == dst.end()) {
+    if (std::find_if(dst.begin(), dst.end(), [elem](const std::string_view &s) { return s == elem; }) == dst.end()) {
       dst.push_back(elem);
     }
   }

--- a/src/lib/deskflow/win32/AppUtilWindows.h
+++ b/src/lib/deskflow/win32/AppUtilWindows.h
@@ -29,7 +29,7 @@ enum AppExitMode
 class AppUtilWindows : public AppUtil
 {
 public:
-  AppUtilWindows(IEventQueue *events);
+  explicit AppUtilWindows(IEventQueue *events);
   ~AppUtilWindows() override;
 
   static AppUtilWindows &instance();

--- a/src/lib/gui/widgets/NewScreenWidget.h
+++ b/src/lib/gui/widgets/NewScreenWidget.h
@@ -17,7 +17,7 @@ class NewScreenWidget : public QLabel
   Q_OBJECT
 
 public:
-  NewScreenWidget(QWidget *parent);
+  explicit NewScreenWidget(QWidget *parent);
 
 protected:
   void mousePressEvent(QMouseEvent *event) override;

--- a/src/lib/gui/widgets/ScreenSetupView.h
+++ b/src/lib/gui/widgets/ScreenSetupView.h
@@ -23,7 +23,7 @@ class ScreenSetupView : public QTableView
   Q_OBJECT
 
 public:
-  ScreenSetupView(QWidget *parent);
+  explicit ScreenSetupView(QWidget *parent);
 
 public:
   void setModel(QAbstractItemModel *model) override;

--- a/src/lib/gui/widgets/TrashScreenWidget.h
+++ b/src/lib/gui/widgets/TrashScreenWidget.h
@@ -18,7 +18,7 @@ class TrashScreenWidget : public QLabel
   Q_OBJECT
 
 public:
-  TrashScreenWidget(QWidget *parent) : QLabel(parent)
+  explicit TrashScreenWidget(QWidget *parent) : QLabel(parent)
   {
     // do nothing
   }

--- a/src/lib/mt/CondVar.h
+++ b/src/lib/mt/CondVar.h
@@ -27,7 +27,7 @@ public:
   associated mutex.  The mutex needn't be unique to one condition
   variable.
   */
-  CondVarBase(Mutex *mutex);
+  explicit CondVarBase(Mutex *mutex);
   ~CondVarBase();
 
   //! @name manipulators

--- a/src/lib/mt/Lock.h
+++ b/src/lib/mt/Lock.h
@@ -23,9 +23,9 @@ class Lock
 {
 public:
   //! Lock the mutex \c mutex
-  Lock(const Mutex *mutex);
+  explicit Lock(const Mutex *mutex);
   //! Lock the condition variable \c cv
-  Lock(const CondVarBase *cv);
+  explicit Lock(const CondVarBase *cv);
   //! Unlock the mutex or condition variable
   ~Lock();
 

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -37,7 +37,7 @@ public:
   Create and start a new thread executing the \c adoptedJob.  The
   new thread takes ownership of \c adoptedJob and will delete it.
   */
-  Thread(IJob *adoptedJob);
+  explicit Thread(IJob *adoptedJob);
 
   //! Duplicate a thread handle
   /*!
@@ -190,7 +190,7 @@ public:
   //@}
 
 private:
-  Thread(ArchThread);
+  explicit Thread(ArchThread);
 
   static void *threadFunc(void *);
 

--- a/src/lib/mt/XThread.h
+++ b/src/lib/mt/XThread.h
@@ -19,7 +19,7 @@ class XThreadExit : public XThread
 {
 public:
   //! \c result is the result of the thread
-  XThreadExit(void *result) : m_result(result)
+  explicit XThreadExit(void *result) : m_result(result)
   {
     // do nothing
   }

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -29,7 +29,7 @@ public:
     std::string m_what;
   };
 
-  explicit IDataSocket(IEventQueue *events)
+  explicit IDataSocket(const IEventQueue *events)
   {
     // do nothing
   }

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -22,15 +22,16 @@ public:
   class ConnectionFailedInfo
   {
   public:
-    ConnectionFailedInfo(const char *what) : m_what(what)
+    explicit ConnectionFailedInfo(const char *what) : m_what(what)
     {
       // do nothing
     }
     std::string m_what;
   };
 
-  IDataSocket(IEventQueue *events)
+  explicit IDataSocket(IEventQueue *events)
   {
+    // do nothing
   }
 
   //! @name manipulators

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -26,7 +26,7 @@ public:
   Construct the wildcard address with the given port.  \c port must
   not be zero.
   */
-  NetworkAddress(int port);
+  explicit NetworkAddress(int port);
 
   /*!
   Construct the network address for the given \c hostname and \c port.

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -305,7 +305,7 @@ void SecureSocket::initSsl(bool server)
   initContext(server);
 }
 
-bool SecureSocket::loadCertificates(std::string &filename)
+bool SecureSocket::loadCertificates(const std::string &filename)
 {
   std::lock_guard ssl_lock{ssl_mutex_};
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -65,7 +65,7 @@ public:
   EJobResult doRead() override;
   EJobResult doWrite() override;
   void initSsl(bool server);
-  bool loadCertificates(std::string &CertFile);
+  bool loadCertificates(const std::string &CertFile);
 
 private:
   // SSL

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -209,13 +209,12 @@ QString generateFingerprintArt(const QByteArray &rawDigest)
   int y = rows / 2;
 
   /* process raw key */
-  for (size_t i = 0; i < rawDigest.size(); i++) {
+  for (int byte : rawDigest) {
     /* each byte conveys four 2-bit move commands */
-    int input = rawDigest[i];
     for (uint32_t b = 0; b < 4; b++) {
       /* evaluate 2 bit, rest is shifted later */
-      x += (input & 0x1) ? 1 : -1;
-      y += (input & 0x2) ? 1 : -1;
+      x += (byte & 0x1) ? 1 : -1;
+      y += (byte & 0x2) ? 1 : -1;
 
       /* assure we are still in bounds */
       x = std::clamp(x, 0, columns - 1);
@@ -224,7 +223,7 @@ QString generateFingerprintArt(const QByteArray &rawDigest)
       /* augment the field */
       if (field[x][y] < len - 2)
         field[x][y]++;
-      input = input >> 2;
+      byte = byte >> 2;
     }
   }
 

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -46,7 +46,7 @@ QString formatSSLFingerprint(const QByteArray &fingerprint, bool enableSeparator
     return fingerprint.toHex().toUpper();
 }
 
-Fingerprint sslCertFingerprint(X509 *cert, Fingerprint::Type type)
+Fingerprint sslCertFingerprint(const X509 *cert, Fingerprint::Type type)
 {
   if (!cert) {
     throw std::runtime_error("certificate is null");

--- a/src/lib/net/SecureUtils.h
+++ b/src/lib/net/SecureUtils.h
@@ -26,7 +26,7 @@ QString formatSSLFingerprint(const QByteArray &fingerprint, bool enableSeparator
 
 QString formatSSLFingerprintColumns(const QByteArray &fingerprint);
 
-Fingerprint sslCertFingerprint(X509 *cert, Fingerprint::Type type);
+Fingerprint sslCertFingerprint(const X509 *cert, Fingerprint::Type type);
 
 Fingerprint pemFileCertFingerprint(const std::string &path, Fingerprint::Type type);
 

--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -25,7 +25,9 @@ class EventQueueTimer
 
 namespace deskflow {
 
-EiEventQueueBuffer::EiEventQueueBuffer(EiScreen *screen, ei *ei, IEventQueue *events) : ei_(ei_ref(ei)), events_(events)
+EiEventQueueBuffer::EiEventQueueBuffer(const EiScreen *screen, ei *ei, IEventQueue *events)
+    : ei_(ei_ref(ei)),
+      events_(events)
 {
   // We need a pipe to signal ourselves when addEvent() is called
   int pipefd[2];

--- a/src/lib/platform/EiEventQueueBuffer.h
+++ b/src/lib/platform/EiEventQueueBuffer.h
@@ -23,7 +23,7 @@ namespace deskflow {
 class EiEventQueueBuffer : public IEventQueueBuffer
 {
 public:
-  EiEventQueueBuffer(EiScreen *screen, ei *ei, IEventQueue *events);
+  EiEventQueueBuffer(const EiScreen *screen, ei *ei, IEventQueue *events);
   ~EiEventQueueBuffer() override;
 
   // IEventQueueBuffer overrides

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -91,7 +91,7 @@ EiScreen::~EiScreen()
   delete portal_input_capture_;
 }
 
-void EiScreen::handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context) const
+void EiScreen::handle_ei_log_event(ei_log_priority priority, const char *message) const
 {
   switch (priority) {
   case EI_LOG_PRIORITY_DEBUG:
@@ -693,7 +693,7 @@ void EiScreen::on_motion_event(ei_event *event)
   }
 }
 
-void EiScreen::on_abs_motion_event(ei_event *event) const
+void EiScreen::on_abs_motion_event(const ei_event *event) const
 {
   assert(is_primary_);
 }

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -96,16 +96,17 @@ private:
   void on_pointer_scroll_event(ei_event *event);
   void on_pointer_scroll_discrete_event(ei_event *event);
   void on_motion_event(ei_event *event);
-  void on_abs_motion_event(ei_event *event) const;
+  void on_abs_motion_event(const ei_event *event) const;
   bool on_hotkey(KeyID key, bool is_press, KeyModifierMask mask);
-  void handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context) const;
+  void handle_ei_log_event(ei_log_priority priority, const char *message) const;
+
   void handle_connected_to_eis_event(const Event &event, void *);
   void handle_portal_session_closed(const Event &event, void *);
 
   static void cb_handle_ei_log_event(ei *ei, ei_log_priority priority, const char *message, ei_log_context *context)
   {
     auto screen = reinterpret_cast<EiScreen *>(ei_get_user_data(ei));
-    screen->handle_ei_log_event(ei, priority, message, context);
+    screen->handle_ei_log_event(priority, message);
   }
 
 private:

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -164,7 +164,7 @@ private:
   class HotKeySet
   {
   public:
-    HotKeySet(KeyID keyid);
+    explicit HotKeySet(KeyID keyid);
     KeyID keyid() const
     {
       return id_;

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -161,7 +161,7 @@ void PortalInputCapture::cb_init_input_capture_session(GObject *object, GAsyncRe
   cb_zones_changed(session_, nullptr);
 }
 
-void PortalInputCapture::cb_set_pointer_barriers(GObject *object, GAsyncResult *res)
+void PortalInputCapture::cb_set_pointer_barriers(const GObject *object, GAsyncResult *res)
 {
   g_autoptr(GError) error = nullptr;
 
@@ -244,7 +244,7 @@ void PortalInputCapture::release(double x, double y)
   is_active_ = false;
 }
 
-void PortalInputCapture::cb_disabled(XdpInputCaptureSession *session, GVariant *option)
+void PortalInputCapture::cb_disabled(const XdpInputCaptureSession *session, const GVariant *option)
 {
   LOG_DEBUG("portal cb disabled");
 
@@ -269,7 +269,9 @@ void PortalInputCapture::cb_disabled(XdpInputCaptureSession *session, GVariant *
   );
 }
 
-void PortalInputCapture::cb_activated(XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options)
+void PortalInputCapture::cb_activated(
+    const XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options
+)
 {
   LOG_DEBUG("portal cb activated, id=%d", activation_id);
 
@@ -288,7 +290,9 @@ void PortalInputCapture::cb_activated(XdpInputCaptureSession *session, std::uint
   is_active_ = true;
 }
 
-void PortalInputCapture::cb_deactivated(XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options)
+void PortalInputCapture::cb_deactivated(
+    const XdpInputCaptureSession *session, std::uint32_t activation_id, const GVariant *options
+)
 {
   LOG_DEBUG("cb deactivated, id=%i", activation_id);
   is_active_ = false;

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -37,11 +37,11 @@ private:
   gboolean timeout_handler() const;
   gboolean init_input_capture_session();
   void cb_init_input_capture_session(GObject *object, GAsyncResult *res);
-  void cb_set_pointer_barriers(GObject *object, GAsyncResult *res);
+  void cb_set_pointer_barriers(const GObject *object, GAsyncResult *res);
   void cb_session_closed(XdpSession *session);
-  void cb_disabled(XdpInputCaptureSession *session, GVariant *option);
-  void cb_activated(XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options);
-  void cb_deactivated(XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options);
+  void cb_disabled(const XdpInputCaptureSession *session, const GVariant *option);
+  void cb_activated(const XdpInputCaptureSession *session, std::uint32_t activation_id, GVariant *options);
+  void cb_deactivated(const XdpInputCaptureSession *session, std::uint32_t activation_id, const GVariant *options);
   void cb_zones_changed(XdpInputCaptureSession *session, GVariant *options);
 
   /// g_signal_connect callback wrapper

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1063,8 +1063,8 @@ void XWindowsClipboard::clearReplies()
 
 void XWindowsClipboard::clearReplies(ReplyList &replies)
 {
-  for (auto index = replies.begin(); index != replies.end(); ++index) {
-    delete *index;
+  for (auto reply : replies) {
+    delete reply;
   }
   replies.clear();
 }

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1254,7 +1254,7 @@ bool XWindowsClipboard::CICCCMGetClipboard::readClipboard(
   return !m_failed;
 }
 
-bool XWindowsClipboard::CICCCMGetClipboard::processEvent(Display *display, XEvent *xevent)
+bool XWindowsClipboard::CICCCMGetClipboard::processEvent(Display *display, const XEvent *xevent)
 {
   // process event
   switch (xevent->type) {

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -138,7 +138,7 @@ protected:
     bool readClipboard(Display *display, Atom selection, Atom target, Atom *actualTarget, std::string *data);
 
   private:
-    bool processEvent(Display *display, XEvent *event);
+    bool processEvent(Display *display, const XEvent *event);
 
   private:
     Window m_requestor;

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -13,7 +13,7 @@
 class XWindowsClipboardBMPConverter : public IXWindowsClipboardConverter
 {
 public:
-  XWindowsClipboardBMPConverter(Display *display);
+  explicit XWindowsClipboardBMPConverter(Display *display);
   ~XWindowsClipboardBMPConverter() override = default;
 
   // IXWindowsClipboardConverter overrides

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -210,8 +210,8 @@ void XWindowsEventQueueBuffer::flush()
   // note -- m_mutex must be locked on entry
 
   // flush the posted event list to the X server
-  for (size_t i = 0; i < m_postedEvents.size(); ++i) {
-    XSendEvent(m_display, m_window, False, 0, &m_postedEvents[i]);
+  for (auto &event : m_postedEvents) {
+    XSendEvent(m_display, m_window, False, 0, &event);
   }
   XFlush(m_display);
   m_postedEvents.clear();

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -65,7 +65,7 @@ XWindowsKeyState::~XWindowsKeyState()
 #endif
 }
 
-void XWindowsKeyState::init(Display *display, bool useXKB)
+void XWindowsKeyState::init(const Display *display, bool useXKB)
 {
   XGetKeyboardControl(m_display, &m_keyboardState);
 #if HAVE_XKB_EXTENSION

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -105,7 +105,7 @@ protected:
   void fakeKey(const Keystroke &keystroke) override;
 
 private:
-  void init(Display *display, bool useXKB);
+  void init(const Display *display, bool useXKB);
   void updateKeysymMap(deskflow::KeyMap &);
   void updateKeysymMapXKB(deskflow::KeyMap &);
   bool hasModifiersXKB() const;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1480,7 +1480,7 @@ void XWindowsScreen::onKeyRelease(XKeyEvent &xkey, bool isRepeat)
   }
 }
 
-bool XWindowsScreen::onHotKey(XKeyEvent &xkey, bool isRepeat)
+bool XWindowsScreen::onHotKey(const XKeyEvent &xkey, bool isRepeat)
 {
   // find the hot key id
   HotKeyToIDMap::const_iterator i = m_hotKeyToIDMap.find(HotKeyItem(xkey.keycode, xkey.state));

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -293,11 +293,10 @@ void XWindowsScreen::enter()
   // keyboard if they're grabbed.
   XUnmapWindow(m_display, m_window);
 
-  /* maybe call this if entering for the screensaver
-          // set keyboard focus to root window.  the screensaver should then
-          // pick up key events for when the user enters a password to unlock.
-          XSetInputFocus(m_display, PointerRoot, PointerRoot, CurrentTime);
-  */
+  // maybe call this if entering for the screensaver
+  // set keyboard focus to root window.  the screensaver should then
+  // pick up key events for when the user enters a password to unlock.
+  // XSetInputFocus(m_display, PointerRoot, PointerRoot, CurrentTime);
 
   if (!m_isPrimary) {
     // get the keyboard control state

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -128,7 +128,7 @@ private:
   bool grabMouseAndKeyboard();
   void onKeyPress(XKeyEvent &);
   void onKeyRelease(XKeyEvent &, bool isRepeat);
-  bool onHotKey(XKeyEvent &, bool isRepeat);
+  bool onHotKey(const XKeyEvent &, bool isRepeat);
   void onMousePress(const XButtonEvent &);
   void onMouseRelease(const XButtonEvent &);
   void onMouseMove(const XMotionEvent &);

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -125,7 +125,7 @@ public:
     /*!
     Ignore X11 errors.
     */
-    ErrorLock(Display *);
+    explicit ErrorLock(Display *);
     ErrorLock(ErrorLock const &) = delete;
     ErrorLock(ErrorLock &&) = delete;
 

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -20,7 +20,7 @@ public:
   /*!
   \c name is the name of the client.
   */
-  BaseClientProxy(const std::string &name);
+  explicit BaseClientProxy(const std::string &name);
   ~BaseClientProxy() override = default;
 
   //! @name manipulators

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -925,7 +925,7 @@ void Config::readSectionAliases(ConfigReadContext &s)
 }
 
 InputFilter::Condition *
-Config::parseCondition(ConfigReadContext &s, const std::string &name, const std::vector<std::string> &args)
+Config::parseCondition(const ConfigReadContext &s, const std::string &name, const std::vector<std::string> &args)
 {
   if (name == "keystroke") {
     if (args.size() != 1) {
@@ -1147,7 +1147,7 @@ void Config::parseAction(
   rule.adoptAction(action, activate);
 }
 
-void Config::parseScreens(ConfigReadContext &c, const std::string &s, std::set<std::string> &screens) const
+void Config::parseScreens(const ConfigReadContext &c, const std::string &s, std::set<std::string> &screens) const
 {
   screens.clear();
 

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1599,13 +1599,13 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
 {
   // screens section
   s << "section: screens" << std::endl;
-  for (auto screen = config.begin(); screen != config.end(); ++screen) {
-    s << "\t" << screen->c_str() << ":" << std::endl;
-    const Config::ScreenOptions *options = config.getOptions(*screen);
+  for (const auto &screen : config) {
+    s << "\t" << screen.c_str() << ":" << std::endl;
+    const auto options = config.getOptions(screen);
     if (options != nullptr && options->size() > 0) {
-      for (auto option = options->begin(); option != options->end(); ++option) {
-        const char *name = Config::getOptionName(option->first);
-        std::string value = Config::getOptionValue(option->first, option->second);
+      for (auto [optionId, optionValue] : *options) {
+        const char *name = Config::getOptionName(optionId);
+        std::string value = Config::getOptionValue(optionId, optionValue);
         if (name != nullptr && !value.empty()) {
           s << "\t\t" << name << " = " << value << std::endl;
         }
@@ -1617,10 +1617,10 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
   // links section
   std::string neighbor;
   s << "section: links" << std::endl;
-  for (auto screen = config.begin(); screen != config.end(); ++screen) {
-    s << "\t" << screen->c_str() << ":" << std::endl;
+  for (const auto &screen : config) {
+    s << "\t" << screen.c_str() << ":" << std::endl;
 
-    for (Config::link_const_iterator link = config.beginNeighbor(*screen), nend = config.endNeighbor(*screen);
+    for (Config::link_const_iterator link = config.beginNeighbor(screen), nend = config.endNeighbor(screen);
          link != nend; ++link) {
       s << "\t\t" << Config::dirName(link->first.getSide()) << Config::formatInterval(link->first.getInterval())
         << " = " << link->second.getName().c_str() << Config::formatInterval(link->second.getInterval()) << std::endl;
@@ -1655,9 +1655,9 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
   // options section
   s << "section: options" << std::endl;
   if (const Config::ScreenOptions *options = config.getOptions(""); options && options->size() > 0) {
-    for (auto option = options->begin(); option != options->end(); ++option) {
-      const char *name = Config::getOptionName(option->first);
-      std::string value = Config::getOptionValue(option->first, option->second);
+    for (auto [optionId, optionValue] : *options) {
+      const char *name = Config::getOptionName(optionId);
+      std::string value = Config::getOptionValue(optionId, optionValue);
       if (name != nullptr && !value.empty()) {
         s << "\t" << name << " = " << value << std::endl;
       }

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1147,7 +1147,7 @@ void Config::parseAction(
   rule.adoptAction(action, activate);
 }
 
-void Config::parseScreens(const ConfigReadContext &c, const std::string &s, std::set<std::string> &screens) const
+void Config::parseScreens(const ConfigReadContext &c, const std::string_view &s, std::set<std::string> &screens) const
 {
   screens.clear();
 
@@ -1370,7 +1370,7 @@ Config::CellEdge::CellEdge(const std::string &name, EDirection side, const Inter
   init(name, side, interval);
 }
 
-void Config::CellEdge::init(const std::string &name, EDirection side, const Interval &interval)
+void Config::CellEdge::init(const std::string_view &name, EDirection side, const Interval &interval)
 {
   assert(side != kNoDirection);
 
@@ -1384,7 +1384,7 @@ Config::Interval Config::CellEdge::getInterval() const
   return m_interval;
 }
 
-void Config::CellEdge::setName(const std::string &newName)
+void Config::CellEdge::setName(const std::string_view &newName)
 {
   m_name = newName;
 }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -64,7 +64,7 @@ public:
     ~CellEdge() = default;
 
     Interval getInterval() const;
-    void setName(const std::string &newName);
+    void setName(const std::string_view &newName);
     std::string getName() const;
     EDirection getSide() const;
     bool overlaps(const CellEdge &) const;
@@ -84,7 +84,7 @@ public:
     bool operator!=(const CellEdge &) const;
 
   private:
-    void init(const std::string &name, EDirection side, const Interval &);
+    void init(const std::string_view &name, EDirection side, const Interval &);
 
   private:
     std::string m_name;
@@ -474,7 +474,7 @@ private:
       bool activate
   );
 
-  void parseScreens(const ConfigReadContext &, const std::string &, std::set<std::string> &screens) const;
+  void parseScreens(const ConfigReadContext &, const std::string_view &, std::set<std::string> &screens) const;
   static const char *getOptionName(OptionID);
   static std::string getOptionValue(OptionID, OptionValue);
 

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -468,13 +468,13 @@ private:
   void readSectionAliases(ConfigReadContext &);
 
   InputFilter::Condition *
-  parseCondition(ConfigReadContext &, const std::string &condition, const std::vector<std::string> &args);
+  parseCondition(const ConfigReadContext &, const std::string &condition, const std::vector<std::string> &args);
   void parseAction(
       ConfigReadContext &, const std::string &action, const std::vector<std::string> &args, InputFilter::Rule &,
       bool activate
   );
 
-  void parseScreens(ConfigReadContext &, const std::string &, std::set<std::string> &screens) const;
+  void parseScreens(const ConfigReadContext &, const std::string &, std::set<std::string> &screens) const;
   static const char *getOptionName(OptionID);
   static std::string getOptionValue(OptionID, OptionValue);
 

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -201,7 +201,7 @@ public:
     internal_const_iterator m_i;
   };
 
-  Config(IEventQueue *events);
+  explicit Config(IEventQueue *events);
   virtual ~Config() = default;
 
   //! @name manipulators

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -845,7 +845,7 @@ void InputFilter::setPrimaryClient(PrimaryClient *client)
   }
 }
 
-std::string InputFilter::format(const std::string &linePrefix) const
+std::string InputFilter::format(const std::string_view &linePrefix) const
 {
   std::string s;
   for (auto i = m_ruleList.begin(); i != m_ruleList.end(); ++i) {

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -662,9 +662,9 @@ bool InputFilter::Rule::handleEvent(const Event &event)
   }
 
   // perform actions
-  for (auto i = actions->begin(); i != actions->end(); ++i) {
-    LOG((CLOG_DEBUG1 "hotkey: %s", (*i)->format().c_str()));
-    (*i)->perform(event);
+  for (auto action : *actions) {
+    LOG((CLOG_DEBUG1 "hotkey: %s", action->format().c_str()));
+    action->perform(event);
   }
 
   return true;

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -375,7 +375,7 @@ public:
   virtual void setPrimaryClient(PrimaryClient *client);
 
   // convert rules to a string
-  std::string format(const std::string &linePrefix) const;
+  std::string format(const std::string_view &linePrefix) const;
 
   // get number of rules
   uint32_t getNumRules() const;

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -301,7 +301,7 @@ public:
   {
   public:
     Rule();
-    Rule(Condition *adopted);
+    explicit Rule(Condition *adopted);
     Rule(const Rule &);
     ~Rule();
 
@@ -355,7 +355,7 @@ public:
   // -------------------------------------------------------------------------
   using RuleList = std::vector<Rule>;
 
-  InputFilter(IEventQueue *events);
+  explicit InputFilter(IEventQueue *events);
   InputFilter(const InputFilter &);
   virtual ~InputFilter();
 

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -20,10 +20,7 @@ PrimaryClient::PrimaryClient(const std::string &name, deskflow::Screen *screen)
       m_screen(screen),
       m_fakeInputCount(0)
 {
-  // all clipboards are clean
-  for (uint32_t i = 0; i < kClipboardEnd; ++i) {
-    m_clipboardDirty[i] = false;
-  }
+  // do nothing
 }
 
 void PrimaryClient::reconfigure(uint32_t activeSides)

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -142,6 +142,6 @@ public:
 
 private:
   deskflow::Screen *m_screen;
-  bool m_clipboardDirty[kClipboardEnd];
+  bool m_clipboardDirty[kClipboardEnd] = {false, false};
   int32_t m_fakeInputCount;
 };

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -83,8 +83,7 @@ Server::Server(
   std::string primaryName = getName(primaryClient);
 
   // clear clipboards
-  for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
-    ClipboardInfo &clipboard = m_clipboards[id];
+  for (auto &clipboard : m_clipboards) {
     clipboard.m_clipboardOwner = primaryName;
     clipboard.m_clipboardSeqNum = m_seqNum;
     if (clipboard.m_clipboard.open(0)) {
@@ -1062,9 +1061,9 @@ void Server::sendOptions(BaseClientProxy *client) const
   if (options != nullptr) {
     // convert options to a more convenient form for sending
     optionsList.reserve(2 * options->size());
-    for (auto index = options->begin(); index != options->end(); ++index) {
-      optionsList.push_back(index->first);
-      optionsList.push_back(static_cast<uint32_t>(index->second));
+    for (auto [optionId, optionValue] : *options) {
+      optionsList.push_back(optionId);
+      optionsList.push_back(static_cast<uint32_t>(optionValue));
     }
   }
 
@@ -1073,9 +1072,9 @@ void Server::sendOptions(BaseClientProxy *client) const
   if (options != nullptr) {
     // convert options to a more convenient form for sending
     optionsList.reserve(optionsList.size() + 2 * options->size());
-    for (auto index = options->begin(); index != options->end(); ++index) {
-      optionsList.push_back(index->first);
-      optionsList.push_back(static_cast<uint32_t>(index->second));
+    for (auto [optionId, optionValue] : *options) {
+      optionsList.push_back(optionId);
+      optionsList.push_back(static_cast<uint32_t>(optionValue));
     }
   }
 
@@ -1096,9 +1095,9 @@ void Server::processOptions()
   m_switchNeedsAlt = false;     // doesnt' work correct.
 
   bool newRelativeMoves = m_relativeMoves;
-  for (auto index = options->begin(); index != options->end(); ++index) {
-    const OptionID id = index->first;
-    const OptionValue value = index->second;
+  for (auto [optionId, optionValue] : *options) {
+    const OptionID id = optionId;
+    const OptionValue value = optionValue;
     if (id == kOptionProtocol) {
       using enum ENetworkProtocol;
       const auto enumValue = static_cast<ENetworkProtocol>(value);
@@ -2010,8 +2009,8 @@ void Server::closeClients(const ServerConfig &config)
 
   // now close them.  we collect the list then close in two steps
   // because closeClient() modifies the collection we iterate over.
-  for (auto index = removed.begin(); index != removed.end(); ++index) {
-    closeClient(*index, kMsgCClose);
+  for (auto &client : removed) {
+    closeClient(client, kMsgCClose);
   }
 }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -386,7 +386,7 @@ bool Server::isLockedToScreen() const
   return false;
 }
 
-int32_t Server::getJumpZoneSize(BaseClientProxy *client) const
+int32_t Server::getJumpZoneSize(const BaseClientProxy *client) const
 {
   if (client == m_primaryClient) {
     return m_primaryClient->getJumpZoneSize();
@@ -525,7 +525,7 @@ void Server::jumpToScreen(BaseClientProxy *newScreen)
   switchScreen(newScreen, x, y, false);
 }
 
-float Server::mapToFraction(BaseClientProxy *client, EDirection dir, int32_t x, int32_t y) const
+float Server::mapToFraction(const BaseClientProxy *client, EDirection dir, int32_t x, int32_t y) const
 {
   int32_t sx;
   int32_t sy;
@@ -548,7 +548,7 @@ float Server::mapToFraction(BaseClientProxy *client, EDirection dir, int32_t x, 
   return 0.0f;
 }
 
-void Server::mapToPixel(BaseClientProxy *client, EDirection dir, float f, int32_t &x, int32_t &y) const
+void Server::mapToPixel(const BaseClientProxy *client, EDirection dir, float f, int32_t &x, int32_t &y) const
 {
   int32_t sx;
   int32_t sy;
@@ -572,14 +572,14 @@ void Server::mapToPixel(BaseClientProxy *client, EDirection dir, float f, int32_
   }
 }
 
-bool Server::hasAnyNeighbor(BaseClientProxy *client, EDirection dir) const
+bool Server::hasAnyNeighbor(const BaseClientProxy *client, EDirection dir) const
 {
   assert(client != nullptr);
 
   return m_config->hasNeighbor(getName(client), dir);
 }
 
-BaseClientProxy *Server::getNeighbor(BaseClientProxy *src, EDirection dir, int32_t &x, int32_t &y) const
+BaseClientProxy *Server::getNeighbor(const BaseClientProxy *src, EDirection dir, int32_t &x, int32_t &y) const
 {
   // note -- must be locked on entry
 
@@ -732,7 +732,7 @@ BaseClientProxy *Server::mapToNeighbor(BaseClientProxy *src, EDirection srcSide,
   return dst;
 }
 
-void Server::avoidJumpZone(BaseClientProxy *dst, EDirection dir, int32_t &x, int32_t &y) const
+void Server::avoidJumpZone(const BaseClientProxy *dst, EDirection dir, int32_t &x, int32_t &y) const
 {
   // we only need to avoid jump zones on the primary screen
   if (dst != m_primaryClient) {
@@ -981,7 +981,7 @@ bool Server::isSwitchWaitStarted() const
   return (m_switchWaitTimer != nullptr);
 }
 
-uint32_t Server::getCorner(BaseClientProxy *client, int32_t x, int32_t y, int32_t size) const
+uint32_t Server::getCorner(const BaseClientProxy *client, int32_t x, int32_t y, int32_t size) const
 {
   assert(client != nullptr);
 
@@ -1447,7 +1447,7 @@ void Server::handleFakeInputEndEvent(const Event &, void *)
   m_primaryClient->fakeInputEnd();
 }
 
-void Server::onClipboardChanged(BaseClientProxy *sender, ClipboardID id, uint32_t seqNum)
+void Server::onClipboardChanged(const BaseClientProxy *sender, ClipboardID id, uint32_t seqNum)
 {
   ClipboardInfo &clipboard = m_clipboards[id];
 
@@ -2040,7 +2040,7 @@ void Server::removeOldClient(BaseClientProxy *client)
   }
 }
 
-void Server::forceLeaveClient(BaseClientProxy *client)
+void Server::forceLeaveClient(const BaseClientProxy *client)
 {
   if (BaseClientProxy *active = (m_activeSaver != nullptr) ? m_activeSaver : m_active; active == client) {
     // record new position (center of primary screen)

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -204,7 +204,7 @@ private:
   bool isLockedToScreen() const;
 
   // returns the jump zone of the client
-  int32_t getJumpZoneSize(BaseClientProxy *) const;
+  int32_t getJumpZoneSize(const BaseClientProxy *) const;
 
   // change the active screen
   void switchScreen(BaseClientProxy *, int32_t x, int32_t y, bool forScreenSaver);
@@ -214,19 +214,19 @@ private:
 
   // convert pixel position to fraction, using x or y depending on the
   // direction.
-  float mapToFraction(BaseClientProxy *, EDirection, int32_t x, int32_t y) const;
+  float mapToFraction(const BaseClientProxy *, EDirection, int32_t x, int32_t y) const;
 
   // convert fraction to pixel position, writing only x or y depending
   // on the direction.
-  void mapToPixel(BaseClientProxy *, EDirection, float f, int32_t &x, int32_t &y) const;
+  void mapToPixel(const BaseClientProxy *, EDirection, float f, int32_t &x, int32_t &y) const;
 
   // returns true if the client has a neighbor anywhere along the edge
   // indicated by the direction.
-  bool hasAnyNeighbor(BaseClientProxy *, EDirection) const;
+  bool hasAnyNeighbor(const BaseClientProxy *, EDirection) const;
 
   // lookup neighboring screen, mapping the coordinate independent of
   // the direction to the neighbor's coordinate space.
-  BaseClientProxy *getNeighbor(BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
+  BaseClientProxy *getNeighbor(const BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
 
   // lookup neighboring screen.  given a position relative to the
   // source screen, find the screen we should move onto and where.
@@ -237,7 +237,7 @@ private:
 
   // adjusts x and y or neither to avoid ending up in a jump zone
   // after entering the client in the given direction.
-  void avoidJumpZone(BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
+  void avoidJumpZone(const BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
 
   // test if a switch is permitted.  this includes testing user
   // options like switch delay and tracking any state required to
@@ -277,7 +277,7 @@ private:
 
   // returns the corner (EScreenSwitchCornerMasks) where x,y is on the
   // given client.  corners have the given size.
-  uint32_t getCorner(BaseClientProxy *, int32_t x, int32_t y, int32_t size) const;
+  uint32_t getCorner(const BaseClientProxy *, int32_t x, int32_t y, int32_t size) const;
 
   // stop relative mouse moves
   void stopRelativeMoves();
@@ -313,7 +313,7 @@ private:
   void handleFakeInputEndEvent(const Event &, void *);
 
   // event processing
-  void onClipboardChanged(BaseClientProxy *sender, ClipboardID id, uint32_t seqNum);
+  void onClipboardChanged(const BaseClientProxy *sender, ClipboardID id, uint32_t seqNum);
   void onScreensaver(bool activated);
   void onKeyDown(KeyID, KeyModifierMask, KeyButton, const std::string &, const char *screens);
   void onKeyUp(KeyID, KeyModifierMask, KeyButton, const char *screens);
@@ -345,7 +345,7 @@ private:
   void removeOldClient(BaseClientProxy *);
 
   // force the cursor off of \p client
-  void forceLeaveClient(BaseClientProxy *client);
+  void forceLeaveClient(const BaseClientProxy *client);
 
 private:
   class ClipboardInfo

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -86,8 +86,9 @@ public:
   class ScreenConnectedInfo
   {
   public:
-    ScreenConnectedInfo(std::string screen) : m_screen(screen)
+    explicit ScreenConnectedInfo(std::string screen) : m_screen(screen)
     {
+      // do nothing
     }
 
   public:


### PR DESCRIPTION
 - more explicit methods
 - use const pointers / references when possible
 - remove the goto in `EventQueue`
 - use `std::string_view` were its possible
 - remove `//` from comment blocks
 - Use more ranged for loops
 - use `RETRY_TIME` directly in `ClientApp` , remove unused old methods around it 
 - use of `emplace_back` in modified code
