### PR TITLE
Remove Ifdef around iso_level5

### DIFF
--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1684,10 +1684,8 @@ KeyID XWindowsUtil::mapKeySymToKeyID(KeySym k)
     case XK_ISO_Level3_Shift:
       return kKeyAltGr;
 
-#ifdef XK_ISO_Level5_Shift
     case XK_ISO_Level5_Shift:
       return XK_ISO_Level5_Shift; // FIXME: there is no "usual" key for this...
-#endif
 
     case XK_ISO_Next_Group:
       return kKeyNextGroup;
@@ -1787,10 +1785,8 @@ uint32_t XWindowsUtil::getModifierBitForKeySym(KeySym keysym)
   case XK_ISO_Level3_Shift:
     return kKeyModifierBitAltGr;
 
-#ifdef XK_ISO_Level5_Shift
   case XK_ISO_Level5_Shift:
     return kKeyModifierBitLevel5Lock;
-#endif
 
   case XK_Caps_Lock:
     return kKeyModifierBitCapsLock;


### PR DESCRIPTION
Why was this guarded ? 
related #3259  to the latest comments ? 