### PR TITLE
Log Error and stop the core process if print database is not writable

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -811,7 +811,11 @@ void MainWindow::checkFingerprint(const QString &line)
 
   if (fingerprintDialog.exec() == QDialog::Accepted) {
     db.addTrusted(sha256);
-    db.write(trustedFingerprintDatabase());
+    if (!db.write(trustedFingerprintDatabase())) {
+      qCritical().noquote() << "unable to write fingerprint to db:" << trustedFingerprintDatabase();
+      m_coreProcess.stop();
+      return;
+    }
     if (isClient) {
       m_checkedServers.removeAll(sha256Text);
       m_coreProcess.start();


### PR DESCRIPTION
If for some reason writing to the fingerprint database fails we log a message and also stop the core process so the user can address the problem related to #8598 Should at least stop a loop in the case of an un-writable db file.