### PR TITLE
feat: improve connections status bar info

### DIFF
--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -159,6 +159,8 @@ private:
   // Returns true if successful
   bool regenerateLocalFingerprints();
 
+  void serverClientsChanged(const QStringList &clients);
+
   inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
   inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
 

--- a/src/lib/gui/core/ServerConnection.h
+++ b/src/lib/gui/core/ServerConnection.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <QString>
-#include <QStringList>
 
 #include "gui/Messages.h"
 #include "gui/config/IServerConfig.h"
@@ -35,14 +34,16 @@ public:
 Q_SIGNALS:
   void messageShowing();
   void configureClient(const QString &clientName);
+  void clientsChanged(const QStringList &clients);
 
 private:
   void handleNewClient(const QString &clientName);
+  QStringList connectedClients() const;
 
   QWidget *m_pParent;
   IServerConfig &m_serverConfig;
   std::shared_ptr<Deps> m_pDeps;
-  QStringList m_receivedClients;
+  QSet<QString> m_connectedClients;
   bool m_messageShowing = false;
 };
 


### PR DESCRIPTION
fixes: #8688 

Modify the status area to show different message on connections

ServerConnection Changes:
 - Added new Q_EMIT to ServerConnection::clientsChanged (QStringList) 
 - Replace `QStringList m_receivedClients` => `QSet<QString> m_connectedClients` (set items are unique) 

MainWindows Changes: 

Clients will show
`Deskflow is connected as client of <serverName>`

Servers will show a few things depends on the number of clients
No clients: `Deskflow is waiting for clients`
1 Client: `Deskflow is connected to a client: <clientName>
2-4 Clients: `Deskflow is connected N clients: <clientName1>, <clientName2>, <clientName3>, <clientName4>
5+ Clients: `Deskflow is connected to N clients`

If any more then one client is connected the client list is set to the status bars tooltip in a message like 
```
Clients:
  ClientA
  ClientB
  ClientC
....
```
Can be tested from the artifacts from the Ci job : https://github.com/deskflow/deskflow/actions/runs/15663414272