### PR TITLE
Restart option

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -325,7 +325,7 @@ void MainWindow::connectSlots()
   connect(&m_clientConnection, &ClientConnection::messageShowing, this, &MainWindow::showAndActivate);
 
   connect(ui->btnToggleCore, &QPushButton::clicked, m_actionStartCore, &QAction::trigger, Qt::UniqueConnection);
-  connect(ui->btnApplySettings, &QPushButton::clicked, this, &MainWindow::resetCore);
+  connect(ui->btnRestartCore, &QPushButton::clicked, this, &MainWindow::resetCore);
   connect(ui->btnConnect, &QPushButton::clicked, this, &MainWindow::resetCore);
 
   connect(ui->lineHostname, &QLineEdit::returnPressed, ui->btnConnect, &QPushButton::click);
@@ -945,7 +945,7 @@ void MainWindow::coreProcessStateChanged(CoreProcessState state)
     ui->btnToggleCore->setText(tr("&Stop"));
     ui->btnToggleCore->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::ProcessStop));
 
-    ui->btnApplySettings->setEnabled(true);
+    ui->btnRestartCore->setEnabled(true);
     m_actionStartCore->setVisible(false);
     m_actionRestartCore->setVisible(true);
     m_actionStopCore->setEnabled(true);
@@ -957,7 +957,7 @@ void MainWindow::coreProcessStateChanged(CoreProcessState state)
     ui->btnToggleCore->setText(tr("&Start"));
     ui->btnToggleCore->setIcon(QIcon::fromTheme(QStringLiteral("system-run")));
 
-    ui->btnApplySettings->setEnabled(false);
+    ui->btnRestartCore->setEnabled(false);
     m_actionStartCore->setVisible(true);
     m_actionRestartCore->setVisible(false);
     m_actionStopCore->setEnabled(false);
@@ -1150,7 +1150,7 @@ void MainWindow::toggleCanRunCore(bool enableButtons)
 {
   ui->btnToggleCore->setEnabled(enableButtons);
   ui->btnConnect->setEnabled(enableButtons);
-  ui->btnApplySettings->setEnabled(enableButtons && m_coreProcess.isStarted());
+  ui->btnRestartCore->setEnabled(enableButtons && m_coreProcess.isStarted());
   m_actionStartCore->setEnabled(enableButtons);
   m_actionStopCore->setEnabled(enableButtons);
 }

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -193,5 +193,6 @@ private:
   QAction *m_actionRestore = nullptr;
   QAction *m_actionSettings = nullptr;
   QAction *m_actionStartCore = nullptr;
+  QAction *m_actionRestartCore = nullptr;
   QAction *m_actionStopCore = nullptr;
 };

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -401,12 +401,15 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="btnApplySettings">
+          <widget class="QPushButton" name="btnRestartCore">
            <property name="enabled">
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>&amp;Apply</string>
+            <string>Rest&amp;art</string>
+           </property>
+           <property name="icon">
+            <iconset theme="view-refresh"/>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Add a restart option fixes #8542 

 - Menus hide "restart" if not running and show "start"
 - Menus hide "start" if running and show "restart"
 - Renamed the btnApplySettings to btnRestartCore, changed it text to Restart
