### PR TITLE
Begin to use std::mutex in place of ArchMutex

### DIFF
--- a/src/lib/arch/ArchString.h
+++ b/src/lib/arch/ArchString.h
@@ -24,7 +24,7 @@ public:
   ArchString() = default;
   ArchString(const ArchString &) = delete;
   ArchString(ArchString &&) = delete;
-  ~ArchString() override;
+  ~ArchString() = default;
 
   ArchString &operator=(const ArchString &) = delete;
   ArchString &operator=(ArchString &&) = delete;

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -10,6 +10,7 @@
 #include "arch/IArchMultithread.h"
 
 #include <list>
+#include <mutex>
 #include <pthread.h>
 
 #define ARCH_MULTITHREAD ArchMultithreadPosix
@@ -101,7 +102,7 @@ private:
 
   bool m_newThreadCalled = false;
 
-  ArchMutex m_threadMutex;
+  std::mutex m_threadMutex;
   ArchThread m_mainThread;
   ThreadList m_threadList;
   ThreadID m_nextID = 0;

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -11,6 +11,7 @@
 #include "arch/IArchNetwork.h"
 
 #include <memory>
+#include <mutex>
 #include <poll.h>
 #include <sys/socket.h>
 
@@ -62,7 +63,7 @@ public:
   }
   ArchNetworkBSD(ArchNetworkBSD const &) = delete;
   ArchNetworkBSD(ArchNetworkBSD &&) = delete;
-  ~ArchNetworkBSD() override;
+  ~ArchNetworkBSD() = default;
 
   ArchNetworkBSD &operator=(ArchNetworkBSD const &) = delete;
   ArchNetworkBSD &operator=(ArchNetworkBSD &&) = delete;
@@ -108,5 +109,5 @@ private:
 
 private:
   std::shared_ptr<Deps> m_pDeps;
-  ArchMutex m_mutex{};
+  std::mutex m_mutex;
 };

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -10,6 +10,7 @@
 #include "arch/IArchMultithread.h"
 
 #include <list>
+#include <mutex>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -103,7 +104,7 @@ private:
 
   static ArchMultithreadWindows *s_instance;
 
-  ArchMutex m_threadMutex;
+  std::mutex m_threadMutex;
 
   ThreadList m_threadList;
   ArchThread m_mainThread;

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -21,6 +21,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <list>
+#include <mutex>
 
 #pragma comment(lib, "ws2_32.lib")
 
@@ -51,7 +52,7 @@ public:
 class ArchNetworkWinsock : public IArchNetwork
 {
 public:
-  ArchNetworkWinsock();
+  ArchNetworkWinsock() = default;
   ~ArchNetworkWinsock() override;
 
   void init() override;
@@ -97,6 +98,6 @@ private:
 private:
   using EventList = std::list<WSAEVENT>;
 
-  ArchMutex m_mutex;
+  std::mutex m_mutex;
   EventList m_unblockEvents;
 };

--- a/src/lib/base/CMakeLists.txt
+++ b/src/lib/base/CMakeLists.txt
@@ -41,3 +41,4 @@ add_library(base STATIC
   XBase.h
 )
 
+target_link_libraries(base PRIVATE arch)

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -15,10 +15,9 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <set>
-
-class Mutex;
 
 //! Event queue
 /*!
@@ -104,7 +103,7 @@ private:
   using HandlerTable = std::map<void *, TypeHandlerTable>;
 
   int m_systemTarget = 0;
-  ArchMutex m_mutex;
+  mutable std::mutex m_mutex;
 
   // buffer of events
   std::unique_ptr<IEventQueueBuffer> m_buffer;

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -11,6 +11,8 @@
 #include "arch/IArchMultithread.h"
 #include "common/Common.h"
 
+#include <mutex>
+
 #define CLOG (Log::getInstance())
 #define BYE "\nTry `%s --help' for more information."
 
@@ -128,7 +130,7 @@ private:
 
   static Log *s_log;
 
-  ArchMutex m_mutex;
+  mutable std::mutex m_mutex;
   OutputterList m_outputters;
   OutputterList m_alwaysOutputters;
   int m_maxPriority;

--- a/src/lib/deskflow/PacketStreamFilter.h
+++ b/src/lib/deskflow/PacketStreamFilter.h
@@ -9,7 +9,8 @@
 
 #include "io/StreamBuffer.h"
 #include "io/StreamFilter.h"
-#include "mt/Mutex.h"
+
+#include <mutex>
 
 class IEventQueue;
 
@@ -41,7 +42,7 @@ private:
   bool readMore();
 
 private:
-  Mutex m_mutex;
+  mutable std::mutex m_mutex;
   uint32_t m_size = 0;
   StreamBuffer m_buffer;
   bool m_inputShutdown = false;

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -10,7 +10,8 @@
 #include "arch/IArchNetwork.h"
 #include "net/IListenSocket.h"
 
-class Mutex;
+#include <mutex>
+
 class ISocketMultiplexerJob;
 class IEventQueue;
 class SocketMultiplexer;
@@ -46,7 +47,7 @@ public:
 
 protected:
   ArchSocket m_socket;
-  Mutex *m_mutex = nullptr;
+  std::mutex m_mutex;
   IEventQueue *m_events;
   SocketMultiplexer *m_socketMultiplexer;
 };

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -9,7 +9,6 @@
 
 #include "base/Event.h"
 #include "base/IEventQueue.h"
-#include "mt/Lock.h"
 #include "mt/Thread.h"
 
 #include <fcntl.h>
@@ -51,7 +50,7 @@ XWindowsEventQueueBuffer::~XWindowsEventQueueBuffer()
 
 int XWindowsEventQueueBuffer::getPendingCountLocked()
 {
-  Lock lock(&m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return XPending(m_display);
 }
 
@@ -69,7 +68,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
   }
 
   {
-    Lock lock(&m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     // we're now waiting for events
     m_waiting = true;
 
@@ -123,7 +122,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
 
   {
     // we're no longer waiting for events
-    Lock lock(&m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_waiting = false;
   }
 
@@ -132,7 +131,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
 
 IEventQueueBuffer::Type XWindowsEventQueueBuffer::getEvent(Event &event, uint32_t &dataID)
 {
-  Lock lock(&m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   // push out pending events
   flush();
@@ -161,7 +160,7 @@ bool XWindowsEventQueueBuffer::addEvent(uint32_t dataID)
   xevent.xclient.data.l[0] = static_cast<long>(dataID);
 
   // save the message
-  Lock lock(&m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_postedEvents.push_back(xevent);
 
   // if we're currently waiting for an event then send saved events to
@@ -187,7 +186,7 @@ bool XWindowsEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool XWindowsEventQueueBuffer::isEmpty() const
 {
-  Lock lock(&m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return (XPending(m_display) == 0);
 }
 

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "base/IEventQueueBuffer.h"
-#include "mt/Mutex.h"
 
+#include <mutex>
 #include <vector>
 
 #include <X11/Xlib.h>
@@ -47,7 +47,7 @@ private:
 private:
   using EventList = std::vector<XEvent>;
 
-  Mutex m_mutex;
+  mutable std::mutex m_mutex;
   Display *m_display;
   Window m_window;
   Atom m_userEvent;


### PR DESCRIPTION
Begin to replace `ArchMutex` with `std::mutex`. In this first step all cases of `ArchMutex` or `Mutex` that were not part of a conditional var have been replaced. 

Tested locally for a few days didn't see any issues.

Backport from https://github.com/debauchee/barrier/pull/410:
 - use `std::mutex` in `arch/unix/ArchMutithreadPosix`
 - use `std::mutex` in `arch/ArchStrings`
 - use `std::mutex` in `base/Log`
 - use `std::mutex` in `base/EventQueue`

Additionally:
- Links arch to base
- use `std::mutex` in `arch/win32/ArchMultiThreadWindows`
- use `std::mutex` in `arch/unix/ArchNetworkBSD`
- use `std::mutex` in `arch/unix/ArchNetworkWinSock`
- use `std::mutex` in `deskflow/PacketStreamFilter`
- use `std::mutex` in `net/TCPListenSocket`
- use `std::mutex` in `platform/XWindowsEventQueue`
