### PR TITLE
ci: use Qt 6.9.0 for x64 windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,7 +133,7 @@ jobs:
             runs-on: "windows-2022"
             timeout: 30
             config-args: "-G Ninja"
-            qt-version: 6.9.1
+            qt-version: 6.9.0
             vcpkg-triplet: x64-windows-release
             arch: "amd64"
 


### PR DESCRIPTION
downgrade Qt on x64 windows to avoid random build failures with 6.9.1.

The build randomly fails locally for me and on CI when building with Qt 6.9.1 on windows x64 (but not arm..) until this is resolved lets save a bunch of Ci time by landing this and letting the cache get repopulated. 