### PR TITLE
refactor: windows write daemon log in ProgramData\Deskflow

### DIFF
--- a/deploy/windows/wix-patch.xml.in
+++ b/deploy/windows/wix-patch.xml.in
@@ -17,6 +17,7 @@
       />
     </ServiceInstall>
     <ServiceControl Id="ServiceControl" Name="Deskflow" Remove="uninstall" Start="install" Stop="both"/>
+    <RemoveFile Id="RmOldLog" On="install" Name="deskflow-daemon.log"/>
   </CPackWiXFragment>
 
   <CPackWiXFragment Id="CM_CP_deskflow_server.exe">

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -129,11 +129,7 @@ QVariant Settings::defaultValue(const QString &key)
   }
 
   if (key == Daemon::LogFile) {
-#ifdef Q_OS_WIN
-    return QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kDaemonLogFilename);
-#else
     return QStringLiteral("%1/%2").arg(Settings::settingsPath(), kDaemonLogFilename);
-#endif
   }
 
   return QVariant();


### PR DESCRIPTION
Windows Only: 
 - write the daemon log to `C:\ProgramData\Deskflow`
 - on update / install remove old log `C:\ProgramFiles\Deskflow\deskflow-daemon.log` (makes sure if updating then uninstalling later on the install dir is removed correctly)
