### PR TITLE
Wix installer use BUILD_ARCHITECTURE to figure out regkey to look for msvc_redist

### DIFF
--- a/deploy/windows/wix-custom.cpp
+++ b/deploy/windows/wix-custom.cpp
@@ -34,7 +34,7 @@ static std::string s_logMessageBuffer; // NOSONAR - Must be mutable.
 
 extern "C" __declspec(dllexport) UINT __stdcall CheckVCRedist(MSIHANDLE hInstall)
 {
-  const auto kKeyName = TEXT("SOFTWARE\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\x64");
+  const auto kKeyName = TEXT(kRegKey);
   const auto kValueName = TEXT("Minor");
   const auto kProperty = "VC_REDIST_VERSION_OK";
 

--- a/deploy/windows/wix-custom.h.in
+++ b/deploy/windows/wix-custom.h.in
@@ -7,6 +7,7 @@
 #pragma once
 
 const auto kAppId = "@CMAKE_PROJECT_NAME@";
+const auto kRegKey = "SOFTWARE\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\@BUILD_ARCHITECTURE@";
 
 // clang-format off
 const auto kWindowsRuntimeMajor = @REQUIRED_MSVC_RUNTIME_MAJOR@;


### PR DESCRIPTION
Use  `BUILD_ARCHITECTURE` not just `x64` when looking for what msvc maybe installed.