### PR TITLE
Feat: Define QT_NO_KEYWORDS, allowing us to use Qt in more places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,10 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 
+# disables the use of signals,slots and emit
+# Instead use Q_SIGNAL, Q_SLOT and Q_EMIT
+# prevents issues when used with glib for libportal
+add_definitions(-DQT_NO_KEYWORDS)
 include(cmake/Libraries.cmake)
 include(GNUInstallDirs)
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -129,7 +129,7 @@ public:
   static void save(bool emitSaving = true);
   static const QStringList validKeys();
 
-signals:
+Q_SIGNALS:
   void settingsChanged(const QString key);
   void serverSettingsChanged();
 

--- a/src/lib/deskflow/ipc/DaemonIpcServer.h
+++ b/src/lib/deskflow/ipc/DaemonIpcServer.h
@@ -24,7 +24,7 @@ public:
 
   void listen();
 
-signals:
+Q_SIGNALS:
   void logLevelChanged(const QString &logLevel);
   void elevateModeChanged(bool elevate);
   void commandChanged(const QString &command);
@@ -38,7 +38,7 @@ private:
   void processElevate(QLocalSocket *&clientSocket, const QStringList &messageParts);
   void processCommand(QLocalSocket *&clientSocket, const QStringList &messageParts);
 
-private slots:
+private Q_SLOTS:
   void handleNewConnection();
   void handleReadyRead();
   void handleDisconnected();

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -6,11 +6,8 @@
  */
 
 #include "deskflow/unix/AppUtilUnix.h"
-#include "deskflow/ArgsBase.h"
 
 #include "base/Log.h"
-#include "base/LogOutputters.h"
-#include "common/Constants.h"
 
 #if WINAPI_XWINDOWS
 #include "deskflow/unix/X11LayoutsParser.h"
@@ -23,7 +20,6 @@
 #endif
 
 #include <filesystem>
-#include <thread>
 
 AppUtilUnix::AppUtilUnix(const IEventQueue *events)
 {

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -7,8 +7,10 @@
 
 #include "deskflow/unix/AppUtilUnix.h"
 #include "deskflow/ArgsBase.h"
-#include <filesystem>
-#include <thread>
+
+#include "base/Log.h"
+#include "base/LogOutputters.h"
+#include "common/Constants.h"
 
 #if WINAPI_XWINDOWS
 #include "deskflow/unix/X11LayoutsParser.h"
@@ -19,9 +21,9 @@
 #else
 #error Platform not supported.
 #endif
-#include "base/Log.h"
-#include "base/LogOutputters.h"
-#include "common/Constants.h"
+
+#include <filesystem>
+#include <thread>
 
 AppUtilUnix::AppUtilUnix(const IEventQueue *events)
 {

--- a/src/lib/gui/DataDownloader.h
+++ b/src/lib/gui/DataDownloader.h
@@ -28,10 +28,10 @@ public:
     return m_IsFinished;
   }
 
-signals:
+Q_SIGNALS:
   void isComplete();
 
-private slots:
+private Q_SLOTS:
   void complete(QNetworkReply *reply);
 
 private:

--- a/src/lib/gui/FileTail.h
+++ b/src/lib/gui/FileTail.h
@@ -20,10 +20,10 @@ class FileTail : public QObject
 public:
   FileTail(const QString &filePath, QObject *parent = nullptr);
 
-signals:
+Q_SIGNALS:
   void newLine(const QString &line);
 
-private slots:
+private Q_SLOTS:
   void handleFileChanged(const QString &);
 
 private:

--- a/src/lib/gui/Logger.h
+++ b/src/lib/gui/Logger.h
@@ -30,7 +30,7 @@ public:
   void handleMessage(const QtMsgType type, const QString &fileLine, const QString &message);
   void logVerbose(const QString &message) const;
 
-signals:
+Q_SIGNALS:
   void newLine(const QString &line);
 
 private:

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -88,7 +88,7 @@ public:
 
   void hide();
 
-signals:
+Q_SIGNALS:
   void shown();
 
 private:

--- a/src/lib/gui/ScreenSetupModel.h
+++ b/src/lib/gui/ScreenSetupModel.h
@@ -55,7 +55,7 @@ public:
   QMimeData *mimeData(const QModelIndexList &indexes) const override;
   bool isFull() const;
 
-signals:
+Q_SIGNALS:
   void screensChanged();
 
 protected:

--- a/src/lib/gui/VersionChecker.h
+++ b/src/lib/gui/VersionChecker.h
@@ -19,9 +19,9 @@ class VersionChecker : public QObject
 public:
   explicit VersionChecker(QObject *parent = nullptr);
   void checkLatest() const;
-public slots:
+public Q_SLOTS:
   void replyFinished(QNetworkReply *reply);
-signals:
+Q_SIGNALS:
   void updateFound(const QString &version);
 
 private:

--- a/src/lib/gui/core/ClientConnection.h
+++ b/src/lib/gui/core/ClientConnection.h
@@ -41,7 +41,7 @@ public:
     m_showMessage = true;
   }
 
-signals:
+Q_SIGNALS:
   void messageShowing();
 
 private:

--- a/src/lib/gui/core/CommandProcess.h
+++ b/src/lib/gui/core/CommandProcess.h
@@ -16,10 +16,10 @@ class CommandProcess : public QObject
 public:
   CommandProcess(QString cmd, QStringList arguments, QString input = "");
 
-signals:
+Q_SIGNALS:
   void finished();
 
-public slots:
+public Q_SLOTS:
   QString run();
 
 private:

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -113,7 +113,7 @@ public:
     m_mode = mode;
   }
 
-signals:
+Q_SIGNALS:
   void starting();
   void error(Error error);
   void logLine(const QString &line);
@@ -122,7 +122,7 @@ signals:
   void secureSocket(bool enabled);
   void daemonIpcClientConnectionFailed();
 
-private slots:
+private Q_SLOTS:
   void onProcessFinished(int exitCode, QProcess::ExitStatus);
   void onProcessReadyReadStandardOutput();
   void onProcessReadyReadStandardError();

--- a/src/lib/gui/core/ServerConnection.h
+++ b/src/lib/gui/core/ServerConnection.h
@@ -32,7 +32,7 @@ public:
   );
   void handleLogLine(const QString &logLine);
 
-signals:
+Q_SIGNALS:
   void messageShowing();
   void configureClient(const QString &clientName);
 

--- a/src/lib/gui/dialogs/ActionDialog.h
+++ b/src/lib/gui/dialogs/ActionDialog.h
@@ -38,7 +38,7 @@ public:
   ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action);
   ~ActionDialog() override;
 
-protected slots:
+protected Q_SLOTS:
   void accept() override;
 
 private:

--- a/src/lib/gui/dialogs/AddClientDialog.h
+++ b/src/lib/gui/dialogs/AddClientDialog.h
@@ -37,7 +37,7 @@ public:
     return m_AddResult;
   }
 
-private slots:
+private Q_SLOTS:
   void handleButtonLeft();
   void handleButtonUp();
   void handleButtonRight();

--- a/src/lib/gui/dialogs/FingerprintDialog.h
+++ b/src/lib/gui/dialogs/FingerprintDialog.h
@@ -32,7 +32,7 @@ public:
   );
   ~FingerprintDialog() override = default;
 
-signals:
+Q_SIGNALS:
   void requestLocalPrintsDialog();
 
 private:

--- a/src/lib/gui/dialogs/HotkeyDialog.h
+++ b/src/lib/gui/dialogs/HotkeyDialog.h
@@ -31,7 +31,7 @@ public:
     return m_Hotkey;
   }
 
-protected slots:
+protected Q_SLOTS:
   void accept() override;
 
 protected:

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.h
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.h
@@ -27,10 +27,10 @@ public:
   ScreenSettingsDialog(QWidget *parent, Screen *pScreen = nullptr, const ScreenList *pScreens = nullptr);
   ~ScreenSettingsDialog() override;
 
-public slots:
+public Q_SLOTS:
   void accept() override;
 
-private slots:
+private Q_SLOTS:
   void on_m_pButtonAddAlias_clicked();
   void on_m_pButtonRemoveAlias_clicked();
   void on_m_pLineEditAlias_textChanged(const QString &text);

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -28,7 +28,7 @@ public:
   ~ServerConfigDialog() override;
   bool addClient(const QString &clientName);
 
-public slots:
+public Q_SLOTS:
   void accept() override;
   void reject() override;
   void message(const QString &message)
@@ -36,7 +36,7 @@ public slots:
     m_Message = message;
   }
 
-protected slots:
+protected Q_SLOTS:
   void onScreenRemoved();
 
 protected:
@@ -102,6 +102,6 @@ private:
   ScreenSetupModel m_ScreenSetupModel;
   QString m_Message = "";
 
-private slots:
+private Q_SLOTS:
   void onChange();
 };

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -30,7 +30,7 @@ public:
   SettingsDialog(QWidget *parent, const IServerConfig &serverConfig, const CoreProcess &coreProcess);
   ~SettingsDialog() override;
 
-signals:
+Q_SIGNALS:
   void shown();
 
 private:

--- a/src/lib/gui/ipc/DaemonIpcClient.h
+++ b/src/lib/gui/ipc/DaemonIpcClient.h
@@ -40,11 +40,11 @@ public:
     return m_state == State::Connected;
   }
 
-signals:
+Q_SIGNALS:
   void connected();
   void connectionFailed();
 
-private slots:
+private Q_SLOTS:
   void handleDisconnected();
   void handleErrorOccurred();
 

--- a/src/lib/gui/proxy/QProcessProxy.h
+++ b/src/lib/gui/proxy/QProcessProxy.h
@@ -26,7 +26,7 @@ public:
   virtual QString readAllStandardOutput();
   virtual QString readAllStandardError();
 
-signals:
+Q_SIGNALS:
   void finished(int exitCode, QProcess::ExitStatus exitStatus);
   void readyReadStandardOutput();
   void readyReadStandardError();

--- a/src/lib/gui/widgets/KeySequenceWidget.h
+++ b/src/lib/gui/widgets/KeySequenceWidget.h
@@ -18,7 +18,7 @@ class KeySequenceWidget : public QPushButton
 public:
   KeySequenceWidget(QWidget *parent, const KeySequence &seq = KeySequence());
 
-signals:
+Q_SIGNALS:
   void keySequenceChanged();
 
 public:

--- a/src/lib/gui/widgets/TrashScreenWidget.h
+++ b/src/lib/gui/widgets/TrashScreenWidget.h
@@ -27,6 +27,6 @@ public:
   void dragEnterEvent(QDragEnterEvent *event) override;
   void dropEvent(QDropEvent *event) override;
 
-signals:
+Q_SIGNALS:
   void screenRemoved();
 };

--- a/src/unittests/arch/ArchStringTests.h
+++ b/src/unittests/arch/ArchStringTests.h
@@ -11,7 +11,7 @@
 class ArchStringTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   // Test are run in order top to bottom
   void convertStringWCToMB_buffer();

--- a/src/unittests/base/PathTests.h
+++ b/src/unittests/base/PathTests.h
@@ -9,7 +9,7 @@
 class PathTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   void testOpen();
 };

--- a/src/unittests/base/StringTests.h
+++ b/src/unittests/base/StringTests.h
@@ -9,7 +9,7 @@
 class StringTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void formatWithArgs();
   void formatedString();
   void intToString();

--- a/src/unittests/base/UnicodeTests.h
+++ b/src/unittests/base/UnicodeTests.h
@@ -11,7 +11,7 @@
 class UnicodeTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   void UTF32ToUTF8();
   void UTF16ToUTF8();

--- a/src/unittests/base/XBaseTests.h
+++ b/src/unittests/base/XBaseTests.h
@@ -9,7 +9,7 @@
 class XBaseTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void empty();
   void nonEmpty();
 };

--- a/src/unittests/common/SettingsTests.h
+++ b/src/unittests/common/SettingsTests.h
@@ -11,7 +11,7 @@
 class SettingsTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   // Test are run in order top to bottom
   void setSettingsFile();

--- a/src/unittests/deskflow/ArgParserTests.h
+++ b/src/unittests/deskflow/ArgParserTests.h
@@ -12,7 +12,7 @@
 class ArgParserTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   // Test are run in order top to bottom
   void isArg();

--- a/src/unittests/deskflow/ClipboardChunksTests.h
+++ b/src/unittests/deskflow/ClipboardChunksTests.h
@@ -9,7 +9,7 @@
 class ClipboardChunksTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void startFormatData();
   void formatDataChunk();

--- a/src/unittests/deskflow/ClipboardTests.h
+++ b/src/unittests/deskflow/ClipboardTests.h
@@ -11,7 +11,7 @@
 class ClipboardTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void basicFunction();

--- a/src/unittests/deskflow/ConfigTests.h
+++ b/src/unittests/deskflow/ConfigTests.h
@@ -11,7 +11,7 @@
 class ConfigTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void loadFile();

--- a/src/unittests/deskflow/IKeyStateTests.h
+++ b/src/unittests/deskflow/IKeyStateTests.h
@@ -11,7 +11,7 @@
 class IKeyStateTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void allocDestination();
 
 private:

--- a/src/unittests/deskflow/KeyMapTests.h
+++ b/src/unittests/deskflow/KeyMapTests.h
@@ -11,7 +11,7 @@ namespace deskflow {
 class KeyMapTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void findBestKey_requiredDown_matchExactFirstItem();
   void findBestKey_requiredAndExtraSensitiveDown_matchExactFirstItem();
   void findBestKey_requiredAndExtraSensitiveDown_matchExactSecondItem();

--- a/src/unittests/deskflow/LanguageManagerTests.h
+++ b/src/unittests/deskflow/LanguageManagerTests.h
@@ -11,7 +11,7 @@
 class LanguageManagerTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   // Test are run in order top to bottom
   void remoteLanguages();

--- a/src/unittests/deskflow/ServerAppTests.h
+++ b/src/unittests/deskflow/ServerAppTests.h
@@ -9,7 +9,7 @@
 class ServerAppTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void version();
 };

--- a/src/unittests/deskflow/X11LayoutParserTests.h
+++ b/src/unittests/deskflow/X11LayoutParserTests.h
@@ -11,7 +11,7 @@
 class X11LayoutParserTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void xmlParse();

--- a/src/unittests/gui/DotEnvTests.h
+++ b/src/unittests/gui/DotEnvTests.h
@@ -9,7 +9,7 @@
 class DotEnvTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void invalidFile();

--- a/src/unittests/gui/LoggerTests.h
+++ b/src/unittests/gui/LoggerTests.h
@@ -9,7 +9,7 @@
 class LoggerTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void newLine();
   void noNewLine();

--- a/src/unittests/gui/config/ScreenTests.h
+++ b/src/unittests/gui/config/ScreenTests.h
@@ -9,7 +9,7 @@
 class ScreenTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void basicFunctionality();

--- a/src/unittests/gui/core/CommandProcessTests.h
+++ b/src/unittests/gui/core/CommandProcessTests.h
@@ -9,7 +9,7 @@
 class CommandProcessTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   // void initTestCase();
   void runCommand();

--- a/src/unittests/net/FingerprintDatabaseTests.h
+++ b/src/unittests/net/FingerprintDatabaseTests.h
@@ -9,7 +9,7 @@
 class FingerprintDatabaseTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void readFile();
   void writeFile();
   void clear();

--- a/src/unittests/net/FingerprintTests.h
+++ b/src/unittests/net/FingerprintTests.h
@@ -9,7 +9,7 @@
 class FingerprintTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void test_isValid();
   void test_toDbLine();
   void test_fromDbLine();

--- a/src/unittests/net/SecureUtilsTests.h
+++ b/src/unittests/net/SecureUtilsTests.h
@@ -9,7 +9,7 @@
 class SecureUtilsTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void checkHex();
   void checkArt();
 };

--- a/src/unittests/platform/MSWindowsClipboardTests.h
+++ b/src/unittests/platform/MSWindowsClipboardTests.h
@@ -11,7 +11,7 @@
 class MSWindowsClipboardTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void cleanupTestCase();

--- a/src/unittests/platform/OSXClipboardTests.h
+++ b/src/unittests/platform/OSXClipboardTests.h
@@ -10,7 +10,7 @@
 class OSXClipboardTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void open();
   void singleFormat();

--- a/src/unittests/platform/OSXKeyStateTests.h
+++ b/src/unittests/platform/OSXKeyStateTests.h
@@ -12,7 +12,7 @@
 class OSXKeyStateTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void initTestCase();
   // Test are run in order top to bottom
   void mapModifiersFromOSX_OSXMask();

--- a/src/unittests/platform/XWindowsClipboardTests.h
+++ b/src/unittests/platform/XWindowsClipboardTests.h
@@ -15,7 +15,7 @@
 class XWindowsClipboardTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   // Test are run in order top to bottom
   void defaultCtor();
   // Tests only work on X Windows

--- a/src/unittests/server/ServerConfigTests.h
+++ b/src/unittests/server/ServerConfigTests.h
@@ -9,7 +9,7 @@
 class ServerConfigTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void equalityCheck();
   void equalityCheck_diff_options();
   void equalityCheck_diff_alias();

--- a/src/unittests/server/ServerTests.h
+++ b/src/unittests/server/ServerTests.h
@@ -9,7 +9,7 @@
 class ServerTests : public QObject
 {
   Q_OBJECT
-private slots:
+private Q_SLOTS:
   void SwitchToScreenInfo_alloc_screen();
   void KeyboardBroadcastInfo_alloc_stateAndSceens();
 };


### PR DESCRIPTION
 - Defines QT_NO_KEYWORDS preventing issues w/ `signals` being defined by both Qt and GTK ( used in libportal) 
    - must use `Q_SIGNALS`, `Q_SLOTS` and `Q_EMIT` in place of signals, slots and emit macros
 - Fixed include order in AppUtilUnix causing X11 to be pulled in before our local code causing issue when building with Qt
 - Tested locally by added QString to the Constants.h.in file  

 - [x] Document in wiki the requirement for `Q_SIGNALS` `Q_SLOTS` and `Q_EMIT`