### PR TITLE
ci: use Qt 6.9.1 on windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,7 +133,7 @@ jobs:
             runs-on: "windows-2022"
             timeout: 30
             config-args: "-G Ninja"
-            qt-version: 6.8.3
+            qt-version: 6.9.1
             vcpkg-triplet: x64-windows-release
             arch: "amd64"
 
@@ -141,7 +141,7 @@ jobs:
             runs-on: "windows-11-arm"
             timeout: 30
             config-args: "-G Ninja"
-            qt-version: 6.8.3
+            qt-version: 6.9.1
             vcpkg-triplet: arm64-windows
             arch: "arm64"
 


### PR DESCRIPTION
Use Qt 6.9.1 on windows