### PR TITLE
chore: MainWindow, Use system monospace font in log

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -27,10 +27,9 @@ runs:
 
   steps:
     - name: Install Depends
+      if: ${{ runner.os != 'Windows' }}
       run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            choco install ninja
-          elif [ "$RUNNER_OS" == "macOS" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
             brew install googletest openssl --quiet
           elif [ "$RUNNER_OS" == "Linux" ]; then
             if [ ${{inputs.like}} == "debian" ]; then

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -85,6 +85,14 @@ MainWindow::MainWindow()
 {
   ui->setupUi(this);
 
+  // setup the log font
+  ui->textLog->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+#ifdef Q_OS_MAC
+  auto f = ui->textLog->font();
+  f.setPixelSize(12);
+  ui->textLog->setFont(f);
+#endif
+
   // Setup Actions
   m_actionAbout->setText(tr("About %1...").arg(kAppName));
   m_actionAbout->setMenuRole(QAction::AboutRole);

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -424,12 +424,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="font">
-          <font>
-           <family>Courier</family>
-           <kerning>true</kerning>
-          </font>
-         </property>
          <property name="lineWrapMode">
           <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
          </property>


### PR DESCRIPTION
Use the system's monospace font for the log.
Bump the font size up a bit for macOS to 12px. Its default is way to small.

fixes : maybe some of https://github.com/deskflow/deskflow/issues/7865 , Others?

windows runner was updated to ninja 1.13.1 so reverting the commit to update it with our action
