### PR TITLE
More Sonar Cleanup (round 5)

### DIFF
--- a/src/lib/arch/Arch.cpp
+++ b/src/lib/arch/Arch.cpp
@@ -57,5 +57,5 @@ double Arch::time()
 {
   auto sinceEpoch = std::chrono::steady_clock::now().time_since_epoch();
   auto uSecSinceEpoch = std::chrono::duration_cast<std::chrono::microseconds>(sinceEpoch).count();
-  return uSecSinceEpoch / 1000000.0;
+  return double(uSecSinceEpoch / 1000000);
 }

--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -69,16 +69,16 @@ public:
   Not all platforms support all signals.  Unsupported signals are
   ignored.
   */
-  enum ESignal
+  enum class ThreadSignal : uint8_t
   {
-    kINTERRUPT, //!< Interrupt (e.g. Ctrl+C)
-    kTERMINATE, //!< Terminate (e.g. Ctrl+Break)
-    kHANGUP,    //!< Hangup (SIGHUP)
-    kUSER,      //!< User (SIGUSR2)
-    kNUM_SIGNALS
+    Interrupt, //!< Interrupt (e.g. Ctrl+C)
+    Terminate, //!< Terminate (e.g. Ctrl+Break)
+    Hangup,    //!< Hangup (SIGHUP)
+    User,      //!< User (SIGUSR2)
+    MaxSignals //!< Number of differnt signals
   };
   //! Type of signal handler function
-  using SignalFunc = void (*)(ESignal, void *userData);
+  using SignalFunc = void (*)(ThreadSignal, void *userData);
 
   //! @name manipulators
   //@{
@@ -249,15 +249,15 @@ public:
   Sets the function to call on receipt of an external interrupt.
   By default and when \p func is nullptr, the main thread is cancelled.
   */
-  virtual void setSignalHandler(ESignal, SignalFunc func, void *userData) = 0;
+  virtual void setSignalHandler(ThreadSignal, SignalFunc func, void *userData) = 0;
 
   //! Invoke the signal handler
   /*!
   Invokes the signal handler for \p signal, if any.  If no handler
-  cancels the main thread for \c kINTERRUPT and \c kTERMINATE and
+  cancels the main thread for \c ThreadSignal::Interrupt and \c ThreadSignal::Terminate and
   ignores the call otherwise.
   */
-  virtual void raiseSignal(ESignal signal) = 0;
+  virtual void raiseSignal(ThreadSignal signal) = 0;
 
   //@}
 };

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -53,11 +53,11 @@ class IArchNetwork : public IInterface
 {
 public:
   //! Supported address families
-  enum EAddressFamily
+  enum class AddressFamily : uint8_t
   {
-    kUNKNOWN,
-    kINET,
-    kINET6,
+    Unknown,
+    INet,
+    INet6
   };
 
   //! Supported socket types
@@ -105,7 +105,7 @@ public:
   /*!
   The socket is an opaque data type.
   */
-  virtual ArchSocket newSocket(EAddressFamily, ESocketType) = 0;
+  virtual ArchSocket newSocket(AddressFamily, ESocketType) = 0;
 
   //! Copy a socket object
   /*!
@@ -236,7 +236,7 @@ public:
   virtual std::string getHostName() = 0;
 
   //! Create an "any" network address
-  virtual ArchNetAddress newAnyAddr(EAddressFamily) = 0;
+  virtual ArchNetAddress newAnyAddr(AddressFamily) = 0;
 
   //! Copy a network address
   virtual ArchNetAddress copyAddr(ArchNetAddress) = 0;
@@ -254,7 +254,7 @@ public:
   virtual std::string addrToString(ArchNetAddress) = 0;
 
   //! Get an address's family
-  virtual EAddressFamily getAddrFamily(ArchNetAddress) = 0;
+  virtual AddressFamily getAddrFamily(ArchNetAddress) = 0;
 
   //! Set the port of an address
   virtual void setAddrPort(ArchNetAddress, int port) = 0;

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -274,4 +274,15 @@ public:
   //@}
 
   virtual void init() = 0;
+
+private:
+  /**
+   * @brief throwError, Used to throw network errors
+   */
+  [[noreturn]] virtual void throwError(int) const = 0;
+
+  /**
+   * @brief throwNameError, Errors related to client names.
+   */
+  [[noreturn]] virtual void throwNameError(int) const = 0;
 };

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -61,10 +61,10 @@ public:
   };
 
   //! Supported socket types
-  enum ESocketType
+  enum class SocketType : uint8_t
   {
-    kDGRAM,
-    kSTREAM
+    DataGram,
+    Stream
   };
 
   //! Events for \c poll()
@@ -105,7 +105,7 @@ public:
   /*!
   The socket is an opaque data type.
   */
-  virtual ArchSocket newSocket(AddressFamily, ESocketType) = 0;
+  virtual ArchSocket newSocket(AddressFamily, SocketType) = 0;
 
   //! Copy a socket object
   /*!

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -72,12 +72,12 @@ public:
   Events for \c poll() are bitmasks and can be combined using the
   bitwise operators.
   */
-  enum
+  struct PollEventMask
   {
-    kPOLLIN = 1,  //!< Socket is readable
-    kPOLLOUT = 2, //!< Socket is writable
-    kPOLLERR = 4, //!< The socket is in an error state
-    kPOLLNVAL = 8 //!< The socket is invalid
+    inline static const int In = 1;      //!< Socket is readable
+    inline static const int Out = 2;     //!< Socket is writable
+    inline static const int Error = 4;   //!< The socket is in an error state
+    inline static const int Invalid = 8; //!< The socket is invalid
   };
 
   //! A socket query for \c poll()
@@ -89,8 +89,7 @@ public:
 
     //! The events to query for
     /*!
-    The events to query for can be any combination of kPOLLIN and
-    kPOLLOUT.
+    The events to query for can be any combination of PollEventMask::In and PollEventMask::Out.
     */
     unsigned short m_events;
 
@@ -175,9 +174,9 @@ public:
   and/or writable (or indefinitely if \c timeout < 0).  Returns the
   number of sockets that were readable (if readability was being
   queried) or writable (if writablility was being queried) and sets
-  the \c m_revents members of the entries.  \c kPOLLERR and \c kPOLLNVAL
+  the \c m_revents members of the entries.  \c PollEventMask::Error and \c PollEventMask::Invalid
   are set in \c m_revents as appropriate.  If a socket indicates
-  \c kPOLLERR then \c throwErrorOnSocket() can be used to determine
+  \c PollEventMask::Error then \c throwErrorOnSocket() can be used to determine
   the type of error.  Returns 0 immediately regardless of the \c timeout
   if no valid sockets are selected for testing.
 

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -76,8 +76,8 @@ public:
   bool isExitedThread(ArchThread) override;
   void *getResultOfThread(ArchThread) override;
   ThreadID getIDOfThread(ArchThread) override;
-  void setSignalHandler(ESignal, SignalFunc, void *) override;
-  void raiseSignal(ESignal) override;
+  void setSignalHandler(ThreadSignal, SignalFunc, void *) override;
+  void raiseSignal(ThreadSignal) override;
 
 private:
   void startSignalHandler();
@@ -108,6 +108,6 @@ private:
   ThreadID m_nextID = 0;
 
   pthread_t m_signalThread;
-  SignalFunc m_signalFunc[kNUM_SIGNALS];
-  void *m_signalUserData[kNUM_SIGNALS];
+  SignalFunc m_signalFunc[static_cast<int>(ThreadSignal::MaxSignals)];
+  void *m_signalUserData[static_cast<int>(ThreadSignal::MaxSignals)];
 };

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -95,10 +95,10 @@ void ArchNetworkBSD::init()
   // do nothing
 }
 
-ArchSocket ArchNetworkBSD::newSocket(AddressFamily family, ESocketType type)
+ArchSocket ArchNetworkBSD::newSocket(AddressFamily family, SocketType type)
 {
   // create socket
-  int fd = socket(s_family[static_cast<int>(family)], s_type[type], 0);
+  int fd = socket(s_family[static_cast<int>(family)], s_type[static_cast<int>(type)], 0);
   if (fd == -1) {
     throwError(errno);
   }

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -742,7 +742,7 @@ const int *ArchNetworkBSD::getUnblockPipeForThread(ArchThread thread)
   return unblockPipe;
 }
 
-void ArchNetworkBSD::throwError(int err) const
+[[noreturn]] void ArchNetworkBSD::throwError(int err) const
 {
   switch (err) {
   case EINTR:
@@ -813,7 +813,7 @@ void ArchNetworkBSD::throwError(int err) const
   }
 }
 
-void ArchNetworkBSD::throwNameError(int err) const
+[[noreturn]] void ArchNetworkBSD::throwNameError(int err) const
 {
   static const char *s_msg[] = {
       "The specified host is unknown", "The requested name is valid but does not have an IP address",

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -278,10 +278,10 @@ int ArchNetworkBSD::pollSocket(PollEntry pe[], int num, double timeout)
   for (int i = 0; i < num; ++i) {
     pfd[i].fd = (pe[i].m_socket == nullptr) ? -1 : pe[i].m_socket->m_fd;
     pfd[i].events = 0;
-    if ((pe[i].m_events & kPOLLIN) != 0) {
+    if ((pe[i].m_events & PollEventMask::In) != 0) {
       pfd[i].events |= POLLIN;
     }
-    if ((pe[i].m_events & kPOLLOUT) != 0) {
+    if ((pe[i].m_events & PollEventMask::Out) != 0) {
       pfd[i].events |= POLLOUT;
     }
   }
@@ -328,16 +328,16 @@ int ArchNetworkBSD::pollSocket(PollEntry pe[], int num, double timeout)
   for (int i = 0; i < num; ++i) {
     pe[i].m_revents = 0;
     if ((pfd[i].revents & POLLIN) != 0) {
-      pe[i].m_revents |= kPOLLIN;
+      pe[i].m_revents |= PollEventMask::In;
     }
     if ((pfd[i].revents & POLLOUT) != 0) {
-      pe[i].m_revents |= kPOLLOUT;
+      pe[i].m_revents |= PollEventMask::Out;
     }
     if ((pfd[i].revents & POLLERR) != 0) {
-      pe[i].m_revents |= kPOLLERR;
+      pe[i].m_revents |= PollEventMask::Error;
     }
     if ((pfd[i].revents & POLLNVAL) != 0) {
-      pe[i].m_revents |= kPOLLNVAL;
+      pe[i].m_revents |= PollEventMask::Invalid;
     }
   }
 

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -71,7 +71,7 @@ public:
   void init() override;
 
   // IArchNetwork overrides
-  ArchSocket newSocket(AddressFamily, ESocketType) override;
+  ArchSocket newSocket(AddressFamily, SocketType) override;
   ArchSocket copySocket(ArchSocket s) override;
   void closeSocket(ArchSocket s) override;
   void closeSocketForRead(ArchSocket s) override;

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -104,10 +104,9 @@ private:
   const int *getUnblockPipe();
   const int *getUnblockPipeForThread(ArchThread);
   void setBlockingOnSocket(int fd, bool blocking) const;
-  void throwError(int) const;
-  void throwNameError(int) const;
+  [[noreturn]] void throwError(int) const override;
+  [[noreturn]] void throwNameError(int) const override;
 
-private:
   std::shared_ptr<Deps> m_pDeps;
   std::mutex m_mutex;
 };

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -71,7 +71,7 @@ public:
   void init() override;
 
   // IArchNetwork overrides
-  ArchSocket newSocket(EAddressFamily, ESocketType) override;
+  ArchSocket newSocket(AddressFamily, ESocketType) override;
   ArchSocket copySocket(ArchSocket s) override;
   void closeSocket(ArchSocket s) override;
   void closeSocketForRead(ArchSocket s) override;
@@ -88,13 +88,13 @@ public:
   bool setNoDelayOnSocket(ArchSocket, bool noDelay) override;
   bool setReuseAddrOnSocket(ArchSocket, bool reuse) override;
   std::string getHostName() override;
-  ArchNetAddress newAnyAddr(EAddressFamily) override;
+  ArchNetAddress newAnyAddr(AddressFamily) override;
   ArchNetAddress copyAddr(ArchNetAddress) override;
   std::vector<ArchNetAddress> nameToAddr(const std::string &) override;
   void closeAddr(ArchNetAddress) override;
   std::string addrToName(ArchNetAddress) override;
   std::string addrToString(ArchNetAddress) override;
-  EAddressFamily getAddrFamily(ArchNetAddress) override;
+  AddressFamily getAddrFamily(ArchNetAddress) override;
   void setAddrPort(ArchNetAddress, int port) override;
   int getAddrPort(ArchNetAddress) override;
   bool isAnyAddr(ArchNetAddress) override;

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -83,8 +83,8 @@ public:
   bool isExitedThread(ArchThread) override;
   void *getResultOfThread(ArchThread) override;
   ThreadID getIDOfThread(ArchThread) override;
-  void setSignalHandler(ESignal, SignalFunc, void *) override;
-  void raiseSignal(ESignal) override;
+  void setSignalHandler(ThreadSignal, SignalFunc, void *) override;
+  void raiseSignal(ThreadSignal) override;
 
 private:
   ArchThreadImpl *find(DWORD id);
@@ -109,6 +109,6 @@ private:
   ThreadList m_threadList;
   ArchThread m_mainThread;
 
-  SignalFunc m_signalFunc[kNUM_SIGNALS];
-  void *m_signalUserData[kNUM_SIGNALS];
+  SignalFunc m_signalFunc[static_cast<int>(ThreadSignal::MaxSignals)];
+  void *m_signalUserData[static_cast<int>(ThreadSignal::MaxSignals)];
 };

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -192,10 +192,10 @@ void ArchNetworkWinsock::initModule(HMODULE module)
   s_networkModule = module;
 }
 
-ArchSocket ArchNetworkWinsock::newSocket(EAddressFamily family, ESocketType type)
+ArchSocket ArchNetworkWinsock::newSocket(AddressFamily family, ESocketType type)
 {
   // create socket
-  SOCKET fd = socket_winsock(s_family[family], s_type[type], 0);
+  SOCKET fd = socket_winsock(s_family[static_cast<int>(family)], s_type[type], 0);
   if (fd == INVALID_SOCKET) {
     throwError(getsockerror_winsock());
   }
@@ -636,11 +636,11 @@ std::string ArchNetworkWinsock::getHostName()
   return name;
 }
 
-ArchNetAddress ArchNetworkWinsock::newAnyAddr(EAddressFamily family)
+ArchNetAddress ArchNetworkWinsock::newAnyAddr(AddressFamily family)
 {
   ArchNetAddressImpl *addr = nullptr;
   switch (family) {
-  case kINET: {
+  case AddressFamily::INet: {
     addr = ArchNetAddressImpl::alloc(sizeof(struct sockaddr_in));
     struct sockaddr_in *ipAddr = TYPED_ADDR(struct sockaddr_in, addr);
     ipAddr->sin_family = AF_INET;
@@ -649,7 +649,7 @@ ArchNetAddress ArchNetworkWinsock::newAnyAddr(EAddressFamily family)
     break;
   }
 
-  case kINET6: {
+  case AddressFamily::INet6: {
     addr = ArchNetAddressImpl::alloc(sizeof(struct sockaddr_in6));
     struct sockaddr_in6 *ipAddr = TYPED_ADDR(struct sockaddr_in6, addr);
     ipAddr->sin6_family = AF_INET6;
@@ -734,12 +734,12 @@ std::string ArchNetworkWinsock::addrToString(ArchNetAddress addr)
   assert(addr != nullptr);
 
   switch (getAddrFamily(addr)) {
-  case kINET: {
+  case AddressFamily::INet: {
     struct sockaddr_in *ipAddr = TYPED_ADDR(struct sockaddr_in, addr);
     return inet_ntoa_winsock(ipAddr->sin_addr);
   }
 
-  case kINET6: {
+  case AddressFamily::INet6: {
     char strAddr[INET6_ADDRSTRLEN];
     struct sockaddr_in6 *ipAddr = TYPED_ADDR(struct sockaddr_in6, addr);
     inet_ntop(AF_INET6, &ipAddr->sin6_addr, strAddr, INET6_ADDRSTRLEN);
@@ -752,19 +752,19 @@ std::string ArchNetworkWinsock::addrToString(ArchNetAddress addr)
   }
 }
 
-IArchNetwork::EAddressFamily ArchNetworkWinsock::getAddrFamily(ArchNetAddress addr)
+IArchNetwork::AddressFamily ArchNetworkWinsock::getAddrFamily(ArchNetAddress addr)
 {
   assert(addr != nullptr);
 
   switch (addr->m_addr.ss_family) {
   case AF_INET:
-    return kINET;
+    return AddressFamily::INet;
 
   case AF_INET6:
-    return kINET6;
+    return AddressFamily::INet6;
 
   default:
-    return kUNKNOWN;
+    return AddressFamily::Unknown;
   }
 }
 
@@ -773,13 +773,13 @@ void ArchNetworkWinsock::setAddrPort(ArchNetAddress addr, int port)
   assert(addr != nullptr);
 
   switch (getAddrFamily(addr)) {
-  case kINET: {
+  case AddressFamily::INet: {
     struct sockaddr_in *ipAddr = TYPED_ADDR(struct sockaddr_in, addr);
     ipAddr->sin_port = htons_winsock(static_cast<u_short>(port));
     break;
   }
 
-  case kINET6: {
+  case AddressFamily::INet6: {
     struct sockaddr_in6 *ipAddr = TYPED_ADDR(struct sockaddr_in6, addr);
     ipAddr->sin6_port = htons_winsock(static_cast<u_short>(port));
     break;
@@ -796,12 +796,12 @@ int ArchNetworkWinsock::getAddrPort(ArchNetAddress addr)
   assert(addr != nullptr);
 
   switch (getAddrFamily(addr)) {
-  case kINET: {
+  case AddressFamily::INet: {
     struct sockaddr_in *ipAddr = TYPED_ADDR(struct sockaddr_in, addr);
     return ntohs_winsock(ipAddr->sin_port);
   }
 
-  case kINET6: {
+  case AddressFamily::INet6: {
     struct sockaddr_in6 *ipAddr = TYPED_ADDR(struct sockaddr_in6, addr);
     return ntohs_winsock(ipAddr->sin6_port);
   }
@@ -817,12 +817,12 @@ bool ArchNetworkWinsock::isAnyAddr(ArchNetAddress addr)
   assert(addr != nullptr);
 
   switch (getAddrFamily(addr)) {
-  case kINET: {
+  case AddressFamily::INet: {
     struct sockaddr_in *ipAddr = TYPED_ADDR(struct sockaddr_in, addr);
     return (addr->m_len == sizeof(struct sockaddr_in) && ipAddr->sin_addr.s_addr == INADDR_ANY);
   }
 
-  case kINET6: {
+  case AddressFamily::INet6: {
     struct sockaddr_in6 *ipAddr = TYPED_ADDR(struct sockaddr_in6, addr);
     return (
         addr->m_len == sizeof(struct sockaddr_in) && memcmp(&ipAddr->sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -840,7 +840,7 @@ bool ArchNetworkWinsock::isEqualAddr(ArchNetAddress a, ArchNetAddress b)
   return (a == b || (a->m_len == b->m_len && memcmp(&a->m_addr, &b->m_addr, a->m_len) == 0));
 }
 
-void ArchNetworkWinsock::throwError(int err)
+[[noreturn]] void ArchNetworkWinsock::throwError(int err) const
 {
   switch (err) {
   case WSAEACCES:
@@ -910,7 +910,7 @@ void ArchNetworkWinsock::throwError(int err)
   }
 }
 
-void ArchNetworkWinsock::throwNameError(int err)
+[[noreturn]] void ArchNetworkWinsock::throwNameError(int err) const
 {
   switch (err) {
   case WSAHOST_NOT_FOUND:

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -192,10 +192,10 @@ void ArchNetworkWinsock::initModule(HMODULE module)
   s_networkModule = module;
 }
 
-ArchSocket ArchNetworkWinsock::newSocket(AddressFamily family, ESocketType type)
+ArchSocket ArchNetworkWinsock::newSocket(AddressFamily family, SocketType type)
 {
   // create socket
-  SOCKET fd = socket_winsock(s_family[static_cast<int>(family)], s_type[type], 0);
+  SOCKET fd = socket_winsock(s_family[static_cast<int>(family)], s_type[static_cast<int>(type)], 0);
   if (fd == INVALID_SOCKET) {
     throwError(getsockerror_winsock());
   }

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -380,16 +380,16 @@ int ArchNetworkWinsock::pollSocket(PollEntry pe[], int num, double timeout)
 
     // set invalid flag if socket is bogus then go to next socket
     if (pe[i].m_socket == nullptr) {
-      pe[i].m_revents |= kPOLLNVAL;
+      pe[i].m_revents |= PollEventMask::Invalid;
       continue;
     }
 
     // select desired events
     long socketEvents = 0;
-    if ((pe[i].m_events & kPOLLIN) != 0) {
+    if ((pe[i].m_events & PollEventMask::In) != 0) {
       socketEvents |= FD_READ | FD_ACCEPT | FD_CLOSE;
     }
-    if ((pe[i].m_events & kPOLLOUT) != 0) {
+    if ((pe[i].m_events & PollEventMask::Out) != 0) {
       socketEvents |= FD_WRITE | FD_CONNECT | FD_CLOSE;
 
       // if m_pollWrite is false then we assume the socket is
@@ -397,7 +397,7 @@ int ArchNetworkWinsock::pollSocket(PollEntry pe[], int num, double timeout)
       // when the state changes from unwritable.
       if (!pe[i].m_socket->m_pollWrite) {
         canWrite = true;
-        pe[i].m_revents |= kPOLLOUT;
+        pe[i].m_revents |= PollEventMask::Out;
       }
     }
 
@@ -462,7 +462,7 @@ int ArchNetworkWinsock::pollSocket(PollEntry pe[], int num, double timeout)
   }
   for (i = 0, n = 0; i < num; ++i) {
     // skip events we didn't check
-    if (pe[i].m_socket == nullptr || (pe[i].m_events & (kPOLLIN | kPOLLOUT)) == 0) {
+    if (pe[i].m_socket == nullptr || (pe[i].m_events & (PollEventMask::In | PollEventMask::Out)) == 0) {
       continue;
     }
 
@@ -472,13 +472,13 @@ int ArchNetworkWinsock::pollSocket(PollEntry pe[], int num, double timeout)
       continue;
     }
     if ((info.lNetworkEvents & FD_READ) != 0) {
-      pe[i].m_revents |= kPOLLIN;
+      pe[i].m_revents |= PollEventMask::In;
     }
     if ((info.lNetworkEvents & FD_ACCEPT) != 0) {
-      pe[i].m_revents |= kPOLLIN;
+      pe[i].m_revents |= PollEventMask::In;
     }
     if ((info.lNetworkEvents & FD_WRITE) != 0) {
-      pe[i].m_revents |= kPOLLOUT;
+      pe[i].m_revents |= PollEventMask::Out;
 
       // socket is now writable so don't bothing polling for
       // writable until it becomes unwritable.
@@ -486,21 +486,21 @@ int ArchNetworkWinsock::pollSocket(PollEntry pe[], int num, double timeout)
     }
     if ((info.lNetworkEvents & FD_CONNECT) != 0) {
       if (info.iErrorCode[FD_CONNECT_BIT] != 0) {
-        pe[i].m_revents |= kPOLLERR;
+        pe[i].m_revents |= PollEventMask::Error;
       } else {
-        pe[i].m_revents |= kPOLLOUT;
+        pe[i].m_revents |= PollEventMask::Out;
         pe[i].m_socket->m_pollWrite = false;
       }
     }
     if ((info.lNetworkEvents & FD_CLOSE) != 0) {
       if (info.iErrorCode[FD_CLOSE_BIT] != 0) {
-        pe[i].m_revents |= kPOLLERR;
+        pe[i].m_revents |= PollEventMask::Error;
       } else {
-        if ((pe[i].m_events & kPOLLIN) != 0) {
-          pe[i].m_revents |= kPOLLIN;
+        if ((pe[i].m_events & PollEventMask::In) != 0) {
+          pe[i].m_revents |= PollEventMask::In;
         }
-        if ((pe[i].m_events & kPOLLOUT) != 0) {
-          pe[i].m_revents |= kPOLLOUT;
+        if ((pe[i].m_events & PollEventMask::Out) != 0) {
+          pe[i].m_revents |= PollEventMask::Out;
         }
       }
     }

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -58,7 +58,7 @@ public:
   void init() override;
 
   // IArchNetwork overrides
-  ArchSocket newSocket(AddressFamily, ESocketType) override;
+  ArchSocket newSocket(AddressFamily, SocketType) override;
   ArchSocket copySocket(ArchSocket s) override;
   void closeSocket(ArchSocket s) override;
   void closeSocketForRead(ArchSocket s) override;

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -92,10 +92,9 @@ private:
 
   void setBlockingOnSocket(SOCKET, bool blocking);
 
-  void throwError(int);
-  void throwNameError(int);
+  [[noreturn]] void throwError(int) const override;
+  [[noreturn]] void throwNameError(int) const override;
 
-private:
   using EventList = std::list<WSAEVENT>;
 
   std::mutex m_mutex;

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -58,7 +58,7 @@ public:
   void init() override;
 
   // IArchNetwork overrides
-  ArchSocket newSocket(EAddressFamily, ESocketType) override;
+  ArchSocket newSocket(AddressFamily, ESocketType) override;
   ArchSocket copySocket(ArchSocket s) override;
   void closeSocket(ArchSocket s) override;
   void closeSocketForRead(ArchSocket s) override;
@@ -75,13 +75,13 @@ public:
   bool setNoDelayOnSocket(ArchSocket, bool noDelay) override;
   bool setReuseAddrOnSocket(ArchSocket, bool reuse) override;
   std::string getHostName() override;
-  ArchNetAddress newAnyAddr(EAddressFamily) override;
+  ArchNetAddress newAnyAddr(AddressFamily) override;
   ArchNetAddress copyAddr(ArchNetAddress) override;
   std::vector<ArchNetAddress> nameToAddr(const std::string &) override;
   void closeAddr(ArchNetAddress) override;
   std::string addrToName(ArchNetAddress) override;
   std::string addrToString(ArchNetAddress) override;
-  EAddressFamily getAddrFamily(ArchNetAddress) override;
+  AddressFamily getAddrFamily(ArchNetAddress) override;
   void setAddrPort(ArchNetAddress, int port) override;
   int getAddrPort(ArchNetAddress) override;
   bool isAnyAddr(ArchNetAddress) override;

--- a/src/lib/base/Event.cpp
+++ b/src/lib/base/Event.cpp
@@ -55,10 +55,11 @@ Event::Flags Event::getFlags() const
 void Event::deleteData(const Event &event)
 {
   switch (event.getType()) {
-  case EventTypes::Unknown:
-  case EventTypes::Quit:
-  case EventTypes::System:
-  case EventTypes::Timer:
+    using enum EventTypes;
+  case Unknown:
+  case Quit:
+  case System:
+  case Timer:
     break;
 
   default:

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -17,7 +17,7 @@
 #include <stdexcept>
 
 // interrupt handler.  this just adds a quit event to the queue.
-static void interrupt(Arch::ESignal, void *data)
+static void interrupt(Arch::ThreadSignal, void *data)
 {
   auto *events = static_cast<EventQueue *>(data);
   events->addEvent(Event(EventTypes::Quit));
@@ -29,8 +29,8 @@ static void interrupt(Arch::ESignal, void *data)
 
 EventQueue::EventQueue() : m_readyMutex(new Mutex), m_readyCondVar(new CondVar<bool>(m_readyMutex, false))
 {
-  ARCH->setSignalHandler(Arch::kINTERRUPT, &interrupt, this);
-  ARCH->setSignalHandler(Arch::kTERMINATE, &interrupt, this);
+  ARCH->setSignalHandler(Arch::ThreadSignal::Interrupt, &interrupt, this);
+  ARCH->setSignalHandler(Arch::ThreadSignal::Terminate, &interrupt, this);
   m_buffer = std::make_unique<SimpleEventQueueBuffer>();
 }
 
@@ -39,8 +39,8 @@ EventQueue::~EventQueue()
   delete m_readyCondVar;
   delete m_readyMutex;
 
-  ARCH->setSignalHandler(Arch::kINTERRUPT, nullptr, nullptr);
-  ARCH->setSignalHandler(Arch::kTERMINATE, nullptr, nullptr);
+  ARCH->setSignalHandler(Arch::ThreadSignal::Interrupt, nullptr, nullptr);
+  ARCH->setSignalHandler(Arch::ThreadSignal::Terminate, nullptr, nullptr);
 }
 
 void EventQueue::loop()

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -468,12 +468,13 @@ void Client::cleanupConnecting()
 void Client::cleanupConnection()
 {
   if (m_stream != nullptr) {
-    m_events->removeHandler(EventTypes::StreamInputReady, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamOutputError, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamInputShutdown, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamOutputShutdown, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::SocketDisconnected, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::SocketStopRetry, m_stream->getEventTarget());
+    using enum EventTypes;
+    m_events->removeHandler(StreamInputReady, m_stream->getEventTarget());
+    m_events->removeHandler(StreamOutputError, m_stream->getEventTarget());
+    m_events->removeHandler(StreamInputShutdown, m_stream->getEventTarget());
+    m_events->removeHandler(StreamOutputShutdown, m_stream->getEventTarget());
+    m_events->removeHandler(SocketDisconnected, m_stream->getEventTarget());
+    m_events->removeHandler(SocketStopRetry, m_stream->getEventTarget());
     cleanupStream();
   }
 }

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -318,11 +318,11 @@ void ClientApp::closeClient(Client *client)
   if (client == nullptr) {
     return;
   }
-
-  m_events->removeHandler(EventTypes::ClientConnected, client);
-  m_events->removeHandler(EventTypes::ClientConnectionFailed, client);
-  m_events->removeHandler(EventTypes::ClientConnectionRefused, client);
-  m_events->removeHandler(EventTypes::ClientDisconnected, client);
+  using enum EventTypes;
+  m_events->removeHandler(ClientConnected, client);
+  m_events->removeHandler(ClientConnectionFailed, client);
+  m_events->removeHandler(ClientConnectionRefused, client);
+  m_events->removeHandler(ClientDisconnected, client);
   delete client;
 }
 

--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -708,20 +708,21 @@ void KeyState::sendKeyEvent(
     void *target, bool press, bool isAutoRepeat, KeyID key, KeyModifierMask mask, int32_t count, KeyButton button
 )
 {
+  using enum EventTypes;
   if (m_keyMap.isHalfDuplex(key, button)) {
     if (isAutoRepeat) {
       // ignore auto-repeat on half-duplex keys
     } else {
-      m_events->addEvent(Event(EventTypes::KeyStateKeyDown, target, KeyInfo::alloc(key, mask, button, 1)));
-      m_events->addEvent(Event(EventTypes::KeyStateKeyUp, target, KeyInfo::alloc(key, mask, button, 1)));
+      m_events->addEvent(Event(KeyStateKeyDown, target, KeyInfo::alloc(key, mask, button, 1)));
+      m_events->addEvent(Event(KeyStateKeyUp, target, KeyInfo::alloc(key, mask, button, 1)));
     }
   } else {
     if (isAutoRepeat) {
-      m_events->addEvent(Event(EventTypes::KeyStateKeyRepeat, target, KeyInfo::alloc(key, mask, button, count)));
+      m_events->addEvent(Event(KeyStateKeyRepeat, target, KeyInfo::alloc(key, mask, button, count)));
     } else if (press) {
-      m_events->addEvent(Event(EventTypes::KeyStateKeyDown, target, KeyInfo::alloc(key, mask, button, 1)));
+      m_events->addEvent(Event(KeyStateKeyDown, target, KeyInfo::alloc(key, mask, button, 1)));
     } else {
-      m_events->addEvent(Event(EventTypes::KeyStateKeyUp, target, KeyInfo::alloc(key, mask, button, 1)));
+      m_events->addEvent(Event(KeyStateKeyUp, target, KeyInfo::alloc(key, mask, button, 1)));
     }
   }
 }

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -285,9 +285,10 @@ void ServerApp::closePrimaryClient(PrimaryClient *primaryClient)
 void ServerApp::closeServerScreen(deskflow::Screen *screen)
 {
   if (screen != nullptr) {
-    m_events->removeHandler(EventTypes::ScreenError, screen->getEventTarget());
-    m_events->removeHandler(EventTypes::ScreenSuspend, screen->getEventTarget());
-    m_events->removeHandler(EventTypes::ScreenResume, screen->getEventTarget());
+    using enum EventTypes;
+    m_events->removeHandler(ScreenError, screen->getEventTarget());
+    m_events->removeHandler(ScreenSuspend, screen->getEventTarget());
+    m_events->removeHandler(ScreenResume, screen->getEventTarget());
     delete screen;
   }
 }
@@ -535,8 +536,8 @@ void ServerApp::handleResume()
 
 ClientListener *ServerApp::openClientListener(const NetworkAddress &address)
 {
-  auto securityLevel = args().m_enableCrypto ? args().m_chkPeerCert ? SecurityLevel::PeerAuth : SecurityLevel::Encrypted
-                                             : SecurityLevel::PlainText;
+  using enum SecurityLevel;
+  auto securityLevel = args().m_enableCrypto ? args().m_chkPeerCert ? PeerAuth : Encrypted : PlainText;
 
   auto *listen = new ClientListener(getAddress(address), getSocketFactory(), m_events, securityLevel);
 

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -537,7 +537,14 @@ void ServerApp::handleResume()
 ClientListener *ServerApp::openClientListener(const NetworkAddress &address)
 {
   using enum SecurityLevel;
-  auto securityLevel = args().m_enableCrypto ? args().m_chkPeerCert ? PeerAuth : Encrypted : PlainText;
+  auto securityLevel = PlainText;
+  if (args().m_enableCrypto) {
+    if (args().m_chkPeerCert) {
+      securityLevel = PeerAuth;
+    } else {
+      securityLevel = Encrypted;
+    }
+  }
 
   auto *listen = new ClientListener(getAddress(address), getSocketFactory(), m_events, securityLevel);
 

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -140,7 +140,7 @@ void ServerApp::help()
   LOG((CLOG_PRINT "%s", help.str().c_str()));
 }
 
-void ServerApp::reloadSignalHandler(Arch::ESignal, void *)
+void ServerApp::reloadSignalHandler(Arch::ThreadSignal, void *)
 {
   IEventQueue *events = App::instance().getEvents();
   events->addEvent(Event(EventTypes::ServerAppReloadConfig, events->getSystemTarget()));
@@ -608,7 +608,7 @@ int ServerApp::mainLoop()
   appUtil().startNode();
 
   // handle hangup signal by reloading the server's configuration
-  ARCH->setSignalHandler(Arch::kHANGUP, &reloadSignalHandler, nullptr);
+  ARCH->setSignalHandler(Arch::ThreadSignal::Hangup, &reloadSignalHandler, nullptr);
   m_events->addHandler(EventTypes::ServerAppReloadConfig, m_events->getSystemTarget(), [this](const auto &) {
     reloadConfig();
   });

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -118,7 +118,7 @@ public:
   // Static functions
   //
 
-  static void reloadSignalHandler(Arch::ESignal, void *);
+  static void reloadSignalHandler(Arch::ThreadSignal, void *);
   static ServerApp &instance()
   {
     return (ServerApp &)App::instance();

--- a/src/lib/net/Fingerprint.cpp
+++ b/src/lib/net/Fingerprint.cpp
@@ -12,11 +12,12 @@
 bool Fingerprint::isValid() const
 {
   switch (type) {
-  case Fingerprint::Type::Invalid:
+    using enum Type;
+  case Invalid:
     return false;
-  case Fingerprint::Type::SHA1:
+  case SHA1:
     return data.length() == 20;
-  case Fingerprint::Type::SHA256:
+  case SHA256:
     return data.length() == 32;
   default:
     return false;
@@ -68,12 +69,13 @@ Fingerprint Fingerprint::fromDbLine(const QString &line)
 
 Fingerprint::Type Fingerprint::typeFromString(const QString &type)
 {
+  using enum Type;
   const auto t = type.toLower();
   if (t == m_type_sha1)
-    return Type::SHA1;
+    return SHA1;
   if (t == m_type_sha256)
-    return Type::SHA256;
-  return Type::Invalid;
+    return SHA256;
+  return Invalid;
 }
 
 QString Fingerprint::typeToString(Fingerprint::Type type)

--- a/src/lib/net/ISocketFactory.h
+++ b/src/lib/net/ISocketFactory.h
@@ -28,12 +28,14 @@ public:
 
   //! Create data socket
   virtual IDataSocket *create(
-      IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
+      IArchNetwork::AddressFamily family = IArchNetwork::AddressFamily::INet,
+      SecurityLevel securityLevel = SecurityLevel::PlainText
   ) const = 0;
 
   //! Create listen socket
   virtual IListenSocket *createListen(
-      IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
+      IArchNetwork::AddressFamily family = IArchNetwork::AddressFamily::INet,
+      SecurityLevel securityLevel = SecurityLevel::PlainText
   ) const = 0;
 
   //@}

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -23,7 +23,7 @@
 NetworkAddress::NetworkAddress(int port) : m_port(port)
 {
   checkPort();
-  m_address = ARCH->newAnyAddr(IArchNetwork::kINET);
+  m_address = ARCH->newAnyAddr(IArchNetwork::AddressFamily::INet);
   ARCH->setAddrPort(m_address, m_port);
 }
 
@@ -125,7 +125,7 @@ size_t NetworkAddress::resolve(size_t index)
     // if hostname is empty then use wildcard address otherwise look
     // up the name.
     if (m_hostname.empty()) {
-      m_address = ARCH->newAnyAddr(IArchNetwork::kINET);
+      m_address = ARCH->newAnyAddr(IArchNetwork::AddressFamily::INet);
       resolvedAddressesCount = 1;
     } else {
       // Logic for temporary filtring only ipv4 addresses
@@ -133,7 +133,7 @@ size_t NetworkAddress::resolve(size_t index)
       {
         auto addresses = ARCH->nameToAddr(m_hostname);
         for (auto address : addresses) {
-          if (ARCH->getAddrFamily(address) == IArchNetwork::kINET) {
+          if (ARCH->getAddrFamily(address) == IArchNetwork::AddressFamily::INet) {
             ipv4OnlyAddresses.emplace_back(address);
           } else {
             ARCH->closeAddr(address);

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -22,7 +22,7 @@
 //
 
 SecureListenSocket::SecureListenSocket(
-    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family,
+    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family,
     SecurityLevel securityLevel
 )
     : TCPListenSocket(events, socketMultiplexer, family),

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -20,7 +20,7 @@ class SecureListenSocket : public TCPListenSocket
 {
 public:
   SecureListenSocket(
-      IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family,
+      IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family,
       SecurityLevel securityLevel = SecurityLevel::PlainText
   );
 

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -626,9 +626,10 @@ void SecureSocket::checkResult(int status, int &retry)
 
 void SecureSocket::disconnect()
 {
-  sendEvent(EventTypes::SocketStopRetry);
-  sendEvent(EventTypes::SocketDisconnected);
-  sendEvent(EventTypes::StreamInputShutdown);
+  using enum EventTypes;
+  sendEvent(SocketStopRetry);
+  sendEvent(SocketDisconnected);
+  sendEvent(StreamInputShutdown);
 }
 
 bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath) const

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -55,7 +55,7 @@ static int verifyIgnoreCertCallback(X509_STORE_CTX *, void *)
 }
 
 SecureSocket::SecureSocket(
-    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family,
+    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family,
     SecurityLevel securityLevel
 )
     : TCPSocket(events, socketMultiplexer, family),

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -30,7 +30,7 @@ class SecureSocket : public TCPSocket
 {
 public:
   SecureSocket(
-      IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family,
+      IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family,
       SecurityLevel securityLevel = SecurityLevel::Encrypted
   );
   SecureSocket(

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -152,10 +152,10 @@ void SocketMultiplexer::serviceThread(void *)
           pfd.m_socket = job->getSocket();
           pfd.m_events = 0;
           if (job->isReadable()) {
-            pfd.m_events |= IArchNetwork::kPOLLIN;
+            pfd.m_events |= IArchNetwork::PollEventMask::In;
           }
           if (job->isWritable()) {
-            pfd.m_events |= IArchNetwork::kPOLLOUT;
+            pfd.m_events |= IArchNetwork::PollEventMask::Out;
           }
           pfds.push_back(pfd);
         }
@@ -187,9 +187,10 @@ void SocketMultiplexer::serviceThread(void *)
         if (*jobCursor != nullptr) {
           // get poll state
           unsigned short revents = pfds[i].m_revents;
-          bool read = ((revents & IArchNetwork::kPOLLIN) != 0);
-          bool write = ((revents & IArchNetwork::kPOLLOUT) != 0);
-          bool error = ((revents & (IArchNetwork::kPOLLERR | IArchNetwork::kPOLLNVAL)) != 0);
+          bool read = ((revents & int(IArchNetwork::PollEventMask::In)) != 0);
+          bool write = ((revents & int(IArchNetwork::PollEventMask::Out)) != 0);
+          bool error =
+              ((revents & (int(IArchNetwork::PollEventMask::Error) | int(IArchNetwork::PollEventMask::Invalid))) != 0);
 
           // run job
           ISocketMultiplexerJob *job = *jobCursor;

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -29,7 +29,7 @@ TCPListenSocket::TCPListenSocket(
       m_socketMultiplexer(socketMultiplexer)
 {
   try {
-    m_socket = ARCH->newSocket(family, IArchNetwork::kSTREAM);
+    m_socket = ARCH->newSocket(family, IArchNetwork::SocketType::Stream);
   } catch (XArchNetwork &e) {
     throw XSocketCreate(e.what());
   }

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -23,7 +23,7 @@
 //
 
 TCPListenSocket::TCPListenSocket(
-    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family
+    IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family
 )
     : m_events(events),
       m_socketMultiplexer(socketMultiplexer)

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -23,7 +23,7 @@ A listen socket using TCP.
 class TCPListenSocket : public IListenSocket
 {
 public:
-  TCPListenSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family);
+  TCPListenSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family);
   TCPListenSocket(TCPListenSocket const &) = delete;
   TCPListenSocket(TCPListenSocket &&) = delete;
   ~TCPListenSocket() override;

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -27,7 +27,7 @@ static const std::size_t MAX_INPUT_BUFFER_SIZE = 1024 * 1024;
 // TCPSocket
 //
 
-TCPSocket::TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::EAddressFamily family)
+TCPSocket::TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, IArchNetwork::AddressFamily family)
     : IDataSocket(events),
       m_events(events),
       m_flushed(&m_mutex, true),

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -34,7 +34,7 @@ TCPSocket::TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, 
       m_socketMultiplexer(socketMultiplexer)
 {
   try {
-    m_socket = ARCH->newSocket(family, IArchNetwork::kSTREAM);
+    m_socket = ARCH->newSocket(family, IArchNetwork::SocketType::Stream);
   } catch (const XArchNetwork &e) {
     throw XSocketCreate(e.what());
   }

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -28,7 +28,7 @@ class TCPSocket : public IDataSocket
 public:
   TCPSocket(
       IEventQueue *events, SocketMultiplexer *socketMultiplexer,
-      IArchNetwork::EAddressFamily family = IArchNetwork::kINET
+      IArchNetwork::AddressFamily family = IArchNetwork::AddressFamily::INet
   );
   TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, ArchSocket socket);
   TCPSocket(TCPSocket const &) = delete;

--- a/src/lib/net/TCPSocketFactory.cpp
+++ b/src/lib/net/TCPSocketFactory.cpp
@@ -25,7 +25,7 @@ TCPSocketFactory::TCPSocketFactory(IEventQueue *events, SocketMultiplexer *socke
   // do nothing
 }
 
-IDataSocket *TCPSocketFactory::create(IArchNetwork::EAddressFamily family, SecurityLevel securityLevel) const
+IDataSocket *TCPSocketFactory::create(IArchNetwork::AddressFamily family, SecurityLevel securityLevel) const
 {
   if (securityLevel != SecurityLevel::PlainText) {
     auto *secureSocket = new SecureSocket(m_events, m_socketMultiplexer, family, securityLevel);
@@ -36,7 +36,7 @@ IDataSocket *TCPSocketFactory::create(IArchNetwork::EAddressFamily family, Secur
   }
 }
 
-IListenSocket *TCPSocketFactory::createListen(IArchNetwork::EAddressFamily family, SecurityLevel securityLevel) const
+IListenSocket *TCPSocketFactory::createListen(IArchNetwork::AddressFamily family, SecurityLevel securityLevel) const
 {
   IListenSocket *socket = nullptr;
   if (securityLevel != SecurityLevel::PlainText) {

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -23,10 +23,12 @@ public:
 
   // ISocketFactory overrides
   IDataSocket *create(
-      IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
+      IArchNetwork::AddressFamily family = IArchNetwork::AddressFamily::INet,
+      SecurityLevel securityLevel = SecurityLevel::PlainText
   ) const override;
   IListenSocket *createListen(
-      IArchNetwork::EAddressFamily family = IArchNetwork::kINET, SecurityLevel securityLevel = SecurityLevel::PlainText
+      IArchNetwork::AddressFamily family = IArchNetwork::AddressFamily::INet,
+      SecurityLevel securityLevel = SecurityLevel::PlainText
   ) const override;
 
 private:

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1477,17 +1477,18 @@ void XWindowsScreen::onMousePress(const XButtonEvent &xbutton)
 
 void XWindowsScreen::onMouseRelease(const XButtonEvent &xbutton)
 {
+  using enum EventTypes;
   LOG((CLOG_DEBUG1 "event: ButtonRelease button=%d", xbutton.button));
   ButtonID button = mapButtonFromX(&xbutton);
   KeyModifierMask mask = m_keyState->mapModifiersFromX(xbutton.state);
   if (button != kButtonNone) {
-    sendEvent(EventTypes::PrimaryScreenButtonUp, ButtonInfo::alloc(button, mask));
+    sendEvent(PrimaryScreenButtonUp, ButtonInfo::alloc(button, mask));
   } else if (xbutton.button == 4) {
     // wheel forward (away from user)
-    sendEvent(EventTypes::PrimaryScreenWheel, WheelInfo::alloc(0, 120));
+    sendEvent(PrimaryScreenWheel, WheelInfo::alloc(0, 120));
   } else if (xbutton.button == 5) {
     // wheel backward (toward user)
-    sendEvent(EventTypes::PrimaryScreenWheel, WheelInfo::alloc(0, -120));
+    sendEvent(PrimaryScreenWheel, WheelInfo::alloc(0, -120));
   }
   // XXX -- support x-axis scrolling
 }

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -87,14 +87,15 @@ void ClientListener::start()
 
 void ClientListener::stop()
 {
+  using enum EventTypes;
   LOG((CLOG_DEBUG1 "stop listening for clients"));
 
   // discard already connected clients
   for (auto index = m_newClients.begin(); index != m_newClients.end(); ++index) {
     ClientProxyUnknown *client = *index;
-    m_events->removeHandler(EventTypes::ClientProxyUnknownSuccess, client);
-    m_events->removeHandler(EventTypes::ClientProxyUnknownFailure, client);
-    m_events->removeHandler(EventTypes::ClientProxyDisconnected, client);
+    m_events->removeHandler(ClientProxyUnknownSuccess, client);
+    m_events->removeHandler(ClientProxyUnknownFailure, client);
+    m_events->removeHandler(ClientProxyDisconnected, client);
     delete client;
   }
 
@@ -105,7 +106,7 @@ void ClientListener::stop()
     client = getNextClient();
   }
 
-  m_events->removeHandler(EventTypes::ListenSocketConnecting, m_listen);
+  m_events->removeHandler(ListenSocketConnecting, m_listen);
   cleanupListenSocket();
   cleanupClientSockets();
 }

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -61,13 +61,14 @@ void ClientProxy1_0::disconnect()
 
 void ClientProxy1_0::removeHandlers()
 {
+  using enum EventTypes;
   // uninstall event handlers
-  m_events->removeHandler(EventTypes::StreamInputReady, getStream()->getEventTarget());
-  m_events->removeHandler(EventTypes::StreamOutputError, getStream()->getEventTarget());
-  m_events->removeHandler(EventTypes::StreamInputShutdown, getStream()->getEventTarget());
-  m_events->removeHandler(EventTypes::StreamOutputShutdown, getStream()->getEventTarget());
-  m_events->removeHandler(EventTypes::StreamInputFormatError, getStream()->getEventTarget());
-  m_events->removeHandler(EventTypes::Timer, this);
+  m_events->removeHandler(StreamInputReady, getStream()->getEventTarget());
+  m_events->removeHandler(StreamOutputError, getStream()->getEventTarget());
+  m_events->removeHandler(StreamInputShutdown, getStream()->getEventTarget());
+  m_events->removeHandler(StreamOutputShutdown, getStream()->getEventTarget());
+  m_events->removeHandler(StreamInputFormatError, getStream()->getEventTarget());
+  m_events->removeHandler(Timer, this);
 
   // remove timer
   removeHeartbeatTimer();

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -119,16 +119,17 @@ void ClientProxyUnknown::addProxyHandlers()
 
 void ClientProxyUnknown::removeHandlers()
 {
+  using enum EventTypes;
   if (m_stream != nullptr) {
-    m_events->removeHandler(EventTypes::StreamInputReady, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamOutputError, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamInputShutdown, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamInputFormatError, m_stream->getEventTarget());
-    m_events->removeHandler(EventTypes::StreamOutputShutdown, m_stream->getEventTarget());
+    m_events->removeHandler(StreamInputReady, m_stream->getEventTarget());
+    m_events->removeHandler(StreamOutputError, m_stream->getEventTarget());
+    m_events->removeHandler(StreamInputShutdown, m_stream->getEventTarget());
+    m_events->removeHandler(StreamInputFormatError, m_stream->getEventTarget());
+    m_events->removeHandler(StreamOutputShutdown, m_stream->getEventTarget());
   }
   if (m_proxy != nullptr) {
-    m_events->removeHandler(EventTypes::ClientProxyReady, m_proxy);
-    m_events->removeHandler(EventTypes::ClientProxyDisconnected, m_proxy);
+    m_events->removeHandler(ClientProxyReady, m_proxy);
+    m_events->removeHandler(ClientProxyDisconnected, m_proxy);
   }
 }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -142,19 +142,20 @@ Server::Server(
 Server::~Server()
 {
   // remove event handlers and timers
-  m_events->removeHandler(EventTypes::KeyStateKeyDown, m_inputFilter);
-  m_events->removeHandler(EventTypes::KeyStateKeyUp, m_inputFilter);
-  m_events->removeHandler(EventTypes::KeyStateKeyRepeat, m_inputFilter);
-  m_events->removeHandler(EventTypes::PrimaryScreenButtonDown, m_inputFilter);
-  m_events->removeHandler(EventTypes::PrimaryScreenButtonUp, m_inputFilter);
-  m_events->removeHandler(EventTypes::PrimaryScreenMotionOnPrimary, m_primaryClient->getEventTarget());
-  m_events->removeHandler(EventTypes::PrimaryScreenMotionOnSecondary, m_primaryClient->getEventTarget());
-  m_events->removeHandler(EventTypes::PrimaryScreenWheel, m_primaryClient->getEventTarget());
-  m_events->removeHandler(EventTypes::PrimaryScreenSaverActivated, m_primaryClient->getEventTarget());
-  m_events->removeHandler(EventTypes::PrimaryScreenSaverDeactivated, m_primaryClient->getEventTarget());
-  m_events->removeHandler(EventTypes::PrimaryScreenFakeInputBegin, m_inputFilter);
-  m_events->removeHandler(EventTypes::PrimaryScreenFakeInputEnd, m_inputFilter);
-  m_events->removeHandler(EventTypes::Timer, this);
+  using enum EventTypes;
+  m_events->removeHandler(KeyStateKeyDown, m_inputFilter);
+  m_events->removeHandler(KeyStateKeyUp, m_inputFilter);
+  m_events->removeHandler(KeyStateKeyRepeat, m_inputFilter);
+  m_events->removeHandler(PrimaryScreenButtonDown, m_inputFilter);
+  m_events->removeHandler(PrimaryScreenButtonUp, m_inputFilter);
+  m_events->removeHandler(PrimaryScreenMotionOnPrimary, m_primaryClient->getEventTarget());
+  m_events->removeHandler(PrimaryScreenMotionOnSecondary, m_primaryClient->getEventTarget());
+  m_events->removeHandler(PrimaryScreenWheel, m_primaryClient->getEventTarget());
+  m_events->removeHandler(PrimaryScreenSaverActivated, m_primaryClient->getEventTarget());
+  m_events->removeHandler(PrimaryScreenSaverDeactivated, m_primaryClient->getEventTarget());
+  m_events->removeHandler(PrimaryScreenFakeInputBegin, m_inputFilter);
+  m_events->removeHandler(PrimaryScreenFakeInputEnd, m_inputFilter);
+  m_events->removeHandler(Timer, this);
   stopSwitch();
 
   try {
@@ -167,8 +168,8 @@ Server::~Server()
   for (auto index = m_oldClients.begin(); index != m_oldClients.end(); ++index) {
     BaseClientProxy *client = index->first;
     m_events->deleteTimer(index->second);
-    m_events->removeHandler(EventTypes::Timer, client);
-    m_events->removeHandler(EventTypes::ClientProxyDisconnected, client);
+    m_events->removeHandler(Timer, client);
+    m_events->removeHandler(ClientProxyDisconnected, client);
     delete client;
   }
 
@@ -1873,6 +1874,7 @@ bool Server::addClient(BaseClientProxy *client)
 
 bool Server::removeClient(BaseClientProxy *client)
 {
+  using enum EventTypes;
   // return false if not in list
   ClientSet::iterator i = m_clientSet.find(client);
   if (i == m_clientSet.end()) {
@@ -1880,9 +1882,9 @@ bool Server::removeClient(BaseClientProxy *client)
   }
 
   // remove event handlers
-  m_events->removeHandler(EventTypes::ScreenShapeChanged, client->getEventTarget());
-  m_events->removeHandler(EventTypes::ClipboardGrabbed, client->getEventTarget());
-  m_events->removeHandler(EventTypes::ClipboardChanged, client->getEventTarget());
+  m_events->removeHandler(ScreenShapeChanged, client->getEventTarget());
+  m_events->removeHandler(ClipboardGrabbed, client->getEventTarget());
+  m_events->removeHandler(ClipboardChanged, client->getEventTarget());
 
   // remove from list
   m_clients.erase(getName(client));
@@ -1961,14 +1963,15 @@ void Server::removeActiveClient(BaseClientProxy *client)
 
 void Server::removeOldClient(BaseClientProxy *client)
 {
+  using enum EventTypes;
   OldClients::iterator i = m_oldClients.find(client);
   if (i != m_oldClients.end()) {
-    m_events->removeHandler(EventTypes::ClientProxyDisconnected, client);
-    m_events->removeHandler(EventTypes::Timer, i->second);
+    m_events->removeHandler(ClientProxyDisconnected, client);
+    m_events->removeHandler(Timer, i->second);
     m_events->deleteTimer(i->second);
     m_oldClients.erase(i);
     if (m_clients.size() == 1 && m_oldClients.empty()) {
-      m_events->addEvent(Event(EventTypes::ServerDisconnected, this));
+      m_events->addEvent(Event(ServerDisconnected, this));
     }
   }
 }

--- a/src/unittests/legacytests/legacytests/arch/unix/ArchNetworkBSDTests.cpp
+++ b/src/unittests/legacytests/legacytests/arch/unix/ArchNetworkBSDTests.cpp
@@ -186,7 +186,7 @@ TEST(ArchNetworkBSDTests, isAnyAddr_goodAddress_returnsTrue)
   auto deps = MockDeps::makeNice();
   ArchNetworkBSD networkBSD(deps);
   std::unique_ptr<ArchNetAddressImpl> addr;
-  addr.reset(networkBSD.newAnyAddr(IArchNetwork::kINET6));
+  addr.reset(networkBSD.newAnyAddr(IArchNetwork::AddressFamily::INet6));
 
   auto result = networkBSD.isAnyAddr(addr.get());
 
@@ -198,7 +198,7 @@ TEST(ArchNetworkBSDTests, isAnyAddr_badAddress_returnsFalse)
   auto deps = MockDeps::makeNice();
   ArchNetworkBSD networkBSD(deps);
   std::unique_ptr<ArchNetAddressImpl> addr;
-  addr.reset(networkBSD.newAnyAddr(IArchNetwork::kINET6));
+  addr.reset(networkBSD.newAnyAddr(IArchNetwork::AddressFamily::INet6));
   auto scratch = (char *)&addr->m_addr;
   std::string badAddr = "badaddr";
   std::ranges::copy(badAddr, scratch + 2);

--- a/src/unittests/legacytests/legacytests/arch/unix/ArchNetworkBSDTests.cpp
+++ b/src/unittests/legacytests/legacytests/arch/unix/ArchNetworkBSDTests.cpp
@@ -84,7 +84,8 @@ TEST(ArchNetworkBSDTests, pollSocket_pfdHasRevents_copiedToEntries)
 
   networkBSD.pollSocket(entries.data(), static_cast<int>(entries.size()), 1);
 
-  const auto expect = IArchNetwork::kPOLLIN | IArchNetwork::kPOLLOUT | IArchNetwork::kPOLLERR | IArchNetwork::kPOLLNVAL;
+  const auto expect = IArchNetwork::PollEventMask::In | IArchNetwork::PollEventMask::Out |
+                      IArchNetwork::PollEventMask::Error | IArchNetwork::PollEventMask::Invalid;
   EXPECT_EQ(entries[0].m_revents, expect);
 }
 
@@ -116,7 +117,7 @@ TEST(ArchNetworkBSDTests, pollSocket_eventHasPollInBit_bitWasSet)
   auto deps = MockDeps::makeNice();
   ArchNetworkBSD networkBSD(deps);
   ArchSocketImpl socket{1, 0};
-  PollEntries entries{{&socket, IArchNetwork::kPOLLIN, 0}};
+  PollEntries entries{{&socket, IArchNetwork::PollEventMask::In, 0}};
 
   networkBSD.pollSocket(entries.data(), static_cast<int>(entries.size()), 1);
 
@@ -128,7 +129,7 @@ TEST(ArchNetworkBSDTests, pollSocket_eventHasPollOutBit_bitWasSet)
   auto deps = MockDeps::makeNice();
   ArchNetworkBSD networkBSD(deps);
   ArchSocketImpl socket{1, 0};
-  PollEntries entries{{&socket, IArchNetwork::kPOLLOUT, 0}};
+  PollEntries entries{{&socket, IArchNetwork::PollEventMask::Out, 0}};
 
   networkBSD.pollSocket(entries.data(), static_cast<int>(entries.size()), 1);
 


### PR DESCRIPTION
Clean up more sonar issues 
 - `IArchMultiThread::ESignal` Make a enum class and rename to `ThreadSignal`, conform members names.
 - `IArchNetwork::EAddressFamily` make enum class and rename to `AddressFamily`, conform members names.
 - `IArchNetwork::EStreamType` make enum class and rename to `StreamType`, conform members names.
 - Anonymous enum in IArchNetwork new set of static variables, in new `PollEventMask` struct
 - Add `using enum EventTypes`  in places with 3 or more events 
 - Move `throwError` and `throwNameError` into `IArchNetwork`  
 - Make `throwError` and `throwNameError` `[[noreturn]]`