### PR TITLE
InputCapture portal Improvements

### DIFF
--- a/src/lib/base/CMakeLists.txt
+++ b/src/lib/base/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 add_library(base STATIC
+  DirectionTypes.h
   Event.cpp
   Event.h
   EventQueue.cpp

--- a/src/lib/base/DirectionTypes.h
+++ b/src/lib/base/DirectionTypes.h
@@ -1,0 +1,47 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <cstdint>
+/**
+ * @brief Screen edge directions for mouse movement
+ *
+ * Used to specify which edge of a screen the mouse cursor crosses
+ * when moving between primary and secondary screens.
+ *
+ * @since Protocol version 1.0
+ */
+enum class Direction : uint8_t
+{
+  NoDirection,                                                             ///< No specific direction
+  Left,                                                                    ///< Left edge of screen
+  Right,                                                                   ///< Right edge of screen
+  Top,                                                                     ///< Top edge of screen
+  Bottom,                                                                  ///< Bottom edge of screen
+  FirstDirection = Direction::Left,                                        ///< First valid direction value
+  LastDirection = Direction::Bottom,                                       ///< Last valid direction value
+  NumDirections = Direction::LastDirection - Direction::FirstDirection + 1 ///< Total number of directions
+};
+
+/**
+ * @brief Bitmask values for screen edge directions
+ *
+ * Used to create bitmasks representing multiple screen edges.
+ * Useful for configuration and edge detection.
+ *
+ * @since Protocol version 1.0
+ */
+enum class DirectionMask
+{
+  NoDirMask = 0,                                        ///< No direction mask
+  LeftMask = 1 << static_cast<int>(Direction::Left),    ///< Left edge mask
+  RightMask = 1 << static_cast<int>(Direction::Right),  ///< Right edge mask
+  TopMask = 1 << static_cast<int>(Direction::Top),      ///< Top edge mask
+  BottomMask = 1 << static_cast<int>(Direction::Bottom) ///< Bottom edge mask
+};

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -155,6 +155,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(uint32_t activeSides) override = 0;
+  uint32_t activeSides() override = 0;
   void warpCursor(int32_t x, int32_t y) override = 0;
   uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override = 0;
   void unregisterHotKey(uint32_t id) override = 0;

--- a/src/lib/deskflow/IPrimaryScreen.h
+++ b/src/lib/deskflow/IPrimaryScreen.h
@@ -85,6 +85,12 @@ public:
   */
   virtual void reconfigure(uint32_t activeSides) = 0;
 
+  /**
+   * @brief activeSides
+   * @return a bitmask of DirectionMask indicating which sides of the primary screen are linked to clients
+   */
+  virtual uint32_t activeSides() = 0;
+
   //! Warp cursor
   /*!
   Warp the cursor to the absolute coordinates \c x,y.  Also

--- a/src/lib/deskflow/PlatformScreen.h
+++ b/src/lib/deskflow/PlatformScreen.h
@@ -34,6 +34,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(uint32_t activeSides) override = 0;
+  uint32_t activeSides() override = 0;
   void warpCursor(int32_t x, int32_t y) override = 0;
   uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override = 0;
   void unregisterHotKey(uint32_t id) override = 0;

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -7,9 +7,8 @@
 
 #pragma once
 
+#include "base/DirectionTypes.h"
 #include "base/EventTypes.h"
-
-#include <cstdint>
 
 /**
  * @file ProtocolTypes.h
@@ -149,43 +148,6 @@ static constexpr uint32_t PROTOCOL_MAX_STRING_LENGTH = 1024 * 1024;
  * @brief Enumeration types used in protocol messages
  * @{
  */
-
-/**
- * @brief Screen edge directions for mouse movement
- *
- * Used to specify which edge of a screen the mouse cursor crosses
- * when moving between primary and secondary screens.
- *
- * @since Protocol version 1.0
- */
-enum class Direction : uint8_t
-{
-  NoDirection,                                                             ///< No specific direction
-  Left,                                                                    ///< Left edge of screen
-  Right,                                                                   ///< Right edge of screen
-  Top,                                                                     ///< Top edge of screen
-  Bottom,                                                                  ///< Bottom edge of screen
-  FirstDirection = Direction::Left,                                        ///< First valid direction value
-  LastDirection = Direction::Bottom,                                       ///< Last valid direction value
-  NumDirections = Direction::LastDirection - Direction::FirstDirection + 1 ///< Total number of directions
-};
-
-/**
- * @brief Bitmask values for screen edge directions
- *
- * Used to create bitmasks representing multiple screen edges.
- * Useful for configuration and edge detection.
- *
- * @since Protocol version 1.0
- */
-enum class DirectionMask
-{
-  NoDirMask = 0,                                        ///< No direction mask
-  LeftMask = 1 << static_cast<int>(Direction::Left),    ///< Left edge mask
-  RightMask = 1 << static_cast<int>(Direction::Right),  ///< Right edge mask
-  TopMask = 1 << static_cast<int>(Direction::Top),      ///< Top edge mask
-  BottomMask = 1 << static_cast<int>(Direction::Bottom) ///< Bottom edge mask
-};
 
 /**
  * @brief File transfer data chunk types

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -177,9 +177,15 @@ void EiScreen::getCursorPos(int32_t &x, int32_t &y) const
   y = m_cursorY;
 }
 
-void EiScreen::reconfigure(uint32_t)
+void EiScreen::reconfigure(uint32_t activeSides)
 {
-  // do nothing
+  LOG((CLOG_DEBUG "active sides: %x", activeSides));
+  m_activeSides = activeSides;
+}
+
+std::uint32_t EiScreen::activeSides()
+{
+  return m_activeSides;
 }
 
 void EiScreen::warpCursor(int32_t x, int32_t y)

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -43,6 +43,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(std::uint32_t activeSides) override;
+  std::uint32_t activeSides() override;
   void warpCursor(std::int32_t x, std::int32_t y) override;
   std::uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override;
   void unregisterHotKey(std::uint32_t id) override;
@@ -128,6 +129,7 @@ private:
 
   std::uint32_t m_sequenceNumber = 0;
 
+  std::uint32_t m_activeSides = 0;
   std::uint32_t m_x = 0;
   std::uint32_t m_y = 0;
   std::uint32_t m_w = 0;

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -115,6 +115,11 @@ void MSWindowsHook::setSides(uint32_t sides)
   g_zoneSides = sides;
 }
 
+uint32_t MSWindowsHook::getSides()
+{
+  return g_zoneSides;
+}
+
 void MSWindowsHook::setZone(int32_t x, int32_t y, int32_t w, int32_t h, int32_t jumpZoneSize)
 {
   g_zoneSize = jumpZoneSize;

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -56,6 +56,7 @@ public:
   int cleanup();
 
   void setSides(uint32_t sides);
+  uint32_t getSides();
 
   void setZone(int32_t x, int32_t y, int32_t w, int32_t h, int32_t jumpZoneSize);
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -507,6 +507,11 @@ void MSWindowsScreen::reconfigure(uint32_t activeSides)
   m_hook.setSides(activeSides);
 }
 
+uint32_t MSWindowsScreen::activeSides()
+{
+  return m_hook.getSides();
+}
+
 void MSWindowsScreen::warpCursor(int32_t x, int32_t y)
 {
   // warp mouse

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -86,6 +86,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(uint32_t activeSides) override;
+  uint32_t activeSides() override;
   void warpCursor(int32_t x, int32_t y) override;
   uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override;
   void unregisterHotKey(uint32_t id) override;

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -64,6 +64,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(uint32_t activeSides) override;
+  uint32_t activeSides() override;
   void warpCursor(int32_t x, int32_t y) override;
   uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override;
   void unregisterHotKey(uint32_t id) override;
@@ -229,6 +230,7 @@ private:
   // the display
   CGDirectDisplayID m_displayID;
 
+  uint32_t m_activeSides = 0;
   // screen shape stuff
   int32_t m_x, m_y;
   int32_t m_w, m_h;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -244,9 +244,15 @@ void OSXScreen::getCursorPos(int32_t &x, int32_t &y) const
   CFRelease(event);
 }
 
-void OSXScreen::reconfigure(uint32_t)
+void OSXScreen::reconfigure(uint32_t activeSides)
 {
-  // do nothing
+  LOG((CLOG_DEBUG "active sides: %x", activeSides));
+  m_activeSides = activeSides;
+}
+
+uint32_t OSXScreen::activeSides()
+{
+  return m_activeSides;
 }
 
 void OSXScreen::warpCursor(int32_t x, int32_t y)

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -72,8 +72,6 @@ private:
     static_cast<PortalInputCapture *>(data)->handleZonesChanged(session, options);
   }
 
-  int fakeEisFd() const;
-
 private:
   enum class Signal : uint8_t
   {

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -477,9 +477,14 @@ void XWindowsScreen::getCursorPos(int32_t &x, int32_t &y) const
   }
 }
 
-void XWindowsScreen::reconfigure(uint32_t)
+void XWindowsScreen::reconfigure(uint32_t activeSides)
 {
-  // do nothing
+  m_activeSides = activeSides;
+}
+
+uint32_t XWindowsScreen::activeSides()
+{
+  return m_activeSides;
 }
 
 void XWindowsScreen::warpCursor(int32_t x, int32_t y)

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -46,6 +46,7 @@ public:
 
   // IPrimaryScreen overrides
   void reconfigure(uint32_t activeSides) override;
+  uint32_t activeSides() override;
   void warpCursor(int32_t x, int32_t y) override;
   uint32_t registerHotKey(KeyID key, KeyModifierMask mask) override;
   void unregisterHotKey(uint32_t id) override;
@@ -175,6 +176,7 @@ private:
   // true if mouse has entered the screen
   bool m_isOnScreen;
 
+  uint32_t m_activeSides = 0;
   // screen shape stuff
   int32_t m_x = 0;
   int32_t m_y = 0;


### PR DESCRIPTION
fixes #8572 
fixes #8452 
fixes #8605 
any remaining cases of #8005 
Maybe more as well as those cases where the mouse could just vanish when it touched an edge (at least for wayland) 

 - Remove un needed `InputCapturePortal::fakeEisFd` method 
 - Set only the barriers that have a screen next to them on wayland 
   - Move Direction and DirectionMask enums to `base/DirectionTypes.h`
   - Add `IPrimaryScreen::activeSides` to return the side mask
   - Implement `IPrimaryScreen::refactor` in the subclasses 
   - Use activeSide data to set zones used when making the InputCapture portal request


