### PR TITLE
fix: save geometry not frameGeometry on exit

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -849,7 +849,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
   }
 
   if (m_saveOnExit) {
-    Settings::setValue(Settings::Gui::WindowGeometry, frameGeometry());
+    Settings::setValue(Settings::Gui::WindowGeometry, geometry());
   }
   qDebug() << "quitting application";
   event->accept();


### PR DESCRIPTION
fixes #8741

save `geometry` not `frameGeometry` on close.. most places they are the same but if your desktop happens to be CSD then your window's title bar height is added to the geometry height to give you a new height in your `frameGeometry`  This is what causes the window to grow on gnome..