### PR TITLE
ci: Fix windows random build failures

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Build and cache vcpkg
       if: ${{ runner.os == 'Windows' }}
       id: vcpkg
-      uses: sithlord48/vcpkg-action@v7
+      uses: johnwason/vcpkg-action@v7
       with:
         pkgs: gtest openssl
         extra-args: --classic

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,16 +133,19 @@ jobs:
             runs-on: "windows-2022"
             timeout: 30
             config-args: "-G Ninja"
+            qt-version: 6.8.3
 
           - name: "macos-14-arm64"
             runs-on: "macos-14"
             timeout: 10
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64\" -DCMAKE_OSX_SYSROOT=/Applications/Xcode_15.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            qt-version: 6.9.1
 
           - name: "macos-13-x64"
             runs-on: macos-13
             timeout: 20
             config-args: "-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" -DCMAKE_OSX_SYSROOT=/Applications/Xcode_15.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            qt-version: 6.9.1
 
           - name: "debian-13-x86_64"
             runs-on: ubuntu-latest
@@ -268,7 +271,7 @@ jobs:
         id: get-deps
         uses: ./.github/actions/install-dependencies
         with:
-          qt-version: 6.9.1
+          qt-version: ${{ matrix.target.qt-version }}
           like: ${{ matrix.target.like }}
 
       - name: Get version

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -17,7 +17,6 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
-#include <QGuiApplication>
 #include <QLocalSocket>
 #include <QMessageBox>
 #include <QSharedMemory>

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -32,7 +32,6 @@
 #include "Config.h"
 #endif
 
-#include <QApplication>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QLocalServer>

--- a/src/lib/gui/StyleUtils.h
+++ b/src/lib/gui/StyleUtils.h
@@ -8,7 +8,6 @@
 
 #include <QDir>
 #include <QFileInfoList>
-#include <QGuiApplication>
 #include <QPalette>
 #include <QStyleHints>
 

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -14,7 +14,6 @@
 #include "net/FingerprintDatabase.h"
 #include "net/SecureUtils.h"
 
-#include <QCoreApplication>
 #include <QDir>
 #include <QProcess>
 


### PR DESCRIPTION
 - windows has random build failues with 6.9.1 so reverted it to 6.8.3
 - reverted the vcpkg action to no longer use my fork since johnwason's now is updated.
 - A few files ha included QApplication, QGuiApplicaiton or QCoreApplication when it was not needed this removes those includes.