### PR TITLE
chore use std::getenv Not c style getenv

### DIFF
--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -41,7 +41,7 @@ int execSelfNonDaemonized()
 
 bool alreadyDaemonized()
 {
-  return getenv("_DESKFLOW_DAEMONIZED") != nullptr;
+  return std::getenv("_DESKFLOW_DAEMONIZED") != nullptr;
 }
 
 #endif

--- a/src/lib/platform/Wayland.h
+++ b/src/lib/platform/Wayland.h
@@ -30,7 +30,7 @@ const auto kHasPortalInputCapture = false;
 
 inline bool isWayland()
 {
-  const auto session = getenv("XDG_SESSION_TYPE");
+  const auto session = std::getenv("XDG_SESSION_TYPE");
   return session != nullptr && std::string(session) == "wayland";
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -834,7 +834,7 @@ Display *XWindowsScreen::openDisplay(const char *displayName)
 {
   // get the DISPLAY
   if (displayName == nullptr) {
-    displayName = getenv("DISPLAY");
+    displayName = std::getenv("DISPLAY");
     if (displayName == nullptr) {
       displayName = ":0.0";
     }


### PR DESCRIPTION
idea from: https://github.com/debauchee/barrier/pull/847/

we are now being sure to use the version from std 