### PR TITLE
Remove anon namespace from Serverconfig::addtoFirstEmptyGrid

### DIFF
--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -505,7 +505,7 @@ int ServerConfig::showAddClientDialog(const QString &clientName)
   return result;
 }
 
-void ::ServerConfig::addToFirstEmptyGrid(const QString &clientName)
+void ServerConfig::addToFirstEmptyGrid(const QString &clientName)
 {
   for (int i = 0; i < screens().size(); i++) {
     if (screens()[i].isNull()) {


### PR DESCRIPTION
Noticed two small things when looking at QStrings.

 - remove anon namespace before ServerConfig::addToFirstEmptyGrid