### PR TITLE
refactor: free SecureSocket cert after use

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -639,6 +639,9 @@ bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
   const auto cert = SSL_get_peer_certificate(m_ssl->m_ssl);
   const auto sha256 = deskflow::sslCertFingerprint(cert, Fingerprint::Type::SHA256);
 
+  if (cert)
+    X509_free(cert);
+
   if (!sha256.isValid())
     return false;
 


### PR DESCRIPTION
 In `SecureSocket::verifyCertFingerprint` we never called X509_free when we were finished with our certificated.