### PR TITLE
Mac os make sure server save and config are the same height

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -239,10 +239,11 @@ void MainWindow::setupControls()
   ui->lineEditName->setVisible(false);
 
 #if defined(Q_OS_MAC)
-
   ui->rbModeServer->setAttribute(Qt::WA_MacShowFocusRect, 0);
   ui->rbModeClient->setAttribute(Qt::WA_MacShowFocusRect, 0);
-
+  ui->btnSaveServerConfig->setFixedWidth(ui->btnSaveServerConfig->height());
+#else
+  ui->btnSaveServerConfig->setIconSize(QSize(22, 22));
 #endif
 
   const auto trayItemSize = QSize(24, 24);

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -234,21 +234,12 @@
               </widget>
              </item>
              <item>
-              <widget class="QToolButton" name="btnSaveServerConfig">
+              <widget class="QPushButton" name="btnSaveServerConfig">
                <property name="toolTip">
                 <string>Export server configuration</string>
                </property>
-               <property name="text">
-                <string>...</string>
-               </property>
                <property name="icon">
                 <iconset theme="QIcon::ThemeIcon::DocumentSaveAs"/>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
On mac os the save server config buttons is much taller then the other buttons, this fixes that 

 - Convert btnSaveConfig to QPushbutton
 - Set the icon size to 22x22 only when not on mac os
 - On mac os make sure the button is square
 - Remove the unneeded text from the button 

Before: (macOS)
<img width="236" alt="Screenshot 2025-06-05 at 11 04 05 AM" src="https://github.com/user-attachments/assets/977c1929-8670-4b54-b161-a3369afa3f33" />

After: (macOS)
<img width="236" alt="Screenshot 2025-06-05 at 11 00 25 AM" src="https://github.com/user-attachments/assets/6999e55e-2a8c-4479-9aef-cbc84258eed3" />
