### PR TITLE
Minor smell cleanup

### DIFF
--- a/src/lib/arch/ArchString.cpp
+++ b/src/lib/arch/ArchString.cpp
@@ -20,7 +20,7 @@ std::mutex s_mutex;
 
 int ArchString::convStringWCToMB(char *dst, const wchar_t *src, uint32_t n, bool *errors) const
 {
-  std::lock_guard<std::mutex> lock(s_mutex);
+  std::scoped_lock lock{s_mutex};
   ptrdiff_t len = 0;
 
   bool dummyErrors;
@@ -77,7 +77,7 @@ ArchString::EWideCharEncoding ArchString::getWideCharEncoding() const
 
 int ArchString::convStringMBToWC(wchar_t *dst, const char *src, uint32_t n, bool *errors) const
 {
-  std::lock_guard<std::mutex> lock(s_mutex);
+  std::scoped_lock lock{s_mutex};
   ptrdiff_t len = 0;
   wchar_t dummy;
 

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -424,7 +424,7 @@ bool ArchMultithreadPosix::wait(ArchThread target, double timeout)
       const double start = Arch::time();
       do {
         // wait a little
-        ARCH->sleep(0.05);
+        Arch::sleep(0.05);
 
         // repeat test
         testCancelThreadImpl(self);

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -421,7 +421,7 @@ bool ArchMultithreadPosix::wait(ArchThread target, double timeout)
 
     // wait and repeat test if there's a timeout
     if (timeout != 0.0) {
-      const double start = ARCH->time();
+      const double start = Arch::time();
       do {
         // wait a little
         ARCH->sleep(0.05);
@@ -434,7 +434,7 @@ bool ArchMultithreadPosix::wait(ArchThread target, double timeout)
         }
 
         // repeat wait and test until timed out
-      } while (timeout < 0.0 || (ARCH->time() - start) <= timeout);
+      } while (timeout < 0.0 || (Arch::time() - start) <= timeout);
     }
 
     closeThread(target);

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -63,7 +63,7 @@ static in_addr_t inet_aton(const char *cp, struct in_addr *inp)
 
 void ArchNetworkBSD::Deps::sleep(double seconds)
 {
-  ARCH->sleep(seconds);
+  Arch::sleep(seconds);
 }
 
 int ArchNetworkBSD::Deps::poll(struct pollfd *fds, nfds_t nfds, int timeout)

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -169,7 +169,7 @@ void ArchDaemonWindows::uninstallDaemon(const char *name)
   // give windows a chance to remove the service before we check if it still exists.
   // 100ms should be plenty of time.
   LOG_DEBUG("waiting for service to be removed");
-  ARCH->sleep(0.1);
+  Arch::sleep(0.1);
 
   // handle failure.  ignore error if service isn't installed anymore.
   if (!okay && isDaemonInstalled(name)) {

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -225,7 +225,7 @@ ArchSocket ArchNetworkWinsock::copySocket(ArchSocket s)
   assert(s != nullptr);
 
   // ref the socket and return it
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   ++s->m_refCount;
   return s;
 }
@@ -237,7 +237,7 @@ void ArchNetworkWinsock::closeSocket(ArchSocket s)
   // unref the socket and note if it should be released
   bool doClose = false;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     doClose = (--s->m_refCount == 0);
   }
 
@@ -247,7 +247,7 @@ void ArchNetworkWinsock::closeSocket(ArchSocket s)
       // close failed.  restore the last ref and throw.
       int err = getsockerror_winsock();
       {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        std::scoped_lock lock{m_mutex};
         ++s->m_refCount;
       }
       throwError(err);
@@ -684,7 +684,7 @@ std::vector<ArchNetAddress> ArchNetworkWinsock::nameToAddr(const std::string &na
   hints.ai_family = AF_UNSPEC;
   int ret = -1;
 
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   if ((ret = getaddrinfo(name.c_str(), nullptr, &hints, &pResult)) != 0) {
     throwNameError(ret);
   }

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -70,7 +70,7 @@ void EventQueue::loop()
 
 void EventQueue::adoptBuffer(IEventQueueBuffer *buffer)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
 
   LOG((CLOG_DEBUG "adopting new buffer"));
 
@@ -139,7 +139,7 @@ bool EventQueue::processEvent(Event &event, double timeout, Stopwatch &timer)
     return true;
 
   case IEventQueueBuffer::kUser: {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     event = removeEvent(dataID);
     return true;
   }
@@ -195,7 +195,7 @@ void EventQueue::addEvent(const Event &event)
 
 void EventQueue::addEventToBuffer(const Event &event)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
 
   // store the event's data locally
   auto eventID = saveEvent(event);
@@ -216,7 +216,7 @@ EventQueueTimer *EventQueue::newTimer(double duration, void *target)
   if (target == nullptr) {
     target = timer;
   }
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_timers.insert(timer);
   // initial duration is requested duration plus whatever's on
   // the clock currently because the latter will be subtracted
@@ -233,7 +233,7 @@ EventQueueTimer *EventQueue::newOneShotTimer(double duration, void *target)
   if (target == nullptr) {
     target = timer;
   }
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_timers.insert(timer);
   // initial duration is requested duration plus whatever's on
   // the clock currently because the latter will be subtracted
@@ -244,7 +244,7 @@ EventQueueTimer *EventQueue::newOneShotTimer(double duration, void *target)
 
 void EventQueue::deleteTimer(EventQueueTimer *timer)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   for (auto index = m_timerQueue.begin(); index != m_timerQueue.end(); ++index) {
     if (index->getTimer() == timer) {
       m_timerQueue.erase(index);
@@ -259,7 +259,7 @@ void EventQueue::deleteTimer(EventQueueTimer *timer)
 
 void EventQueue::adoptHandler(EventTypes type, void *target, IEventJob *handler)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_handlers[target][type].reset(handler);
 }
 
@@ -267,7 +267,7 @@ void EventQueue::removeHandler(EventTypes type, void *target)
 {
   std::unique_ptr<IEventJob> handler;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     HandlerTable::iterator index = m_handlers.find(target);
     if (index != m_handlers.end()) {
       TypeHandlerTable &typeHandlers = index->second;
@@ -285,7 +285,7 @@ void EventQueue::removeHandlers(void *target)
 {
   std::vector<std::unique_ptr<IEventJob>> handlers;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     HandlerTable::iterator index = m_handlers.find(target);
     if (index != m_handlers.end()) {
       // copy to handlers array and clear table for target
@@ -306,7 +306,7 @@ bool EventQueue::isEmpty() const
 
 IEventJob *EventQueue::getHandler(EventTypes type, void *target) const
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   if (HandlerTable::const_iterator index = m_handlers.find(target); index != m_handlers.end()) {
     const TypeHandlerTable &typeHandlers = index->second;
     TypeHandlerTable::const_iterator index2 = typeHandlers.find(type);

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -415,11 +415,11 @@ void *EventQueue::getSystemTarget()
 
 void EventQueue::waitForReady() const
 {
-  double timeout = ARCH->time() + 10;
+  double timeout = Arch::time() + 10;
   Lock lock(m_readyMutex);
 
   while (!m_readyCondVar->wait()) {
-    if (ARCH->time() > timeout) {
+    if (Arch::time() > timeout) {
       throw std::runtime_error("event queue is not ready within 5 sec");
     }
   }

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -208,7 +208,7 @@ void Log::insert(ILogOutputter *adoptedOutputter, bool alwaysAtHead)
 {
   assert(adoptedOutputter != nullptr);
 
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   if (alwaysAtHead) {
     m_alwaysOutputters.push_front(adoptedOutputter);
   } else {
@@ -220,14 +220,14 @@ void Log::insert(ILogOutputter *adoptedOutputter, bool alwaysAtHead)
 
 void Log::remove(ILogOutputter *outputter)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_outputters.remove(outputter);
   m_alwaysOutputters.remove(outputter);
 }
 
 void Log::pop_front(bool alwaysAtHead)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   OutputterList *list = alwaysAtHead ? &m_alwaysOutputters : &m_outputters;
   if (!list->empty()) {
     delete list->front();
@@ -251,13 +251,13 @@ bool Log::setFilter(const char *maxPriority)
 
 void Log::setFilter(int maxPriority)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_maxPriority = maxPriority;
 }
 
 int Log::getFilter() const
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   return m_maxPriority;
 }
 
@@ -268,7 +268,7 @@ void Log::output(ELevel priority, const char *msg)
   if (!msg)
     return;
 
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
 
   OutputterList::const_iterator i;
 

--- a/src/lib/base/Stopwatch.cpp
+++ b/src/lib/base/Stopwatch.cpp
@@ -15,7 +15,7 @@
 Stopwatch::Stopwatch(bool triggered) : m_triggered(triggered), m_stopped(triggered)
 {
   if (!triggered) {
-    m_mark = ARCH->time();
+    m_mark = Arch::time();
   }
 }
 
@@ -26,7 +26,7 @@ double Stopwatch::reset()
     m_mark = 0.0;
     return dt;
   } else {
-    const double t = ARCH->time();
+    const double t = Arch::time();
     const double dt = t - m_mark;
     m_mark = t;
     return dt;
@@ -40,7 +40,7 @@ void Stopwatch::stop()
   }
 
   // save the elapsed time
-  m_mark = ARCH->time() - m_mark;
+  m_mark = Arch::time() - m_mark;
   m_stopped = true;
 }
 
@@ -52,7 +52,7 @@ void Stopwatch::start()
   }
 
   // set the mark such that it reports the time elapsed at stop()
-  m_mark = ARCH->time() - m_mark;
+  m_mark = Arch::time() - m_mark;
   m_stopped = false;
 }
 
@@ -71,7 +71,7 @@ double Stopwatch::getTime()
   } else if (m_stopped) {
     return m_mark;
   } else {
-    return ARCH->time() - m_mark;
+    return Arch::time() - m_mark;
   }
 }
 
@@ -90,7 +90,7 @@ double Stopwatch::getTime() const
   if (m_stopped) {
     return m_mark;
   } else {
-    return ARCH->time() - m_mark;
+    return Arch::time() - m_mark;
   }
 }
 

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -101,7 +101,7 @@ int App::run(int argc, char **argv)
     // display invalid exceptions can occur when going to sleep. When this
     // process exits, the UI will restart us instantly. We don't really want
     // that behevior, so we quies for a bit
-    ARCH->sleep(10);
+    Arch::sleep(10);
   } catch (std::runtime_error &re) {
     LOG((CLOG_CRIT "a runtime error occurred: %s\n", re.what()));
   } catch (std::exception &e) {

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -197,7 +197,7 @@ void AppUtilWindows::eventLoop()
 
   LOG_DEBUG("windows event loop running");
   {
-    std::lock_guard lock(m_eventThreadStartedMutex);
+    std::scoped_lock lock{m_eventThreadStartedMutex};
     m_eventThreadRunning = true;
   }
   m_eventThreadStartedCond.notify_one();

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -436,7 +436,7 @@ int SecureSocket::secureAccept(int socket)
     LOG((CLOG_ERR "failed to accept secure socket"));
     LOG((CLOG_WARN "client connection may not be secure"));
     m_secureReady = false;
-    ARCH->sleep(1);
+    Arch::sleep(1);
     retry = 0;
     return -1; // Failed, error out
   }
@@ -459,7 +459,7 @@ int SecureSocket::secureAccept(int socket)
   if (retry > 0) {
     LOG((CLOG_DEBUG2 "retry accepting secure socket"));
     m_secureReady = false;
-    ARCH->sleep(s_retryDelay);
+    Arch::sleep(s_retryDelay);
     return 0;
   }
 
@@ -507,7 +507,7 @@ int SecureSocket::secureConnect(int socket)
   if (retry > 0) {
     LOG((CLOG_DEBUG2 "retry connect secure socket"));
     m_secureReady = false;
-    ARCH->sleep(s_retryDelay);
+    Arch::sleep(s_retryDelay);
     return 0;
   }
 

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -230,7 +230,7 @@ TCPSocket::EJobResult SecureSocket::doWrite()
 
 int SecureSocket::secureRead(void *buffer, int size, int &read)
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   if (m_ssl->m_ssl != nullptr) {
     LOG((CLOG_DEBUG2 "reading secure socket"));
@@ -257,7 +257,7 @@ int SecureSocket::secureRead(void *buffer, int size, int &read)
 
 int SecureSocket::secureWrite(const void *buffer, int size, int &wrote)
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   if (m_ssl->m_ssl != nullptr) {
     LOG((CLOG_DEBUG2 "writing secure socket: %p", this));
@@ -290,7 +290,7 @@ bool SecureSocket::isSecureReady() const
 
 void SecureSocket::initSsl(bool server)
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   m_ssl = new Ssl();
   m_ssl->m_context = nullptr;
@@ -301,7 +301,7 @@ void SecureSocket::initSsl(bool server)
 
 bool SecureSocket::loadCertificates(const std::string &filename)
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   if (filename.empty()) {
     SslLogger::logError("tls certificate is not specified");
@@ -392,7 +392,7 @@ void SecureSocket::createSSL()
 
 void SecureSocket::freeSSL()
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   isFatal(true);
   // take socket from multiplexer ASAP otherwise the race condition
@@ -417,7 +417,7 @@ void SecureSocket::freeSSL()
 
 int SecureSocket::secureAccept(int socket)
 {
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   createSSL();
 
@@ -479,7 +479,7 @@ int SecureSocket::secureConnect(int socket)
     return -1;
   }
 
-  std::lock_guard ssl_lock{ssl_mutex_};
+  std::scoped_lock ssl_lock{ssl_mutex_};
 
   createSSL();
 

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -51,7 +51,7 @@ TCPListenSocket::~TCPListenSocket()
 void TCPListenSocket::bind(const NetworkAddress &addr)
 {
   try {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     ARCH->setReuseAddrOnSocket(m_socket, true);
     ARCH->bindSocket(m_socket, addr.getAddress());
     ARCH->listenOnSocket(m_socket);
@@ -69,7 +69,7 @@ void TCPListenSocket::bind(const NetworkAddress &addr)
 
 void TCPListenSocket::close()
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   if (m_socket == nullptr) {
     throw XIOClosed();
   }

--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -66,7 +66,7 @@ void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
 
   if (int retval = poll(pfds, POLLFD_COUNT, timeout); retval > 0) {
     if (pfds[EIFD].revents & POLLIN) {
-      std::lock_guard lock(mutex_);
+      std::scoped_lock lock{mutex_};
 
       // libei doesn't allow ei_event_ref() because events are
       // supposed to be short-lived only. So instead, we create an nullptr-data
@@ -108,7 +108,7 @@ IEventQueueBuffer::Type EiEventQueueBuffer::getEvent(Event &event, uint32_t &dat
   // we just have a "something happened" event on the ei fd and the rest is
   // handled by the EiScreen.
   //
-  std::lock_guard lock(mutex_);
+  std::scoped_lock lock{mutex_};
   auto pair = queue_.front();
   queue_.pop();
 
@@ -125,7 +125,7 @@ IEventQueueBuffer::Type EiEventQueueBuffer::getEvent(Event &event, uint32_t &dat
 
 bool EiEventQueueBuffer::addEvent(uint32_t dataID)
 {
-  std::lock_guard lock(mutex_);
+  std::scoped_lock lock{mutex_};
   queue_.push({false, dataID});
 
   // tickle the pipe so our read thread wakes up
@@ -137,7 +137,7 @@ bool EiEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool EiEventQueueBuffer::isEmpty() const
 {
-  std::lock_guard lock(mutex_);
+  std::scoped_lock lock{mutex_};
 
   return queue_.empty();
 }

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -720,7 +720,7 @@ void EiScreen::handle_portal_session_closed(const Event &event, void *)
 
 void EiScreen::handleSystemEvent(const Event &sysevent, void *)
 {
-  std::lock_guard lock(mutex_);
+  std::scoped_lock lock{mutex_};
 
   // Only one ei_dispatch per system event, see the comment in
   // EiEventQueueBuffer::addEvent

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -1387,7 +1387,7 @@ void MSWindowsScreen::warpCursorNoFlush(int32_t x, int32_t y)
   // chance of undesired behavior.  we'll also check for very
   // large motions that look suspiciously like about half width
   // or height of the screen.
-  ARCH->sleep(0.0);
+  Arch::sleep(0.0);
 
   // send an event that we can recognize after the mouse warp
   PostThreadMessage(GetCurrentThreadId(), DESKFLOW_MSG_POST_WARP, 0, 0);

--- a/src/lib/platform/MSWindowsScreenSaver.cpp
+++ b/src/lib/platform/MSWindowsScreenSaver.cpp
@@ -213,7 +213,7 @@ void MSWindowsScreenSaver::watchDesktopThread(void *)
 
   for (;;) {
     // wait a bit
-    ARCH->sleep(0.2);
+    Arch::sleep(0.2);
 
     BOOL running;
     SystemParametersInfo(SPI_GETSCREENSAVERRUNNING, 0, &running, 0);

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -196,7 +196,7 @@ void MSWindowsWatchdog::mainLoop(void *)
 
     case StartScheduled: {
       LOG_DEBUG3("watchdog process start scheduled");
-      if (m_nextStartTime.has_value() && m_nextStartTime.value() <= ARCH->time()) {
+      if (m_nextStartTime.has_value() && m_nextStartTime.value() <= Arch::time()) {
         LOG_DEBUG("start time reached, queueing process start");
         m_processState = StartPending;
       }
@@ -442,7 +442,7 @@ MSWindowsWatchdog::ProcessState MSWindowsWatchdog::handleStartError(const std::s
 
   // When there has been more than one consecutive failure, slow down the retry rate.
   if (m_startFailures > 1) {
-    m_nextStartTime = ARCH->time() + kStartDelaySeconds;
+    m_nextStartTime = Arch::time() + kStartDelaySeconds;
     LOG_WARN("start failed %d times, delaying start", m_startFailures);
     LOG_DEBUG("start delay, seconds=%d, time=%f", kStartDelaySeconds, m_nextStartTime.value());
     return ProcessState::StartScheduled;

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -241,7 +241,7 @@ void MSWindowsWatchdog::mainLoop(void *)
 
     // Sleep for only 100ms rather than 1 second so that the service can shut down faster.
     LOG_DEBUG3("watchdog main loop sleeping");
-    ARCH->sleep(0.1);
+    Arch::sleep(0.1);
   }
 
   LOG_DEBUG("watchdog main loop finished");
@@ -309,7 +309,7 @@ void MSWindowsWatchdog::startProcess()
   } else {
     // Wait for program to fail. This needs to be 1 second, as the process may take some time to fail.
     LOG_DEBUG("watchdog waiting for process start result");
-    ARCH->sleep(1);
+    Arch::sleep(1);
 
     if (!isProcessRunning()) {
       m_process.reset();
@@ -357,7 +357,7 @@ void MSWindowsWatchdog::outputLoop(void *)
 
     if (!success || bytesRead == 0) {
       // Sleep for only 100ms rather than 1 second so that the service can shut down faster.
-      ARCH->sleep(0.1);
+      Arch::sleep(0.1);
     } else {
       buffer[bytesRead] = '\0';
 
@@ -524,7 +524,7 @@ void MSWindowsWatchdog::sasLoop(void *) // NOSONAR - Thread entry point signatur
   while (m_running) {
     if (m_processState != ProcessState::Running) {
       LOG_DEBUG2("watchdog not running, skipping SendSAS");
-      ARCH->sleep(1);
+      Arch::sleep(1);
       continue;
     }
 
@@ -532,7 +532,7 @@ void MSWindowsWatchdog::sasLoop(void *) // NOSONAR - Thread entry point signatur
     MSWindowsHandle sendSasEvent(CreateEvent(nullptr, FALSE, FALSE, kSendSasEventName));
     if (sendSasEvent.get() == nullptr) {
       LOG_ERR("could not create SAS event, error: %s", windowsErrorToString(GetLastError()).c_str());
-      ARCH->sleep(1);
+      Arch::sleep(1);
       continue;
     }
 

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -327,7 +327,7 @@ void MSWindowsWatchdog::startProcess()
 void MSWindowsWatchdog::setProcessConfig(const std::string_view &command, bool elevate)
 {
   LOG_DEBUG1("locking process state mutex for watchdog config change");
-  std::lock_guard lock(m_processStateMutex);
+  std::scoped_lock lock{m_processStateMutex};
 
   LOG_DEBUG("setting watchdog process config");
   m_command = command;

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -66,7 +66,7 @@ bool OSXEventQueueBuffer::addEvent(uint32_t dataID)
 {
   // Use GCD to dispatch event addition on the main queue
   dispatch_async(dispatch_get_main_queue(), ^{
-    std::lock_guard lock(this->m_mutex);
+    std::scoped_lock lock{this->m_mutex};
     LOG_DEBUG2("adding user event with dataID: %u", dataID);
     this->m_dataQueue.push(dataID);
     this->m_cond.notify_one();
@@ -79,7 +79,7 @@ bool OSXEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool OSXEventQueueBuffer::isEmpty() const
 {
-  std::lock_guard lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   bool empty = m_dataQueue.empty();
   LOG_DEBUG2("queue is %s", empty ? "empty" : "not empty");
   return empty;

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -889,7 +889,7 @@ void OSXKeyState::setGroup(int32_t group)
   // event queue and without a delay the subsequent key press
   // event could be applied before the keyboard layout would
   // actually be changed.
-  ARCH->sleep(.01);
+  Arch::sleep(.01);
 }
 
 void OSXKeyState::adjustAltGrModifier(const KeyIDs &ids, KeyModifierMask *mask, bool isCommand) const

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -508,13 +508,13 @@ void OSXScreen::fakeMouseButton(ButtonID id, bool press)
   // This will allow for higher than triple click but the quartz documenation
   // does not specify that this should be limited to triple click
   if (press) {
-    if ((ARCH->time() - m_lastClickTime) <= clickTime && diff <= maxDiff) {
+    if ((Arch::time() - m_lastClickTime) <= clickTime && diff <= maxDiff) {
       m_clickState++;
     } else {
       m_clickState = 1;
     }
 
-    m_lastClickTime = ARCH->time();
+    m_lastClickTime = Arch::time();
   }
 
   if (m_clickState == 1) {
@@ -1752,11 +1752,11 @@ void OSXScreen::waitForCarbonLoop() const
 
   LOG((CLOG_DEBUG "waiting for carbon loop"));
 
-  double timeout = ARCH->time() + kCarbonLoopWaitTimeout;
+  double timeout = Arch::time() + kCarbonLoopWaitTimeout;
   while (!m_carbonLoopReady->wait()) {
-    if (ARCH->time() > timeout) {
+    if (Arch::time() > timeout) {
       LOG((CLOG_DEBUG "carbon loop not ready, waiting again"));
-      timeout = ARCH->time() + kCarbonLoopWaitTimeout;
+      timeout = Arch::time() + kCarbonLoopWaitTimeout;
     }
   }
 

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1232,7 +1232,7 @@ bool XWindowsClipboard::CICCCMGetClipboard::readClipboard(
         }
       }
     } else {
-      ARCH->sleep(0.01);
+      Arch::sleep(0.01);
     }
   }
 

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -50,7 +50,7 @@ XWindowsEventQueueBuffer::~XWindowsEventQueueBuffer()
 
 int XWindowsEventQueueBuffer::getPendingCountLocked()
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   return XPending(m_display);
 }
 
@@ -68,7 +68,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
   }
 
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     // we're now waiting for events
     m_waiting = true;
 
@@ -122,7 +122,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
 
   {
     // we're no longer waiting for events
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock{m_mutex};
     m_waiting = false;
   }
 
@@ -131,7 +131,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
 
 IEventQueueBuffer::Type XWindowsEventQueueBuffer::getEvent(Event &event, uint32_t &dataID)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
 
   // push out pending events
   flush();
@@ -160,7 +160,7 @@ bool XWindowsEventQueueBuffer::addEvent(uint32_t dataID)
   xevent.xclient.data.l[0] = static_cast<long>(dataID);
 
   // save the message
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   m_postedEvents.push_back(xevent);
 
   // if we're currently waiting for an event then send saved events to
@@ -186,7 +186,7 @@ bool XWindowsEventQueueBuffer::addEvent(uint32_t dataID)
 
 bool XWindowsEventQueueBuffer::isEmpty() const
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::scoped_lock lock{m_mutex};
   return (XPending(m_display) == 0);
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1887,7 +1887,7 @@ bool XWindowsScreen::grabMouseAndKeyboard()
       assert(result != GrabNotViewable);
       if (result != GrabSuccess) {
         LOG((CLOG_DEBUG2 "waiting to grab keyboard"));
-        ARCH->sleep(0.05);
+        Arch::sleep(0.05);
         if (timer.getTime() >= s_timeout) {
           LOG((CLOG_DEBUG2 "grab keyboard timed out"));
           return false;
@@ -1904,7 +1904,7 @@ bool XWindowsScreen::grabMouseAndKeyboard()
       // back off to avoid grab deadlock
       XUngrabKeyboard(m_display, CurrentTime);
       LOG((CLOG_DEBUG2 "ungrabbed keyboard, waiting to grab pointer"));
-      ARCH->sleep(0.05);
+      Arch::sleep(0.05);
       if (timer.getTime() >= s_timeout) {
         LOG((CLOG_DEBUG2 "grab pointer timed out"));
         return false;

--- a/src/unittests/platform/OSXKeyStateTests.cpp
+++ b/src/unittests/platform/OSXKeyStateTests.cpp
@@ -116,7 +116,7 @@ void OSXKeyStateTests::fakePollCharWithModifier()
 bool OSXKeyStateTests::isKeyPressed(const OSXKeyState &keyState, KeyButton button)
 {
   // HACK: allow os to realize key state changes.
-  ARCH->sleep(.2);
+  Arch::sleep(.2);
 
   IKeyState::KeyButtonSet pressed;
   keyState.pollPressedKeys(pressed);


### PR DESCRIPTION
 - Use `std::scoped_lock` in place of `std::lock_guard` 
 - use Arch::time in place of ARCH->time()
 - use Arch::sleep() in place of ARCH->sleep()