### PR TITLE
fix: Error text is not shown for Qt CLI parser

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -36,6 +36,8 @@ using namespace deskflow::gui;
 bool checkMacAssistiveDevices();
 #endif
 
+const static auto kHeader = QStringLiteral("%1: %2\n").arg(kAppName, kDisplayVersion);
+
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_UNIX) && defined(QT_DEBUG)
@@ -63,15 +65,19 @@ int main(int argc, char *argv[])
   parser.addOption(resetOption);
   parser.parse(QCoreApplication::arguments());
 
-  const auto header = QStringLiteral("%1: %2\n").arg(kAppName, kDisplayVersion);
-  if (parser.isSet(helpOption) || !parser.unknownOptionNames().isEmpty() || !parser.errorText().isEmpty()) {
-    QTextStream(stdout) << header << QStringLiteral("  %1\n\n").arg(kAppDescription)
+  if (!parser.errorText().isEmpty()) {
+    qCritical().noquote() << parser.errorText() << "\nUse --help for more information.";
+    return 1;
+  }
+
+  if (parser.isSet(helpOption)) {
+    QTextStream(stdout) << kHeader << QStringLiteral("  %1\n\n").arg(kAppDescription)
                         << parser.helpText().replace(QApplication::applicationFilePath(), kAppId);
     return 0;
   }
 
   if (parser.isSet(versionOption)) {
-    QTextStream(stdout) << header << kCopyright << Qt::endl;
+    QTextStream(stdout) << kHeader << kCopyright << Qt::endl;
     return 0;
   }
 


### PR DESCRIPTION
Related to: #8685

We should print the parser error text to stderr and return non-zero exit code so that it's clear when you enter an invalid option.

As it is, it's a bit confusing how it doesn't tell you when you enter an invalid arg.