### PR TITLE
fix: disable App Nap on macOS

### DIFF
--- a/src/apps/res/deskflow.plist.in
+++ b/src/apps/res/deskflow.plist.in
@@ -35,6 +35,10 @@
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
 
+	<!-- Don't allow the app to be background throttled -->
+	<key>NSAppSleepDisabled</key>
+	<true/>
+
 	<!-- Local Lan Entitlements -->
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>This app uses local network permissions for communication between a Deskflow server and clients.</string>


### PR DESCRIPTION
Been trying to diagnose a random disconnect (Windows server, Mac Client) and found a bunch of macOS console messages related to App Sleep right around the time that the disconnect happened. I'm still testing whether this causes it... but surely Deskflow is an app that would want to out out of App Sleep backgrounding in any case, yes? [Some similar discussion around QEMU here](https://gitlab.com/qemu-project/qemu/-/issues/334).