### PR TITLE
build: add qt6-svg to arch package depends

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -57,7 +57,7 @@ runs:
             elif [ ${{ inputs.like }} == "arch" ]; then
               pacman -Syu --noconfirm base-devel cmake ninja \
                 gcc openssl glib2 libxtst libxkbfile gtest libei libportal \
-                qt6-base qt6-tools gtk3 tomlplusplus cli11 help2man
+                qt6-base qt6-tools qt6-svg gtk3 tomlplusplus cli11 help2man
             else
               echo "Unknown like"
             fi

--- a/deploy/linux/arch/PKGBUILD.in
+++ b/deploy/linux/arch/PKGBUILD.in
@@ -32,6 +32,7 @@ depends=(
   libxtst
   openssl
   qt6-base
+  qt6-svg
   tomlplusplus
 )
 


### PR DESCRIPTION
Add `qt6-svg` to our dependencies on Arch Linux.

Fixes #8626
