### PR TITLE
chore: add short options help and version in deskflow-gui

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -52,8 +52,8 @@ int main(int argc, char *argv[])
   QApplication app(argc, argv);
 
   // Add Command Line Options
-  auto helpOption = QCommandLineOption("help", "Display Help on the command line");
-  auto versionOption = QCommandLineOption("version", "Display version information");
+  auto helpOption = QCommandLineOption({"h", "help"}, "Display Help on the command line");
+  auto versionOption = QCommandLineOption({"v", "version"}, "Display version information");
   auto resetOption = QCommandLineOption("reset", "Reset all settings");
 
   QCommandLineParser parser;


### PR DESCRIPTION
 Adds `-h` and `-v` short options for help and version in deskflow-gui 
 Had this branch locally should just get it landed. 