### PR TITLE
chore: simplify icon theme path fallback path

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -111,8 +111,13 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  // Sets the fallback icon path
-  setIconFallbackPaths();
+  // Sets the fallback icon path and fallback theme
+  const auto themeName = QStringLiteral("deskflow-%1").arg(iconMode());
+  if (QIcon::themeName().isEmpty())
+    QIcon::setThemeName(themeName);
+  else
+    QIcon::setFallbackThemeName(themeName);
+  QIcon::setFallbackSearchPaths({QStringLiteral(":/icons/%1").arg(themeName)});
 
   qInstallMessageHandler(deskflow::gui::messages::messageHandler);
   qInfo("%s v%s", kAppName, qPrintable(kVersion));

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -83,12 +83,6 @@ MainWindow::MainWindow()
       m_actionRestartCore{new QAction(tr("Rest&art"), this)},
       m_actionStopCore{new QAction(tr("S&top"), this)}
 {
-  const auto themeName = QStringLiteral("deskflow-%1").arg(iconMode());
-  if (QIcon::themeName().isEmpty())
-    QIcon::setThemeName(themeName);
-  else
-    QIcon::setFallbackThemeName(themeName);
-
   ui->setupUi(this);
 
   // Setup Actions

--- a/src/lib/gui/StyleUtils.h
+++ b/src/lib/gui/StyleUtils.h
@@ -35,31 +35,4 @@ inline QString iconMode()
   return isDarkMode() ? QStringLiteral("dark") : QStringLiteral("light");
 }
 
-/**
- * @brief checkSubDir checks for subdirs in a dir
- * @param path The path to check for subdirs
- * @return list of subdirs
- */
-inline QStringList checkSubDir(const QString &path)
-{
-  QStringList paths;
-  auto dir = QDir(path);
-  const QFileInfoList items = dir.entryInfoList({"*"}, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-  for (const QFileInfo &item : items) {
-    if (item.isDir()) {
-      paths.append(item.absoluteFilePath());
-      paths.append(checkSubDir(item.absoluteFilePath()));
-    }
-  }
-  return paths;
-}
-
-/**
- * @brief setIconFallbackPaths Set the icon fallback path to our light or dark theme
- */
-inline void setIconFallbackPaths()
-{
-  QStringList paths = checkSubDir(QStringLiteral(":/icons/deskflow-%1").arg(iconMode()));
-  QIcon::setFallbackSearchPaths(paths);
-}
 } // namespace deskflow::gui


### PR DESCRIPTION
Simplify how we resolve the fallback search paths. 
 1. We do not need to to search any themes child dirs. `StyleUtil::checkSubDir` is not needed  and has been removed
 2. Set our fallback search to always include the icon theme path `:icons/deskflow-light` or `:/icons/deskflow-dark` `StyleUtil::SetFallbackThemePath` has been removed and just is set in deskflow-gui.cpp 
 3. Remove the Theme settings in MainWindow and do it deskflow-gui 