### PR TITLE
chore: correct appstream license to gpl2.0 NOT gpl2.0+

### DIFF
--- a/deploy/linux/org.deskflow.deskflow.metainfo.xml
+++ b/deploy/linux/org.deskflow.deskflow.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
 	<id>org.deskflow.deskflow</id>
 	<metadata_license>CC0-1.0</metadata_license>
-	<project_license>GPL-2.0+</project_license>
+	<project_license>GPL-2.0</project_license>
 	<name>Deskflow</name>
 	<developer id="org.deskflow">
 		<name>Deskflow Developers</name>


### PR DESCRIPTION
The Appstream file incorrectly says the project is `gpl2.0+`. the project is `gpl2.0` 