### PR TITLE
fix: avoid leaking build paths in manpages

### DIFF
--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -14,10 +14,10 @@ function(generate_app_man TARGET)
   if(HELP2MAN)
     add_custom_command(
       TARGET ${target} POST_BUILD
-        COMMAND QT_QPA_PLATFORM=minimal ${HELP2MAN}
+        COMMAND QT_QPA_PLATFORM=minimal PATH=$<TARGET_FILE_DIR:${target}>:${PATH} ${HELP2MAN}
           --include ${CMAKE_SOURCE_DIR}/src/apps/res/manpage.txt
           --no-info
-          $<TARGET_FILE:${target}>
+          ${target}
           -o $<TARGET_FILE_DIR:${target}>/${target}.1
     )
     install(


### PR DESCRIPTION
Avoid leaking build paths in manpages by not passing the full build path of deskflow binaries to help2man.

FIx #8525