### PR TITLE
Sonar cleanup 6

### DIFF
--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -95,7 +95,6 @@ private:
   static void threadCancel(int);
   static void *threadSignalHandler(void *vrep);
 
-private:
   using ThreadList = std::list<ArchThread>;
 
   static ArchMultithreadPosix *s_instance;

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -464,8 +464,3 @@ void EventQueue::Timer::fillEvent(TimerEvent &event) const
     event.m_count = static_cast<uint32_t>((m_timeout - m_time) / m_timeout);
   }
 }
-
-bool EventQueue::Timer::operator<(const Timer &t) const
-{
-  return m_time < t.m_time;
-}

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -86,8 +86,6 @@ private:
     void *getTarget() const;
     void fillEvent(TimerEvent &) const;
 
-    bool operator<(const Timer &) const;
-
   private:
     EventQueueTimer *m_timer;
     double m_timeout;

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -76,13 +76,13 @@ public:
   }
 
   //! Swap contents with another priority queue
-  void swap(PriorityQueue<T, Container, Compare> &q)
+  void swap(PriorityQueue<T, Container, Compare> &q) noexcept
   {
     c.swap(q.c);
   }
 
   //! Swap contents with another container
-  void swap(Container &c2)
+  void swap(Container &c2) noexcept
   {
     c.swap(c2);
     std::make_heap(c.begin(), c.end(), comp);

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -29,6 +29,7 @@ public:
   // IEventQueueBuffer overrides
   void init() override
   {
+    // do nothing
   }
   void waitForEvent(double timeout) override;
   Type getEvent(Event &event, uint32_t &dataID) override;

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -630,6 +630,9 @@ uint32_t Unicode::fromUTF8(const uint8_t *&data, uint32_t &n)
       truncated = true;
       size = 1;
     }
+
+  default:
+    break;
   }
 
   // update parameters

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -441,6 +441,9 @@ KeyID ServerProxy::translateKey(KeyID id) const
     id2 = kKeyModifierIDSuper;
     side = 1;
     break;
+
+  default:
+    break;
   }
 
   if (id2 != kKeyModifierIDNull) {

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -33,7 +33,6 @@
 ServerProxy::ServerProxy(Client *client, deskflow::IStream *stream, IEventQueue *events)
     : m_client(client),
       m_stream(stream),
-      m_parser(&ServerProxy::parseHandshakeMessage),
       m_events(events)
 {
   assert(m_client != nullptr);

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -521,12 +521,12 @@ void ServerProxy::setClipboard()
   ClipboardID id;
   uint32_t seq;
 
-  int r = ClipboardChunk::assemble(m_stream, dataCached, id, seq);
+  auto r = ClipboardChunk::assemble(m_stream, dataCached, id, seq);
 
-  if (r == kStart) {
+  if (r == TransferState::Started) {
     size_t size = ClipboardChunk::getExpectedSize();
     LOG((CLOG_DEBUG "receiving clipboard %d size=%d", id, size));
-  } else if (r == kFinish) {
+  } else if (r == TransferState::Finished) {
     LOG((CLOG_DEBUG "received clipboard %d size=%d", id, dataCached.size()));
 
     // forward

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -123,7 +123,7 @@ private:
   double m_keepAliveAlarm = 0.0;
   EventQueueTimer *m_keepAliveAlarmTimer = nullptr;
 
-  MessageParser m_parser;
+  MessageParser m_parser = &ServerProxy::parseHandshakeMessage;
   IEventQueue *m_events = nullptr;
   std::string m_serverLanguage = "";
   bool m_isUserNotifiedAboutLanguageSyncError = false;

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -130,59 +130,53 @@ private:
 #else
 #define DAEMON_RUNNING(running_)
 #endif
+constexpr static auto s_helpGeneralArgs = //
+    "  -d, --debug <level>      filter out log messages with priority below level.\n"
+    "                             level may be: FATAL, ERROR, WARNING, NOTE, INFO,\n"
+    "                             DEBUG, DEBUG1, DEBUG2.\n"
+    "  -n, --name <screen-name> use screen-name instead the hostname to identify\n"
+    "                             this screen in the configuration.\n"
+    "  -1, --no-restart         do not try to restart on failure.\n"
+    "*     --restart            restart the server automatically if it fails.\n"
+    "  -l  --log <file>         write log messages to file.\n"
+    "      --enable-crypto      enable TLS encryption.\n"
+    "      --tls-cert           specify the path to the TLS certificate file.\n";
 
-#define HELP_COMMON_INFO_1                                                                                             \
-  "  -d, --debug <level>      filter out log messages with priority below "                                            \
-  "level.\n"                                                                                                           \
-  "                             level may be: FATAL, ERROR, WARNING, NOTE, "                                           \
-  "INFO,\n"                                                                                                            \
-  "                             DEBUG, DEBUG1, DEBUG2.\n"                                                              \
-  "  -n, --name <screen-name> use screen-name instead the hostname to "                                                \
-  "identify\n"                                                                                                         \
-  "                             this screen in the configuration.\n"                                                   \
-  "  -1, --no-restart         do not try to restart on failure.\n"                                                     \
-  "*     --restart            restart the server automatically if it fails.\n"                                         \
-  "  -l  --log <file>         write log messages to file.\n"                                                           \
-  "      --enable-crypto      enable TLS encryption.\n"                                                                \
-  "      --tls-cert           specify the path to the TLS certificate file.\n"
+constexpr static auto s_helpVersionArgs = //
+    "  -h, --help               display this help and exit.\n"
+    "      --version            display version information and exit.\n";
 
-#define HELP_COMMON_INFO_2                                                                                             \
-  "  -h, --help               display this help and exit.\n"                                                           \
-  "      --version            display version information and exit.\n"
-
-#define HELP_COMMON_ARGS                                                                                               \
-  " [--name <screen-name>]"                                                                                            \
-  " [--restart|--no-restart]"                                                                                          \
-  " [--debug <level>]"
+constexpr static auto s_helpCommonArgs = //
+    " [--name <screen-name>]"
+    " [--restart|--no-restart]"
+    " [--debug <level>]";
 
 // system args (windows/unix)
 #if SYSAPI_UNIX
 
 // unix daemon mode args
-#define HELP_SYS_ARGS " [--daemon|--no-daemon]"
-#define HELP_SYS_INFO                                                                                                  \
-  "  -f, --no-daemon          run in the foreground.\n"                                                                \
-  "*     --daemon             run as a daemon.\n"
+constexpr static auto s_helpSysArgs = " [--daemon|--no-daemon]";
+constexpr static auto s_helpSysInfo = //
+    "  -f, --no-daemon          run in the foreground.\n"
+    "*     --daemon             run as a daemon.\n";
 
 #elif SYSAPI_WIN32
 
 // windows args
-#define HELP_SYS_ARGS " [--service <action>] [--relaunch]"
-#define HELP_SYS_INFO                                                                                                  \
-  "      --service <action>   manage the windows service, valid options "                                              \
-  "are:\n"                                                                                                             \
-  "                             install/uninstall/start/stop\n"                                                        \
-  "      --relaunch           persistently relaunches process in current "                                             \
-  "user \n"                                                                                                            \
-  "                             session (useful for vista and upward).\n"
+constexpr static auto s_helpSysArgs = " [--service <action>] [--relaunch]";
+constexpr static auto s_helpSysInfo = //
+    "      --service <action>   manage the windows service, valid options are:\n"
+    "                             install/uninstall/start/stop\n"
+    "      --relaunch           persistently relaunches process in current user \n"
+    "                             session (useful for vista and upward).\n";
 #endif
 
 #if !defined(WINAPI_LIBEI) && WINAPI_XWINDOWS
-const auto kHelpNoWayland = "\n"
-                            "Your Linux distribution does not support Wayland EI (emulated input)\n"
-                            "which is required for Wayland support.  Please use a Linux distribution\n"
-                            "that supports Wayland EI.\n";
+constexpr static auto s_helpNoWayland = //
+    "\nYour Linux distribution does not support Wayland EI (emulated input)\n"
+    "which is required for Wayland support.  Please use a Linux distribution\n"
+    "that supports Wayland EI.\n";
 
 #else
-const auto kHelpNoWayland = "";
+constexpr static auto s_helpNoWayland = "";
 #endif

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -58,7 +58,7 @@
 #include <sstream>
 #include <stdio.h>
 
-#define RETRY_TIME 1.0
+constexpr static auto s_retryTime = 1.0;
 
 ClientApp::ClientApp(IEventQueue *events) : App(events, new deskflow::ClientArgs())
 {
@@ -252,7 +252,7 @@ void ClientApp::handleClientFailed(const Event &e)
     updateStatus(std::string("Failed to connect to server: ") + info->m_what + " Trying next address...");
     LOG((CLOG_WARN "failed to connect to server=%s, trying next address", info->m_what.c_str()));
     if (!m_suspended) {
-      scheduleClientRestart(RETRY_TIME);
+      scheduleClientRestart(s_retryTime);
     }
   } else {
     m_lastServerAddressIndex = 0;
@@ -271,7 +271,7 @@ void ClientApp::handleClientRefused(const Event &e)
   } else {
     LOG((CLOG_WARN "failed to connect to server: %s", info->m_what.c_str()));
     if (!m_suspended) {
-      scheduleClientRestart(RETRY_TIME);
+      scheduleClientRestart(s_retryTime);
     }
   }
 }
@@ -282,7 +282,7 @@ void ClientApp::handleClientDisconnected()
   if (!args().m_restartable) {
     m_events->addEvent(Event(EventTypes::Quit));
   } else if (!m_suspended) {
-    scheduleClientRestart(RETRY_TIME);
+    scheduleClientRestart(s_retryTime);
   }
   updateStatus();
 }

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -106,12 +106,12 @@ void ClientApp::help()
 #ifdef WINAPI_XWINDOWS
        << " [--display <display>]"
 #endif
-       << HELP_SYS_ARGS << HELP_COMMON_ARGS << " <server-address>"
+       << s_helpSysArgs << s_helpCommonArgs << " <server-address>"
        << "\n\n"
        << "Connect to a " << kAppName << " mouse/keyboard sharing server.\n"
        << "\n"
        << "  -a, --address <address>  local network interface address.\n"
-       << HELP_COMMON_INFO_1 << HELP_SYS_INFO << "      --yscroll <delta>    defines the vertical scrolling delta,\n"
+       << s_helpGeneralArgs << s_helpSysInfo << "      --yscroll <delta>    defines the vertical scrolling delta,\n"
        << "                             which is 120 by default.\n"
        << "      --sync-language      enable language synchronization.\n"
        << "      --invert-scroll      invert scroll direction on this\n"
@@ -120,10 +120,10 @@ void ClientApp::help()
        << "      --display <display>  when in X mode, connect to the X server\n"
        << "                             at <display>.\n"
 #endif
-       << HELP_COMMON_INFO_2 << "\n"
+       << s_helpVersionArgs << "\n"
        << "* marks defaults.\n"
 
-       << kHelpNoWayland
+       << s_helpNoWayland
 
        << "\n"
        << "The server address is of the form: [<hostname>][:<port>].\n"

--- a/src/lib/deskflow/ClipboardChunk.cpp
+++ b/src/lib/deskflow/ClipboardChunk.cpp
@@ -121,6 +121,9 @@ void ClipboardChunk::send(deskflow::IStream *stream, void *data)
   case ChunkType::DataEnd:
     LOG((CLOG_DEBUG2 "sending clipboard finished"));
     break;
+
+  default:
+    break;
   }
 
   ProtocolUtil::writef(stream, kMsgDClipboard, id, sequence, mark, &dataChunk);

--- a/src/lib/deskflow/ClipboardChunk.cpp
+++ b/src/lib/deskflow/ClipboardChunk.cpp
@@ -17,20 +17,20 @@ size_t ClipboardChunk::s_expectedSize = 0;
 
 ClipboardChunk::ClipboardChunk(size_t size) : Chunk(size)
 {
-  m_dataSize = size - CLIPBOARD_CHUNK_META_SIZE;
+  m_dataSize = size - s_clipboardChunkMetaSize;
 }
 
 ClipboardChunk *ClipboardChunk::start(ClipboardID id, uint32_t sequence, const std::string &size)
 {
   size_t sizeLength = size.size();
-  auto *start = new ClipboardChunk(sizeLength + CLIPBOARD_CHUNK_META_SIZE);
+  auto *start = new ClipboardChunk(sizeLength + s_clipboardChunkMetaSize);
   char *chunk = start->m_chunk;
 
   chunk[0] = id;
   std::memcpy(&chunk[1], &sequence, 4);
   chunk[5] = kDataStart;
   memcpy(&chunk[6], size.c_str(), sizeLength);
-  chunk[sizeLength + CLIPBOARD_CHUNK_META_SIZE - 1] = '\0';
+  chunk[sizeLength + s_clipboardChunkMetaSize - 1] = '\0';
 
   return start;
 }
@@ -38,27 +38,27 @@ ClipboardChunk *ClipboardChunk::start(ClipboardID id, uint32_t sequence, const s
 ClipboardChunk *ClipboardChunk::data(ClipboardID id, uint32_t sequence, const std::string &data)
 {
   size_t dataSize = data.size();
-  auto *chunk = new ClipboardChunk(dataSize + CLIPBOARD_CHUNK_META_SIZE);
+  auto *chunk = new ClipboardChunk(dataSize + s_clipboardChunkMetaSize);
   char *chunkData = chunk->m_chunk;
 
   chunkData[0] = id;
   std::memcpy(&chunkData[1], &sequence, 4);
   chunkData[5] = kDataChunk;
   memcpy(&chunkData[6], data.c_str(), dataSize);
-  chunkData[dataSize + CLIPBOARD_CHUNK_META_SIZE - 1] = '\0';
+  chunkData[dataSize + s_clipboardChunkMetaSize - 1] = '\0';
 
   return chunk;
 }
 
 ClipboardChunk *ClipboardChunk::end(ClipboardID id, uint32_t sequence)
 {
-  auto *end = new ClipboardChunk(CLIPBOARD_CHUNK_META_SIZE);
+  auto *end = new ClipboardChunk(s_clipboardChunkMetaSize);
   char *chunk = end->m_chunk;
 
   chunk[0] = id;
   std::memcpy(&chunk[1], &sequence, 4);
   chunk[5] = kDataEnd;
-  chunk[CLIPBOARD_CHUNK_META_SIZE - 1] = '\0';
+  chunk[s_clipboardChunkMetaSize - 1] = '\0';
 
   return end;
 }

--- a/src/lib/deskflow/ClipboardChunk.h
+++ b/src/lib/deskflow/ClipboardChunk.h
@@ -9,6 +9,7 @@
 #include "common/Common.h"
 #include "deskflow/Chunk.h"
 #include "deskflow/ClipboardTypes.h"
+#include "deskflow/ProtocolTypes.h"
 
 #include <string>
 
@@ -27,7 +28,8 @@ public:
   static ClipboardChunk *data(ClipboardID id, uint32_t sequence, const std::string &data);
   static ClipboardChunk *end(ClipboardID id, uint32_t sequence);
 
-  static int assemble(deskflow::IStream *stream, std::string &dataCached, ClipboardID &id, uint32_t &sequence);
+  static TransferState
+  assemble(deskflow::IStream *stream, std::string &dataCached, ClipboardID &id, uint32_t &sequence);
 
   static void send(deskflow::IStream *stream, void *data);
 

--- a/src/lib/deskflow/ClipboardChunk.h
+++ b/src/lib/deskflow/ClipboardChunk.h
@@ -12,7 +12,7 @@
 
 #include <string>
 
-#define CLIPBOARD_CHUNK_META_SIZE 7
+constexpr static auto s_clipboardChunkMetaSize = 7;
 
 namespace deskflow {
 class IStream;

--- a/src/lib/deskflow/IPrimaryScreen.h
+++ b/src/lib/deskflow/IPrimaryScreen.h
@@ -79,7 +79,7 @@ public:
   //! Update configuration
   /*!
   This is called when the configuration has changed.  \c activeSides
-  is a bitmask of EDirectionMask indicating which sides of the
+  is a bitmask of DirectionMask indicating which sides of the
   primary screen are linked to clients.  Override to handle the
   possible change in jump zones.
   */

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -35,7 +35,7 @@ KeyMap::KeyMap() : m_numGroups(0), m_composeAcrossGroups(false)
   m_modifierKeyItem.m_client = 0;
 }
 
-void KeyMap::swap(KeyMap &x)
+void KeyMap::swap(KeyMap &x) noexcept
 {
   m_keyIDMap.swap(x.m_keyIDMap);
   m_modifierKeys.swap(x.m_modifierKeys);

--- a/src/lib/deskflow/KeyMap.h
+++ b/src/lib/deskflow/KeyMap.h
@@ -123,7 +123,7 @@ public:
   //@{
 
   //! Swap with another \c KeyMap
-  virtual void swap(KeyMap &);
+  virtual void swap(KeyMap &) noexcept;
 
   //! Add a key entry
   /*!

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -195,17 +195,17 @@ enum EDirectionMask
  *
  * @since Protocol version 1.5
  */
-enum EDataTransfer
+struct ChunkType
 {
-  kDataStart = 1, ///< Start of transfer (contains file size)
-  kDataChunk = 2, ///< Data chunk (contains file content)
-  kDataEnd = 3    ///< End of transfer (transfer complete)
+  inline static const auto DataStart = 1; ///< Start of transfer (contains file size)
+  inline static const auto DataChunk = 2; ///< Data chunk (contains file content)
+  inline static const auto DataEnd = 3;   ///< End of transfer (transfer complete)
 };
 
 /**
- * @brief Data reception status codes
+ * @brief Data reception state codes
  *
- * Used internally to track the status of data reception
+ * Used internally to track the state of data reception
  * during clipboard operations.
  *
  * @since Protocol version 1.5

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -178,13 +178,13 @@ enum EDirection
  *
  * @since Protocol version 1.0
  */
-enum EDirectionMask
+enum class DirectionMask
 {
-  kNoDirMask = 0,            ///< No direction mask
-  kLeftMask = 1 << kLeft,    ///< Left edge mask
-  kRightMask = 1 << kRight,  ///< Right edge mask
-  kTopMask = 1 << kTop,      ///< Top edge mask
-  kBottomMask = 1 << kBottom ///< Bottom edge mask
+  NoDirMask = 0,            ///< No direction mask
+  LeftMask = 1 << kLeft,    ///< Left edge mask
+  RightMask = 1 << kRight,  ///< Right edge mask
+  TopMask = 1 << kTop,      ///< Top edge mask
+  BottomMask = 1 << kBottom ///< Bottom edge mask
 };
 
 /**

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -158,16 +158,16 @@ static constexpr uint32_t PROTOCOL_MAX_STRING_LENGTH = 1024 * 1024;
  *
  * @since Protocol version 1.0
  */
-enum EDirection
+enum class Direction : uint8_t
 {
-  kNoDirection,                                         ///< No specific direction
-  kLeft,                                                ///< Left edge of screen
-  kRight,                                               ///< Right edge of screen
-  kTop,                                                 ///< Top edge of screen
-  kBottom,                                              ///< Bottom edge of screen
-  kFirstDirection = kLeft,                              ///< First valid direction value
-  kLastDirection = kBottom,                             ///< Last valid direction value
-  kNumDirections = kLastDirection - kFirstDirection + 1 ///< Total number of directions
+  NoDirection,                                                             ///< No specific direction
+  Left,                                                                    ///< Left edge of screen
+  Right,                                                                   ///< Right edge of screen
+  Top,                                                                     ///< Top edge of screen
+  Bottom,                                                                  ///< Bottom edge of screen
+  FirstDirection = Direction::Left,                                        ///< First valid direction value
+  LastDirection = Direction::Bottom,                                       ///< Last valid direction value
+  NumDirections = Direction::LastDirection - Direction::FirstDirection + 1 ///< Total number of directions
 };
 
 /**
@@ -180,11 +180,11 @@ enum EDirection
  */
 enum class DirectionMask
 {
-  NoDirMask = 0,            ///< No direction mask
-  LeftMask = 1 << kLeft,    ///< Left edge mask
-  RightMask = 1 << kRight,  ///< Right edge mask
-  TopMask = 1 << kTop,      ///< Top edge mask
-  BottomMask = 1 << kBottom ///< Bottom edge mask
+  NoDirMask = 0,                                        ///< No direction mask
+  LeftMask = 1 << static_cast<int>(Direction::Left),    ///< Left edge mask
+  RightMask = 1 << static_cast<int>(Direction::Right),  ///< Right edge mask
+  TopMask = 1 << static_cast<int>(Direction::Top),      ///< Top edge mask
+  BottomMask = 1 << static_cast<int>(Direction::Bottom) ///< Bottom edge mask
 };
 
 /**

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -210,12 +210,12 @@ enum EDataTransfer
  *
  * @since Protocol version 1.5
  */
-enum EDataReceived
+enum class TransferState : uint8_t
 {
-  kStart,     ///< Reception started
-  kNotFinish, ///< Reception in progress
-  kFinish,    ///< Reception completed successfully
-  kError      ///< Reception failed with error
+  Started,    ///< Reception started
+  InProgress, ///< Reception in progress
+  Finished,   ///< Reception completed successfully
+  Error       ///< Reception failed with error
 };
 
 /** @} */ // end of protocol_enums group

--- a/src/lib/deskflow/ProtocolUtil.cpp
+++ b/src/lib/deskflow/ProtocolUtil.cpp
@@ -255,6 +255,10 @@ uint32_t ProtocolUtil::getLength(const char *fmt, va_list args)
         case 4:
           len = 4 * (uint32_t)(va_arg(args, std::vector<uint32_t> *))->size() + 4;
           break;
+
+        default:
+          LOG((CLOG_ERR "format specifier %%I%d has invalid length", len));
+          break;
         }
         break;
 

--- a/src/lib/deskflow/Screen.h
+++ b/src/lib/deskflow/Screen.h
@@ -71,7 +71,7 @@ public:
   //! Update configuration
   /*!
   This is called when the configuration has changed.  \c activeSides
-  is a bitmask of EDirectionMask indicating which sides of the
+  is a bitmask of DirectionMask indicating which sides of the
   primary screen are linked to clients.
   */
   void reconfigure(uint32_t activeSides);

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -109,16 +109,16 @@ void ServerApp::help()
        << " [--display <display>]"
 #endif
 
-       << HELP_SYS_ARGS HELP_COMMON_ARGS "\n"
+       << s_helpSysArgs << s_helpCommonArgs << "\n"
        << "\n"
        << "Start the " << kAppName << " mouse/keyboard sharing server.\n"
        << "\n"
        << "  -a, --address <address>  listen for clients on the given address.\n"
        << "  -c, --config <pathname>  path of the configuration file\n"
-       << HELP_COMMON_INFO_1
+       << s_helpGeneralArgs
        << "      --disable-client-cert-check disable client SSL certificate \n"
           "                                     checking (deprecated)\n"
-       << HELP_SYS_INFO HELP_COMMON_INFO_2 << "\n"
+       << s_helpSysInfo << s_helpVersionArgs << "\n"
 
 #if WINAPI_XWINDOWS
        << "      --display <display>  when in X mode, connect to the X server\n"
@@ -127,7 +127,7 @@ void ServerApp::help()
 
        << "* marks defaults.\n"
 
-       << kHelpNoWayland
+       << s_helpNoWayland
 
        << "\n"
        << "The argument for --address is of the form: [<hostname>][:<port>].  "

--- a/src/lib/gui/KeySequence.cpp
+++ b/src/lib/gui/KeySequence.cpp
@@ -163,6 +163,9 @@ QString KeySequence::keyToString(int key)
       return "2";
     case Qt::MiddleButton:
       return "3";
+    default:
+      qDebug() << "unknown key" << key;
+      break;
     }
 
     return "4"; // qt only knows three mouse buttons, so assume it's an unknown

--- a/src/lib/gui/ScreenSetupModel.cpp
+++ b/src/lib/gui/ScreenSetupModel.cpp
@@ -57,6 +57,9 @@ QVariant ScreenSetupModel::data(const QModelIndex &index, int role) const
 
   case Qt::DisplayRole:
     return screen(index).name();
+
+  default:
+    break;
   }
   return QVariant();
 }

--- a/src/lib/gui/ScreenSetupModel.cpp
+++ b/src/lib/gui/ScreenSetupModel.cpp
@@ -124,22 +124,24 @@ bool ScreenSetupModel::dropMimeData(
   stream >> sourceColumn;
   stream >> sourceRow;
 
+  const auto pColumn = parent.column();
+  const auto pRow = parent.row();
+
   // don't drop screen onto itself
-  if (sourceColumn == parent.column() && sourceRow == parent.row())
+  if (sourceColumn == pColumn && sourceRow == pRow)
     return false;
 
   Screen droppedScreen;
   stream >> droppedScreen;
 
-  auto oldScreen = Screen(screen(parent.column(), parent.row()));
-  if (!oldScreen.isNull() && sourceColumn != -1 && sourceRow != -1) {
+  if (auto oldScreen = Screen(screen(pColumn, pRow)); !oldScreen.isNull() && sourceColumn != -1 && sourceRow != -1) {
     // mark the screen so it isn't deleted after the dragndrop succeeded
     // see ScreenSetupView::startDrag()
     oldScreen.setSwapped(true);
     screen(sourceColumn, sourceRow) = oldScreen;
   }
 
-  screen(parent.column(), parent.row()) = droppedScreen;
+  screen(pColumn, pRow) = droppedScreen;
 
   Q_EMIT screensChanged();
 

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
@@ -35,14 +35,15 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget *parent, Screen *pScreen, con
   ui->m_pLabelNameError->setStyleSheet(kStyleErrorActiveLabel);
 
   ui->m_pLineEditName->setText(m_pScreen->name());
-  ui->m_pLineEditName->setValidator(new validators::ScreenNameValidator(
-      ui->m_pLineEditName, new validators::ValidationError(this, ui->m_pLabelNameError), pScreens
-  ));
+
+  auto valNameError = new validators::ValidationError(this, ui->m_pLabelNameError);
+  auto valName = new validators::ScreenNameValidator(ui->m_pLineEditName, valNameError, pScreens);
+  ui->m_pLineEditName->setValidator(valName);
   ui->m_pLineEditName->selectAll();
 
-  ui->m_pLineEditAlias->setValidator(new validators::AliasValidator(
-      ui->m_pLineEditAlias, new validators::ValidationError(this, ui->m_pLabelAliasError)
-  ));
+  auto valAliasError = new validators::ValidationError(this, ui->m_pLabelAliasError);
+  auto valAlias = new validators::AliasValidator(ui->m_pLineEditAlias, valAliasError);
+  ui->m_pLineEditAlias->setValidator(valAlias);
 
   for (int i = 0; i < m_pScreen->aliases().count(); i++)
     new QListWidgetItem(m_pScreen->aliases()[i], ui->m_pListAliases);

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -32,8 +32,7 @@ bool TlsCertificate::generateCertificate(const QString &path, int keyLength) con
   qDebug("generating tls certificate: %s", qUtf8Printable(path));
 
   QFileInfo info(path);
-  QDir dir(info.absolutePath());
-  if (!dir.exists() && !dir.mkpath(".")) {
+  if (QDir dir(info.absolutePath()); !dir.exists() && !dir.mkpath(".")) {
     qCritical("failed to create directory for tls certificate");
     return false;
   }

--- a/src/lib/gui/widgets/ScreenSetupView.h
+++ b/src/lib/gui/widgets/ScreenSetupView.h
@@ -40,5 +40,6 @@ protected:
   void initViewItemOption(QStyleOptionViewItem *option) const override;
   void scrollTo(const QModelIndex &, ScrollHint) override
   {
+    // do nothing
   }
 };

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -55,7 +55,7 @@ Thread &Thread::operator=(const Thread &thread)
   return *this;
 }
 
-void Thread::exit(void *result)
+[[noreturn]] void Thread::exit(void *result)
 {
   throw XThreadExit(result);
 }

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -78,7 +78,7 @@ public:
   \endcode
   or add the \c RETHROW_XTHREAD macro to the \c catch(...) block.
   */
-  static void exit(void *);
+  [[noreturn]] static void exit(void *);
 
   //! Cancel thread
   /*!

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -31,10 +31,7 @@
 //
 // SecureSocket
 //
-
-#define MAX_ERROR_SIZE 65535
-
-static const std::size_t MAX_INPUT_BUFFER_SIZE = 1024 * 1024;
+static const std::size_t s_maxInputBufferSize = 1024 * 1024;
 
 static const float s_retryDelay = 0.01f;
 
@@ -142,7 +139,7 @@ TCPSocket::EJobResult SecureSocket::doRead()
     do {
       m_inputBuffer.write(buffer, bytesRead);
 
-      if (m_inputBuffer.getSize() > MAX_INPUT_BUFFER_SIZE) {
+      if (m_inputBuffer.getSize() > s_maxInputBufferSize) {
         break;
       }
 

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -546,10 +546,7 @@ void SecureSocket::checkResult(int status, int &retry)
 {
   // ssl errors are a little quirky. the "want" errors are normal and
   // should result in a retry.
-
-  int errorCode = SSL_get_error(m_ssl->m_ssl, status);
-
-  switch (errorCode) {
+  switch (auto errorCode = SSL_get_error(m_ssl->m_ssl, status); errorCode) {
   case SSL_ERROR_NONE:
     retry = 0;
     // operation completed

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -36,7 +36,8 @@ SocketMultiplexer::SocketMultiplexer()
   m_cursorMark = reinterpret_cast<ISocketMultiplexerJob *>(this);
 
   // start thread
-  m_thread = new Thread(new TMethodJob<SocketMultiplexer>(this, &SocketMultiplexer::serviceThread));
+  auto tMethodJob = new TMethodJob<SocketMultiplexer>(this, &SocketMultiplexer::serviceThread);
+  m_thread = new Thread(tMethodJob);
 }
 
 SocketMultiplexer::~SocketMultiplexer()

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -119,7 +119,7 @@ void SocketMultiplexer::removeSocket(ISocket *socket)
   unlockJobList();
 }
 
-void SocketMultiplexer::serviceThread(void *)
+[[noreturn]] void SocketMultiplexer::serviceThread(void *)
 {
   std::vector<IArchNetwork::PollEntry> pfds;
   IArchNetwork::PollEntry pfd;

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -60,7 +60,7 @@ private:
   // and m_update while m_pollable and m_polling are true.  all other
   // threads must only modify these when m_pollable and m_polling are
   // false.  only the service thread sets m_polling.
-  void serviceThread(void *);
+  [[noreturn]] void serviceThread(void *);
 
   // create, iterate, and destroy a cursor.  a cursor is used to
   // safely iterate through the job list while other threads modify

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <memory>
 
-static const std::size_t MAX_INPUT_BUFFER_SIZE = 1024 * 1024;
+static const std::size_t s_maxInputBufferSize = 1024 * 1024;
 
 //
 // TCPSocket
@@ -311,7 +311,7 @@ TCPSocket::EJobResult TCPSocket::doRead()
     do {
       m_inputBuffer.write(buffer, static_cast<uint32_t>(bytesRead));
 
-      if (m_inputBuffer.getSize() > MAX_INPUT_BUFFER_SIZE) {
+      if (m_inputBuffer.getSize() > s_maxInputBufferSize) {
         break;
       }
 

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -534,16 +534,17 @@ static bool mouseHookHandler(WPARAM wParam, int32_t x, int32_t y, int32_t data)
 
       // check for mouse inside jump zone
       bool inside = false;
-      if (!inside && (g_zoneSides & kLeftMask) != 0) {
+      using enum DirectionMask;
+      if (!inside && (g_zoneSides & static_cast<int>(LeftMask)) != 0) {
         inside = (x < g_xScreen + g_zoneSize);
       }
-      if (!inside && (g_zoneSides & kRightMask) != 0) {
+      if (!inside && (g_zoneSides & static_cast<int>(RightMask)) != 0) {
         inside = (x >= g_xScreen + g_wScreen - g_zoneSize);
       }
-      if (!inside && (g_zoneSides & kTopMask) != 0) {
+      if (!inside && (g_zoneSides & static_cast<int>(TopMask)) != 0) {
         inside = (y < g_yScreen + g_zoneSize);
       }
-      if (!inside && (g_zoneSides & kBottomMask) != 0) {
+      if (!inside && (g_zoneSides & static_cast<int>(BottomMask)) != 0) {
         inside = (y >= g_yScreen + g_hScreen - g_zoneSize);
       }
 

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -22,7 +22,9 @@ PortalInputCapture::PortalInputCapture(EiScreen *screen, IEventQueue *events)
       m_portal{xdp_portal_new()}
 {
   m_glibMainLoop = g_main_loop_new(nullptr, true);
-  m_glibThread = new Thread(new TMethodJob<PortalInputCapture>(this, &PortalInputCapture::glibThread));
+
+  auto tMethodJob = new TMethodJob<PortalInputCapture>(this, &PortalInputCapture::glibThread);
+  m_glibThread = new Thread(tMethodJob);
 
   auto captureCallback = [](gpointer data) { return static_cast<PortalInputCapture *>(data)->initSession(); };
 

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -17,7 +17,9 @@ PortalRemoteDesktop::PortalRemoteDesktop(EiScreen *screen, IEventQueue *events)
       m_portal{xdp_portal_new()}
 {
   m_glibMainLoop = g_main_loop_new(nullptr, true);
-  m_glibThread = new Thread(new TMethodJob<PortalRemoteDesktop>(this, &PortalRemoteDesktop::glibThread));
+
+  auto tMethodJob = new TMethodJob<PortalRemoteDesktop>(this, &PortalRemoteDesktop::glibThread);
+  m_glibThread = new Thread(tMethodJob);
 
   reconnect(0);
 }

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1381,12 +1381,9 @@ XWindowsClipboard::Reply::Reply(
       m_target(target),
       m_time(time),
       m_property(property),
-      m_replied(false),
-      m_done(false),
       m_data(data),
       m_type(type),
-      m_format(format),
-      m_ptr(0)
+      m_format(format)
 {
   // do nothing
 }

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -103,12 +103,12 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
   // and continue doing this until timeout is reached.
   // The human eye can notice 60hz (ansi) which is 16ms, however
   // we want to give the cpu a chance s owe up this to 25ms
-#define TIMEOUT_DELAY 25
+  static const int s_timeoutDelay = 25;
 
   while (((dtimeout < 0.0) || (remaining > 0)) && getPendingCountLocked() == 0 && retval == 0) {
 
-    retval = poll(pfds, 2, TIMEOUT_DELAY); // 16ms = 60hz, but we make it > to
-                                           // play nicely with the cpu
+    retval = poll(pfds, 2, s_timeoutDelay); // 16ms = 60hz, but we make it > to
+                                            // play nicely with the cpu
     if (pfds[1].revents & POLLIN) {
       ssize_t read_response = read(m_pipefd[0], buf, 15);
 
@@ -117,7 +117,7 @@ void XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
         // todo: handle read response
       }
     }
-    remaining -= TIMEOUT_DELAY;
+    remaining -= s_timeoutDelay;
   }
 
   {

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -31,6 +31,7 @@ public:
   // IEventQueueBuffer overrides
   void init() override
   {
+    // do nothing
   }
   void waitForEvent(double timeout) override;
   Type getEvent(Event &event, uint32_t &dataID) override;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1333,6 +1333,9 @@ void XWindowsScreen::handleSystemEvent(const Event &event)
         LOG((CLOG_INFO "group change: %d", xkbEvent->state.group));
         m_keyState->setActiveGroup((int32_t)xkbEvent->state.group);
         return;
+
+      default:
+        return;
       }
     }
 #endif

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -160,6 +160,8 @@ bool XWindowsScreenSaver::handleXEvent(const XEvent *xevent)
       return true;
     }
     break;
+  default:
+    break;
   }
 
   return false;

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -22,7 +22,6 @@
 
 ClientProxy1_0::ClientProxy1_0(const std::string &name, deskflow::IStream *stream, IEventQueue *events)
     : ClientProxy(name, stream),
-      m_parser(&ClientProxy1_0::parseHandshakeMessage),
       m_events(events)
 {
   // install event handlers

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -98,6 +98,6 @@ private:
   ClientInfo m_info;
   double m_heartbeatAlarm;
   EventQueueTimer *m_heartbeatTimer = nullptr;
-  MessageParser m_parser;
+  MessageParser m_parser = &ClientProxy1_0::parseHandshakeMessage;
   IEventQueue *m_events;
 };

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -50,10 +50,10 @@ bool ClientProxy1_6::recvClipboard()
   ClipboardID id;
   uint32_t seq;
 
-  if (int r = ClipboardChunk::assemble(getStream(), dataCached, id, seq); r == kStart) {
+  if (auto r = ClipboardChunk::assemble(getStream(), dataCached, id, seq); r == TransferState::Started) {
     size_t size = ClipboardChunk::getExpectedSize();
     LOG((CLOG_DEBUG "receiving clipboard %d size=%d", id, size));
-  } else if (r == kFinish) {
+  } else if (r == TransferState::Finished) {
     LOG(
         (CLOG_DEBUG "received client \"%s\" clipboard %d seqnum=%d, size=%d", getName().c_str(), id, seq,
          dataCached.size())

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -181,6 +181,9 @@ void ClientProxyUnknown::initProxy(const std::string &name, int major, int minor
     case 8:
       m_proxy = new ClientProxy1_8(name, m_stream, m_server, m_events);
       break;
+
+    default:
+      break;
     }
   }
 

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -197,11 +197,11 @@ void Config::removeAllAliases()
 }
 
 bool Config::connect(
-    const std::string &srcName, EDirection srcSide, float srcStart, float srcEnd, const std::string &dstName,
+    const std::string &srcName, Direction srcSide, float srcStart, float srcEnd, const std::string &dstName,
     float dstStart, float dstEnd
 )
 {
-  assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
+  assert(srcSide >= Direction::FirstDirection && srcSide <= Direction::LastDirection);
 
   // find source cell
   CellMap::iterator index = m_map.find(getCanonicalName(srcName));
@@ -215,9 +215,9 @@ bool Config::connect(
   return index->second.add(srcEdge, dstEdge);
 }
 
-bool Config::disconnect(const std::string &srcName, EDirection srcSide)
+bool Config::disconnect(const std::string &srcName, Direction srcSide)
 {
-  assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
+  assert(srcSide >= Direction::FirstDirection && srcSide <= Direction::LastDirection);
 
   // find source cell
   CellMap::iterator index = m_map.find(srcName);
@@ -231,9 +231,9 @@ bool Config::disconnect(const std::string &srcName, EDirection srcSide)
   return true;
 }
 
-bool Config::disconnect(const std::string &srcName, EDirection srcSide, float position)
+bool Config::disconnect(const std::string &srcName, Direction srcSide, float position)
 {
-  assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
+  assert(srcSide >= Direction::FirstDirection && srcSide <= Direction::LastDirection);
 
   // find source cell
   CellMap::iterator index = m_map.find(srcName);
@@ -405,10 +405,9 @@ std::string Config::getCanonicalName(const std::string &name) const
   }
 }
 
-std::string
-Config::getNeighbor(const std::string &srcName, EDirection srcSide, float position, float *positionOut) const
+std::string Config::getNeighbor(const std::string &srcName, Direction srcSide, float position, float *positionOut) const
 {
-  assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
+  assert(srcSide >= Direction::FirstDirection && srcSide <= Direction::LastDirection);
 
   // find source cell
   CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
@@ -433,14 +432,14 @@ Config::getNeighbor(const std::string &srcName, EDirection srcSide, float positi
   }
 }
 
-bool Config::hasNeighbor(const std::string &srcName, EDirection srcSide) const
+bool Config::hasNeighbor(const std::string &srcName, Direction srcSide) const
 {
   return hasNeighbor(srcName, srcSide, 0.0f, 1.0f);
 }
 
-bool Config::hasNeighbor(const std::string &srcName, EDirection srcSide, float start, float end) const
+bool Config::hasNeighbor(const std::string &srcName, Direction srcSide, float start, float end) const
 {
-  assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
+  assert(srcSide >= Direction::FirstDirection && srcSide <= Direction::LastDirection);
 
   // find source cell
   CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
@@ -556,13 +555,13 @@ void Config::read(ConfigReadContext &context)
   *this = tmp;
 }
 
-const char *Config::dirName(EDirection dir)
+const char *Config::dirName(Direction dir)
 {
   static const char *s_name[] = {"left", "right", "up", "down"};
 
-  assert(dir >= kFirstDirection && dir <= kLastDirection);
+  assert(dir >= Direction::FirstDirection && dir <= Direction::LastDirection);
 
-  return s_name[dir - kFirstDirection];
+  return s_name[static_cast<int>(dir) - static_cast<int>(Direction::FirstDirection)];
 }
 
 InputFilter *Config::getInputFilter()
@@ -855,15 +854,16 @@ void Config::readSectionLinks(ConfigReadContext &s)
       Interval dstInterval(s.parseInterval(dstArgs));
 
       // handle argument
-      EDirection dir;
+      using enum Direction;
+      Direction dir;
       if (side == "left") {
-        dir = kLeft;
+        dir = Left;
       } else if (side == "right") {
-        dir = kRight;
+        dir = Right;
       } else if (side == "up") {
-        dir = kTop;
+        dir = Top;
       } else if (side == "down") {
-        dir = kBottom;
+        dir = Bottom;
       } else {
         // unknown argument
         throw XConfigRead(s, "unknown side \"%{1}\" in link", side);
@@ -1048,15 +1048,16 @@ void Config::parseAction(
       throw XConfigRead(s, "syntax for action: switchInDirection(<left|right|up|down>)");
     }
 
-    EDirection direction;
+    Direction direction;
+    using enum Direction;
     if (args[0] == "left") {
-      direction = kLeft;
+      direction = Left;
     } else if (args[0] == "right") {
-      direction = kRight;
+      direction = Right;
     } else if (args[0] == "up") {
-      direction = kTop;
+      direction = Top;
     } else if (args[0] == "down") {
-      direction = kBottom;
+      direction = Bottom;
     } else {
       throw XConfigRead(s, "unknown direction \"%{1}\" in switchToScreen", args[0]);
     }
@@ -1343,12 +1344,12 @@ bool Config::Name::operator==(const std::string &name) const
 // Config::CellEdge
 //
 
-Config::CellEdge::CellEdge(EDirection side, float position)
+Config::CellEdge::CellEdge(Direction side, float position)
 {
   init("", side, Interval(position, position));
 }
 
-Config::CellEdge::CellEdge(EDirection side, const Interval &interval)
+Config::CellEdge::CellEdge(Direction side, const Interval &interval)
 {
   assert(interval.first >= 0.0f);
   assert(interval.second <= 1.0f);
@@ -1357,7 +1358,7 @@ Config::CellEdge::CellEdge(EDirection side, const Interval &interval)
   init("", side, interval);
 }
 
-Config::CellEdge::CellEdge(const std::string &name, EDirection side, const Interval &interval)
+Config::CellEdge::CellEdge(const std::string &name, Direction side, const Interval &interval)
 {
   assert(interval.first >= 0.0f);
   assert(interval.second <= 1.0f);
@@ -1366,9 +1367,9 @@ Config::CellEdge::CellEdge(const std::string &name, EDirection side, const Inter
   init(name, side, interval);
 }
 
-void Config::CellEdge::init(const std::string_view &name, EDirection side, const Interval &interval)
+void Config::CellEdge::init(const std::string_view &name, Direction side, const Interval &interval)
 {
-  assert(side != kNoDirection);
+  assert(side != Direction::NoDirection);
 
   m_name = name;
   m_side = side;
@@ -1390,7 +1391,7 @@ std::string Config::CellEdge::getName() const
   return m_name;
 }
 
-EDirection Config::CellEdge::getSide() const
+Direction Config::CellEdge::getSide() const
 {
   return m_side;
 }
@@ -1459,7 +1460,7 @@ bool Config::Cell::add(const CellEdge &src, const CellEdge &dst)
   return true;
 }
 
-void Config::Cell::remove(EDirection side)
+void Config::Cell::remove(Direction side)
 {
   for (auto j = m_neighbors.begin(); j != m_neighbors.end();) {
     if (j->first.getSide() == side) {
@@ -1470,7 +1471,7 @@ void Config::Cell::remove(EDirection side)
   }
 }
 
-void Config::Cell::remove(EDirection side, float position)
+void Config::Cell::remove(Direction side, float position)
 {
   for (auto j = m_neighbors.begin(); j != m_neighbors.end(); ++j) {
     if (j->first.getSide() == side && j->first.isInside(position)) {
@@ -1517,7 +1518,7 @@ bool Config::Cell::overlaps(const CellEdge &edge) const
   return false;
 }
 
-bool Config::Cell::getLink(EDirection side, float position, const CellEdge *&src, const CellEdge *&dst) const
+bool Config::Cell::getLink(Direction side, float position, const CellEdge *&src, const CellEdge *&dst) const
 {
   CellEdge edge(side, position);
   EdgeLinks::const_iterator i = m_neighbors.upper_bound(edge);

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -58,15 +58,15 @@ public:
   class CellEdge
   {
   public:
-    CellEdge(EDirection side, float position);
-    CellEdge(EDirection side, const Interval &);
-    CellEdge(const std::string &name, EDirection side, const Interval &);
+    CellEdge(Direction side, float position);
+    CellEdge(Direction side, const Interval &);
+    CellEdge(const std::string &name, Direction side, const Interval &);
     ~CellEdge() = default;
 
     Interval getInterval() const;
     void setName(const std::string_view &newName);
     std::string getName() const;
-    EDirection getSide() const;
+    Direction getSide() const;
     bool overlaps(const CellEdge &) const;
     bool isInside(float x) const;
 
@@ -84,11 +84,11 @@ public:
     bool operator!=(const CellEdge &) const;
 
   private:
-    void init(const std::string_view &name, EDirection side, const Interval &);
+    void init(const std::string_view &name, Direction side, const Interval &);
 
   private:
     std::string m_name;
-    EDirection m_side;
+    Direction m_side;
     Interval m_interval;
   };
 
@@ -114,15 +114,15 @@ private:
     using const_iterator = EdgeLinks::const_iterator;
 
     bool add(const CellEdge &src, const CellEdge &dst);
-    void remove(EDirection side);
-    void remove(EDirection side, float position);
+    void remove(Direction side);
+    void remove(Direction side, float position);
     void remove(const Name &destinationName);
     void rename(const Name &oldName, const std::string &newName);
 
     bool hasEdge(const CellEdge &) const;
     bool overlaps(const CellEdge &) const;
 
-    bool getLink(EDirection side, float position, const CellEdge *&src, const CellEdge *&dst) const;
+    bool getLink(Direction side, float position, const CellEdge *&src, const CellEdge *&dst) const;
 
     bool operator==(const Cell &) const;
     bool operator!=(const Cell &) const;
@@ -278,7 +278,7 @@ public:
   be inside the range [0,1].
   */
   bool connect(
-      const std::string &srcName, EDirection srcSide, float srcStart, float srcEnd, const std::string &dstName,
+      const std::string &srcName, Direction srcSide, float srcStart, float srcEnd, const std::string &dstName,
       float dstStart, float dstEnd
   );
 
@@ -287,7 +287,7 @@ public:
   Removes all connections created by connect() on side \c srcSide.
   Returns false if \c srcName is unknown.
   */
-  bool disconnect(const std::string &srcName, EDirection srcSide);
+  bool disconnect(const std::string &srcName, Direction srcSide);
 
   //! Disconnect screens
   /*!
@@ -295,7 +295,7 @@ public:
   covering position \c position.  Returns false if \c srcName is
   unknown.
   */
-  bool disconnect(const std::string &srcName, EDirection srcSide, float position);
+  bool disconnect(const std::string &srcName, Direction srcSide, float position);
 
   //! Set server address
   /*!
@@ -381,21 +381,21 @@ public:
   saves the position on the neighbor in \c positionOut if it's not
   \c nullptr.
   */
-  std::string getNeighbor(const std::string &, EDirection, float position, float *positionOut) const;
+  std::string getNeighbor(const std::string &, Direction, float position, float *positionOut) const;
 
   //! Check for neighbor
   /*!
   Returns \c true if the screen has a neighbor anywhere along the edge
   given by the direction.
   */
-  bool hasNeighbor(const std::string &, EDirection) const;
+  bool hasNeighbor(const std::string &, Direction) const;
 
   //! Check for neighbor
   /*!
   Returns \c true if the screen has a neighbor in the given range along
   the edge given by the direction.
   */
-  bool hasNeighbor(const std::string &, EDirection, float start, float end) const;
+  bool hasNeighbor(const std::string &, Direction, float start, float end) const;
 
   //! Get beginning neighbor iterator
   link_const_iterator beginNeighbor(const std::string &) const;
@@ -448,7 +448,7 @@ public:
   /*!
   Returns the name of a direction (for debugging).
   */
-  static const char *dirName(EDirection);
+  static const char *dirName(Direction);
 
   //! Get interval as string
   /*!

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -721,7 +721,7 @@ const InputFilter::Action &InputFilter::Rule::getAction(bool onActivation, uint3
 // -----------------------------------------------------------------------------
 // Input Filter Class
 // -----------------------------------------------------------------------------
-InputFilter::InputFilter(IEventQueue *events) : m_primaryClient(nullptr), m_events(events)
+InputFilter::InputFilter(IEventQueue *events) : m_events(events)
 {
   // do nothing
 }

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -297,14 +297,14 @@ void InputFilter::SwitchToScreenAction::perform(const Event &event)
   m_events->addEvent(Event(EventTypes::ServerSwitchToScreen, event.getTarget(), info, Event::kDeliverImmediately));
 }
 
-InputFilter::SwitchInDirectionAction::SwitchInDirectionAction(IEventQueue *events, EDirection direction)
+InputFilter::SwitchInDirectionAction::SwitchInDirectionAction(IEventQueue *events, Direction direction)
     : m_direction(direction),
       m_events(events)
 {
   // do nothing
 }
 
-EDirection InputFilter::SwitchInDirectionAction::getDirection() const
+Direction InputFilter::SwitchInDirectionAction::getDirection() const
 {
   return m_direction;
 }
@@ -318,7 +318,7 @@ std::string InputFilter::SwitchInDirectionAction::format() const
 {
   static const char *s_names[] = {"", "left", "right", "up", "down"};
 
-  return deskflow::string::sprintf("switchInDirection(%s)", s_names[m_direction]);
+  return deskflow::string::sprintf("switchInDirection(%s)", s_names[static_cast<int>(m_direction)]);
 }
 
 void InputFilter::SwitchInDirectionAction::perform(const Event &event)

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -197,9 +197,9 @@ public:
   class SwitchInDirectionAction : public Action
   {
   public:
-    SwitchInDirectionAction(IEventQueue *events, EDirection);
+    SwitchInDirectionAction(IEventQueue *events, Direction);
 
-    EDirection getDirection() const;
+    Direction getDirection() const;
 
     // Action overrides
     Action *clone() const override;
@@ -207,7 +207,7 @@ public:
     void perform(const Event &) override;
 
   private:
-    EDirection m_direction;
+    Direction m_direction;
     IEventQueue *m_events;
   };
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -27,6 +27,9 @@
 #include "server/ClientProxyUnknown.h"
 #include "server/PrimaryClient.h"
 
+#ifdef _WIN32
+#include <array>
+#endif
 #include <climits>
 #include <cmath>
 #include <cstdlib>
@@ -1641,16 +1644,16 @@ bool Server::onMouseMovePrimary(int32_t x, int32_t y)
   }
 
   // check both horizontally and vertically
-  Direction dirs[] = {dirh, dirv};
-  int32_t xs[] = {xh, x};
-  int32_t ys[] = {y, yv};
+  std::array<Direction, 2> dirs = {dirh, dirv};
+  std::array<int32_t, 2> xs = {xh, x};
+  std::array<int32_t, 2> ys = {y, yv};
   for (int i = 0; i < 2; ++i) {
-    Direction dir = dirs[i];
+    Direction dir = dirs.at(i);
     if (dir == NoDirection) {
       continue;
     }
-    x = xs[i], y = ys[i];
-
+    x = xs.at(i);
+    y = ys.at(i);
     // get jump destination
     BaseClientProxy *newScreen = mapToNeighbor(m_active, dir, x, y);
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -305,19 +305,20 @@ std::string Server::getName(const BaseClientProxy *client) const
 
 uint32_t Server::getActivePrimarySides() const
 {
+  using enum DirectionMask;
   uint32_t sides = 0;
   if (!isLockedToScreenServer()) {
     if (hasAnyNeighbor(m_primaryClient, kLeft)) {
-      sides |= kLeftMask;
+      sides |= static_cast<int>(LeftMask);
     }
     if (hasAnyNeighbor(m_primaryClient, kRight)) {
-      sides |= kRightMask;
+      sides |= static_cast<int>(RightMask);
     }
     if (hasAnyNeighbor(m_primaryClient, kTop)) {
-      sides |= kTopMask;
+      sides |= static_cast<int>(TopMask);
     }
     if (hasAnyNeighbor(m_primaryClient, kBottom)) {
-      sides |= kBottomMask;
+      sides |= static_cast<int>(BottomMask);
     }
   }
   return sides;

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -77,10 +77,10 @@ public:
   class SwitchInDirectionInfo
   {
   public:
-    static SwitchInDirectionInfo *alloc(EDirection direction);
+    static SwitchInDirectionInfo *alloc(Direction direction);
 
   public:
-    EDirection m_direction;
+    Direction m_direction;
   };
 
   //! Screen connected data
@@ -215,35 +215,35 @@ private:
 
   // convert pixel position to fraction, using x or y depending on the
   // direction.
-  float mapToFraction(const BaseClientProxy *, EDirection, int32_t x, int32_t y) const;
+  float mapToFraction(const BaseClientProxy *, Direction, int32_t x, int32_t y) const;
 
   // convert fraction to pixel position, writing only x or y depending
   // on the direction.
-  void mapToPixel(const BaseClientProxy *, EDirection, float f, int32_t &x, int32_t &y) const;
+  void mapToPixel(const BaseClientProxy *, Direction, float f, int32_t &x, int32_t &y) const;
 
   // returns true if the client has a neighbor anywhere along the edge
   // indicated by the direction.
-  bool hasAnyNeighbor(const BaseClientProxy *, EDirection) const;
+  bool hasAnyNeighbor(const BaseClientProxy *, Direction) const;
 
   // lookup neighboring screen, mapping the coordinate independent of
   // the direction to the neighbor's coordinate space.
-  BaseClientProxy *getNeighbor(const BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
+  BaseClientProxy *getNeighbor(const BaseClientProxy *, Direction, int32_t &x, int32_t &y) const;
 
   // lookup neighboring screen.  given a position relative to the
   // source screen, find the screen we should move onto and where.
   // if the position is sufficiently far from the source then we
   // cross multiple screens.  if there is no suitable screen then
   // return nullptr and x,y are not modified.
-  BaseClientProxy *mapToNeighbor(BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
+  BaseClientProxy *mapToNeighbor(BaseClientProxy *, Direction, int32_t &x, int32_t &y) const;
 
   // adjusts x and y or neither to avoid ending up in a jump zone
   // after entering the client in the given direction.
-  void avoidJumpZone(const BaseClientProxy *, EDirection, int32_t &x, int32_t &y) const;
+  void avoidJumpZone(const BaseClientProxy *, Direction, int32_t &x, int32_t &y) const;
 
   // test if a switch is permitted.  this includes testing user
   // options like switch delay and tracking any state required to
   // implement them.  returns true iff a switch is permitted.
-  bool isSwitchOkay(BaseClientProxy *dst, EDirection, int32_t x, int32_t y, int32_t xActive, int32_t yActive);
+  bool isSwitchOkay(BaseClientProxy *dst, Direction, int32_t x, int32_t y, int32_t xActive, int32_t yActive);
 
   // update switch state due to a mouse move at \p x, \p y that
   // doesn't switch screens.
@@ -409,7 +409,7 @@ private:
 
   // common state for screen switch tests.  all tests are always
   // trying to reach the same screen in the same direction.
-  EDirection m_switchDir = EDirection::kNoDirection;
+  Direction m_switchDir = Direction::NoDirection;
   BaseClientProxy *m_switchScreen = nullptr;
 
   // state for delayed screen switching

--- a/src/unittests/deskflow/ClipboardChunksTests.cpp
+++ b/src/unittests/deskflow/ClipboardChunksTests.cpp
@@ -21,7 +21,7 @@ void ClipboardChunksTests::startFormatData()
 
   QCOMPARE(chunk->m_chunk[0], id);
   QCOMPARE(temp_m_chunk, sequence);
-  QCOMPARE(chunk->m_chunk[5], kDataStart);
+  QCOMPARE(chunk->m_chunk[5], ChunkType::DataStart);
   QCOMPARE(chunk->m_chunk[6], '1');
   QCOMPARE(chunk->m_chunk[7], '0');
   QCOMPARE(chunk->m_chunk[8], '\0');
@@ -37,7 +37,7 @@ void ClipboardChunksTests::formatDataChunk()
 
   QCOMPARE(chunk->m_chunk[0], id);
   QCOMPARE((uint32_t)chunk->m_chunk[1], sequence);
-  QCOMPARE(chunk->m_chunk[5], kDataChunk);
+  QCOMPARE(chunk->m_chunk[5], ChunkType::DataChunk);
   QCOMPARE(chunk->m_chunk[6], 'm');
   QCOMPARE(chunk->m_chunk[7], 'o');
   QCOMPARE(chunk->m_chunk[8], 'c');
@@ -60,7 +60,7 @@ void ClipboardChunksTests::endFormatData()
 
   QCOMPARE(chunk->m_chunk[0], id);
   QCOMPARE((uint32_t)chunk->m_chunk[1], sequence);
-  QCOMPARE(chunk->m_chunk[5], kDataEnd);
+  QCOMPARE(chunk->m_chunk[5], ChunkType::DataEnd);
   QCOMPARE(chunk->m_chunk[6], '\0');
 
   delete chunk;

--- a/src/unittests/legacytests/mock/deskflow/MockKeyMap.h
+++ b/src/unittests/legacytests/mock/deskflow/MockKeyMap.h
@@ -13,7 +13,7 @@
 class MockKeyMap : public deskflow::KeyMap
 {
 public:
-  MOCK_METHOD(void, swap, (KeyMap &), (override));
+  MOCK_METHOD(void, swap, (KeyMap &), (noexcept));
   MOCK_METHOD(void, finish, (), (override));
   MOCK_METHOD(void, foreachKey, (ForeachKeyCallback, void *), (override));
   MOCK_METHOD(void, addHalfDuplexModifier, (KeyID), (override));

--- a/src/unittests/server/ServerConfigTests.cpp
+++ b/src/unittests/server/ServerConfigTests.cpp
@@ -41,12 +41,12 @@ void ServerConfigTests::equalityCheck()
 
   QVERIFY(a.addScreen("screenB"));
   QVERIFY(a.addScreen("screenC"));
-  QVERIFY(a.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
-  QVERIFY(a.connect("screenB", EDirection::kLeft, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(a.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(a.connect("screenB", Direction::Left, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
   QVERIFY(b.addScreen("screenA"));
   QVERIFY(b.addScreen("screenC"));
-  QVERIFY(b.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
-  QVERIFY(b.connect("screenB", EDirection::kLeft, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(b.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(b.connect("screenB", Direction::Left, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
   QVERIFY(a.addOption("screenA", kOptionClipboardSharing, 1));
   QVERIFY(b.addOption("screenA", kOptionClipboardSharing, 1));
   QVERIFY(a.addOption(std::string(), kOptionClipboardSharing, 1));
@@ -125,7 +125,7 @@ void ServerConfigTests::equalityCheck_diff_neighbours1()
   Config b(nullptr);
   QVERIFY(a.addScreen("screenA"));
   QVERIFY(a.addScreen("screenB"));
-  QVERIFY(a.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(a.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
   QVERIFY(b.addScreen("screenA"));
   QVERIFY(b.addScreen("screenB"));
   QVERIFY(a != b);
@@ -138,10 +138,10 @@ void ServerConfigTests::equalityCheck_diff_neighbours2()
   Config b(nullptr);
   QVERIFY(a.addScreen("screenA"));
   QVERIFY(a.addScreen("screenB"));
-  QVERIFY(a.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(a.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
   QVERIFY(b.addScreen("screenA"));
   QVERIFY(b.addScreen("screenB"));
-  QVERIFY(b.connect("screenA", EDirection::kBottom, 0.0f, 0.25f, "screenB", 0.25f, 1.0f));
+  QVERIFY(b.connect("screenA", Direction::Bottom, 0.0f, 0.25f, "screenB", 0.25f, 1.0f));
   QVERIFY(a != b);
 }
 
@@ -152,11 +152,11 @@ void ServerConfigTests::equalityCheck_diff_neighbours3()
   QVERIFY(a.addScreen("screenA"));
   QVERIFY(a.addScreen("screenB"));
   QVERIFY(a.addScreen("screenC"));
-  QVERIFY(a.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
+  QVERIFY(a.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenB", 0.5f, 1.0f));
   QVERIFY(b.addScreen("screenA"));
   QVERIFY(b.addScreen("screenB"));
   QVERIFY(b.addScreen("screenC"));
-  QVERIFY(b.connect("screenA", EDirection::kBottom, 0.0f, 0.5f, "screenC", 0.5f, 1.0f));
+  QVERIFY(b.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenC", 0.5f, 1.0f));
   QVERIFY(a != b);
 }
 


### PR DESCRIPTION
 Squash more sonar warnings
  - noexcept for swap methods (sonar considers this a "BLOCKING" issue)
  - do not use nested `new`  in calls (sonar considers this a "BLOCKING" issue)
  - comment empty method bodies 
  - prefer in-class initializers over initializer lists.
  - use constexpr / static const in place of defines
  - More enum class use
  - Remove unused < operator for Timer type
  - add default cases for switches
  - Mark a few missed methods noreturn