### PR TITLE
Sonar cleanup 9

### DIFF
--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -45,7 +45,7 @@ public:
   \p target is the intended recipient of the event.
   \p flags is any combination of \c Flags.
   */
-  Event(EventTypes type, void *target = nullptr, void *data = nullptr, Flags flags = EventFlags::NoFlags);
+  explicit Event(EventTypes type, void *target = nullptr, void *data = nullptr, Flags flags = EventFlags::NoFlags);
 
   //! Create \c Event with non-POD data
   /*!
@@ -53,7 +53,7 @@ public:
   \p target is the intended recipient of the event.
   \p dataObject with event data
   */
-  Event(EventTypes type, void *target, EventData *dataObject);
+  explicit Event(EventTypes type, void *target, EventData *dataObject);
 
   //! @name manipulators
   //@{

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -46,13 +46,13 @@ public:
   void push(const value_type &v)
   {
     c.push_back(v);
-    std::push_heap(c.begin(), c.end(), comp);
+    std::ranges::push_heap(c, comp);
   }
 
   //! Remove head element
   void pop()
   {
-    std::pop_heap(c.begin(), c.end(), comp);
+    std::ranges::pop_heap(c, comp);
     c.pop_back();
   }
 
@@ -60,7 +60,7 @@ public:
   void erase(iterator i)
   {
     c.erase(i);
-    std::make_heap(c.begin(), c.end(), comp);
+    std::ranges::make_heap(c, comp);
   }
 
   //! Get start iterator
@@ -85,7 +85,7 @@ public:
   void swap(Container &c2) noexcept
   {
     c.swap(c2);
-    std::make_heap(c.begin(), c.end(), comp);
+    std::ranges::make_heap(c, comp);
   }
 
   //@}

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -493,18 +493,16 @@ const KeyMap::KeyItem *KeyMap::mapCommandKey(
   for (int32_t groupOffset = 0; groupOffset < numGroups; ++groupOffset) {
     const auto effectiveGroup = getEffectiveGroup(group, groupOffset);
     const KeyEntryList &entryList = keyGroupTable[effectiveGroup];
-    for (size_t i = 0; i < entryList.size(); ++i) {
-      if (entryList[i].size() != 1) {
-        // ignore multikey entries
+    for (const auto &entry : entryList) {
+      if (entry.size() != 1) {
         continue;
       }
-
       // match based on shift and make sure all required modifiers,
       // except shift, are already in the desired mask;  we're
       // after the right button not the right character.
       // we'll use desiredMask as-is, overriding the key's required
       // modifiers, when synthesizing this button.
-      const KeyItem &item = entryList[i].back();
+      const auto &item = entry.back();
       KeyModifierMask desiredShiftMask = KeyModifierShift & desiredMask;
       KeyModifierMask requiredIgnoreShiftMask = item.m_required & ~KeyModifierShift;
       if ((item.m_required & desiredShiftMask) == (item.m_sensitive & desiredShiftMask) &&
@@ -514,11 +512,11 @@ const KeyMap::KeyItem *KeyMap::mapCommandKey(
         break;
       }
     }
-    if (keyItem != nullptr) {
+    if (keyItem) {
       break;
     }
   }
-  if (keyItem == nullptr) {
+  if (!keyItem) {
     // no mapping for this keysym
     LOG((CLOG_DEBUG1 "no mapping for key %04x", id));
     return nullptr;

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -780,29 +780,28 @@ bool KeyMap::keysToRestoreModifiers(
   collectButtons(desiredModifiers, newKeys);
 
   // release unwanted keys
-  for (ModifierToKeys::const_iterator i = oldModifiers.begin(); i != oldModifiers.end(); ++i) {
-    KeyButton button = i->second.m_button;
+  for (const auto &[_mask, _keyItem] : oldModifiers) {
+    KeyButton button = _keyItem.m_button;
     if (button != keyItem.m_button && !newKeys.contains(button)) {
       EKeystroke type = kKeystrokeRelease;
-      if (i->second.m_lock) {
+      if (_keyItem.m_lock) {
         type = kKeystrokeUnmodify;
       }
-      addKeystrokes(type, i->second, activeModifiers, currentState, keystrokes);
+      addKeystrokes(type, _keyItem, activeModifiers, currentState, keystrokes);
     }
   }
 
   // press wanted keys
-  for (auto i = desiredModifiers.begin(); i != desiredModifiers.end(); ++i) {
-    const KeyButton button = i->second.m_button;
+  for (const auto &[_mask, _keyItem] : desiredModifiers) {
+    const KeyButton button = _keyItem.m_button;
     if (button != keyItem.m_button && !oldKeys.contains(button)) {
       EKeystroke type = kKeystrokePress;
-      if (i->second.m_lock) {
+      if (_keyItem.m_lock) {
         type = kKeystrokeModify;
       }
-      addKeystrokes(type, i->second, activeModifiers, currentState, keystrokes);
+      addKeystrokes(type, _keyItem, activeModifiers, currentState, keystrokes);
     }
   }
-
   return true;
 }
 

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -1228,7 +1228,7 @@ bool KeyMap::KeyItem::operator==(const KeyItem &x) const
 // KeyMap::Keystroke
 //
 
-KeyMap::Keystroke::Keystroke(KeyButton button, bool press, bool repeat, uint32_t data) : m_type(kButton)
+KeyMap::Keystroke::Keystroke(KeyButton button, bool press, bool repeat, uint32_t data) : m_type(KeyType::Button)
 {
   m_data.m_button.m_button = button;
   m_data.m_button.m_press = press;
@@ -1236,7 +1236,7 @@ KeyMap::Keystroke::Keystroke(KeyButton button, bool press, bool repeat, uint32_t
   m_data.m_button.m_client = data;
 }
 
-KeyMap::Keystroke::Keystroke(int32_t group, bool absolute, bool restore) : m_type(kGroup)
+KeyMap::Keystroke::Keystroke(int32_t group, bool absolute, bool restore) : m_type(KeyType::Group)
 {
   m_data.m_group.m_group = group;
   m_data.m_group.m_absolute = absolute;

--- a/src/lib/deskflow/KeyMap.h
+++ b/src/lib/deskflow/KeyMap.h
@@ -71,10 +71,10 @@ public:
   class Keystroke
   {
   public:
-    enum EType
+    enum class KeyType
     {
-      kButton, //!< Synthesize button
-      kGroup   //!< Set new group
+      Button, //!< Synthesize button
+      Group   //!< Set new group
     };
 
     Keystroke(KeyButton, bool press, bool repeat, uint32_t clientData);
@@ -103,7 +103,7 @@ public:
       Group m_group;
     };
 
-    EType m_type{};
+    KeyType m_type{};
     Data m_data{};
   };
 

--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -874,7 +874,7 @@ bool KeyState::fakeKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyB
     // replace key up with previous KeyButton but leave key down
     // alone so it uses the new KeyButton.
     for (auto &key : keys) {
-      if (key.m_type == Keystroke::kButton && key.m_data.m_button.m_button == localID) {
+      if (key.m_type == Keystroke::KeyType::Button && key.m_data.m_button.m_button == localID) {
         key.m_data.m_button.m_button = oldLocalID;
         break;
       }
@@ -1067,20 +1067,21 @@ void KeyState::fakeKeys(const Keystrokes &keys, uint32_t count)
   // generate key events
   LOG((CLOG_DEBUG1 "keystrokes:"));
   for (auto k = keys.begin(); k != keys.end();) {
-    if (k->m_type == Keystroke::kButton && k->m_data.m_button.m_repeat) {
+    if (k->m_type == Keystroke::KeyType::Button && k->m_data.m_button.m_repeat) {
       // repeat from here up to but not including the next key
       // with m_repeat == false count times.
       Keystrokes::const_iterator start = k;
       while (count-- > 0) {
         // send repeating events
-        for (k = start; k != keys.end() && k->m_type == Keystroke::kButton && k->m_data.m_button.m_repeat; ++k) {
+        for (k = start; k != keys.end() && k->m_type == Keystroke::KeyType::Button && k->m_data.m_button.m_repeat;
+             ++k) {
           fakeKey(*k);
         }
       }
 
       // note -- k is now on the first non-repeat key after the
       // repeat keys, exactly where we'd like to continue from.
-    } else if (k->m_type != Keystroke::kGroup || (!k->m_data.m_group.m_restore && m_isLangSyncEnabled)) {
+    } else if (k->m_type != Keystroke::KeyType::Group || (!k->m_data.m_group.m_restore && m_isLangSyncEnabled)) {
       // send event
       fakeKey(*k);
 

--- a/src/lib/gui/dialogs/ActionDialog.cpp
+++ b/src/lib/gui/dialogs/ActionDialog.cpp
@@ -27,9 +27,7 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
   connect(
       ui->comboActionType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ActionDialog::actionTypeChanged
   );
-  connect(ui->listScreens, &QListWidget::itemChanged, this, [&] {
-    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(canSave());
-  });
+  connect(ui->listScreens, &QListWidget::itemChanged, this, &ActionDialog::itemToggled);
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ActionDialog::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ActionDialog::reject);
 
@@ -114,6 +112,11 @@ void ActionDialog::updateSize()
 void ActionDialog::keySequenceChanged()
 {
   ui->listScreens->setEnabled(!ui->keySequenceWidget->keySequence().isMouseButton());
+  ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(canSave());
+}
+
+void ActionDialog::itemToggled() const
+{
   ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(canSave());
 }
 

--- a/src/lib/gui/dialogs/ActionDialog.h
+++ b/src/lib/gui/dialogs/ActionDialog.h
@@ -44,6 +44,7 @@ protected Q_SLOTS:
 private:
   void updateSize();
   void keySequenceChanged();
+  void itemToggled() const;
   void actionTypeChanged(int index);
   bool isKeyAction(int index) const;
   bool canSave() const;

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -231,7 +231,7 @@ void EiKeyState::getKeyMap(deskflow::KeyMap &keyMap)
 void EiKeyState::fakeKey(const Keystroke &keystroke)
 {
   switch (keystroke.m_type) {
-  case Keystroke::kButton:
+  case Keystroke::KeyType::Button:
     LOG_DEBUG1(
         "fake key: %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client,
         keystroke.m_data.m_button.m_press ? "down" : "up"

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1163,7 +1163,7 @@ void MSWindowsKeyState::getKeyMap(deskflow::KeyMap &keyMap)
 void MSWindowsKeyState::fakeKey(const Keystroke &keystroke)
 {
   switch (keystroke.m_type) {
-  case Keystroke::kButton: {
+  case Keystroke::KeyType::Button: {
     LOG(
         (CLOG_DEBUG1 "  %03x (%08x) %s", keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_client,
          keystroke.m_data.m_button.m_press ? "down" : "up")
@@ -1201,7 +1201,7 @@ void MSWindowsKeyState::fakeKey(const Keystroke &keystroke)
     break;
   }
 
-  case Keystroke::kGroup:
+  case Keystroke::KeyType::Group:
     // we don't restore the group.  we'd like to but we can't be
     // sure the restoring group change will be processed after the
     // key events.

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -594,7 +594,7 @@ void OSXKeyState::postKeyboardKey(CGKeyCode virtualKey, bool keyDown)
 void OSXKeyState::fakeKey(const Keystroke &keystroke)
 {
   switch (keystroke.m_type) {
-  case Keystroke::kButton: {
+  case Keystroke::KeyType::Button: {
     bool keyDown = keystroke.m_data.m_button.m_press;
     uint32_t client = keystroke.m_data.m_button.m_client;
     KeyButton button = keystroke.m_data.m_button.m_button;
@@ -614,7 +614,7 @@ void OSXKeyState::fakeKey(const Keystroke &keystroke)
     break;
   }
 
-  case Keystroke::kGroup: {
+  case Keystroke::KeyType::Group: {
     int32_t group = keystroke.m_data.m_group.m_group;
     if (!keystroke.m_data.m_group.m_restore) {
       if (keystroke.m_data.m_group.m_absolute) {

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -73,7 +73,7 @@ void PortalInputCapture::handleSessionClosed(XdpSession *session)
 {
   LOG_ERR("portal input capture session was closed, exiting");
   g_main_loop_quit(m_glibMainLoop);
-  m_events->addEvent(EventTypes::Quit);
+  m_events->addEvent(Event(EventTypes::Quit));
 
   g_signal_handler_disconnect(session, m_signals.at(Signal::SessionClosed));
   m_signals.at(Signal::SessionClosed) = 0;
@@ -88,7 +88,7 @@ void PortalInputCapture::handleInitSession(GObject *object, GAsyncResult *res)
   if (!session) {
     LOG_ERR("failed to initialize input capture session, quitting: %s", error->message);
     g_main_loop_quit(m_glibMainLoop);
-    m_events->addEvent(EventTypes::Quit);
+    m_events->addEvent(Event(EventTypes::Quit));
     return;
   }
 
@@ -98,7 +98,7 @@ void PortalInputCapture::handleInitSession(GObject *object, GAsyncResult *res)
   if (fd < 0) {
     LOG_ERR("failed to connect to eis: %s", error->message);
     g_main_loop_quit(m_glibMainLoop);
-    m_events->addEvent(EventTypes::Quit);
+    m_events->addEvent(Event(EventTypes::Quit));
     return;
   }
 

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -83,7 +83,7 @@ void PortalRemoteDesktop::handleSessionStarted(GObject *object, GAsyncResult *re
   if (!xdp_session_start_finish(session, res, &error)) {
     LOG_ERR("failed to start portal remote desktop session, quitting: %s", error->message);
     g_main_loop_quit(m_glibMainLoop);
-    m_events->addEvent(EventTypes::Quit);
+    m_events->addEvent(Event(EventTypes::Quit));
     return;
   }
 
@@ -96,7 +96,7 @@ void PortalRemoteDesktop::handleSessionStarted(GObject *object, GAsyncResult *re
   fd = xdp_session_connect_to_eis(session, &error);
   if (fd < 0) {
     g_main_loop_quit(m_glibMainLoop);
-    m_events->addEvent(EventTypes::Quit);
+    m_events->addEvent(Event(EventTypes::Quit));
     return;
   }
 
@@ -116,7 +116,7 @@ void PortalRemoteDesktop::handleInitSession(GObject *object, GAsyncResult *res)
     // fails.
     if (m_sessionIteration == 0) {
       g_main_loop_quit(m_glibMainLoop);
-      m_events->addEvent(EventTypes::Quit);
+      m_events->addEvent(Event(EventTypes::Quit));
     } else {
       this->reconnect(1000);
     }

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -265,7 +265,7 @@ bool XWindowsKeyState::setCurrentLanguageWithDBus(int32_t group) const
 void XWindowsKeyState::fakeKey(const Keystroke &keystroke)
 {
   switch (keystroke.m_type) {
-  case Keystroke::kButton:
+  case Keystroke::KeyType::Button:
     if (keystroke.m_data.m_button.m_repeat) {
       int c = keystroke.m_data.m_button.m_button;
       int i = (c >> 3);
@@ -281,7 +281,7 @@ void XWindowsKeyState::fakeKey(const Keystroke &keystroke)
     );
     break;
 
-  case Keystroke::kGroup:
+  case Keystroke::KeyType::Group:
     if (keystroke.m_data.m_group.m_restore) {
       break;
     }

--- a/src/unittests/legacytests/legacytests/deskflow/KeyStateTests.cpp
+++ b/src/unittests/legacytests/legacytests/deskflow/KeyStateTests.cpp
@@ -290,7 +290,7 @@ TEST(KeyStateTests, fakeKeyRepeat_validKey_returnsTrue)
   MockEventQueue eventQueue;
   KeyStateImpl keyState(eventQueue, keyMap);
   s_stubKeyItem.m_client = 0;
-  s_stubKeystroke.m_type = deskflow::KeyMap::Keystroke::kButton;
+  s_stubKeystroke.m_type = deskflow::KeyMap::Keystroke::KeyType::Button;
   s_stubKeystroke.m_data.m_button.m_button = 2;
 
   // set the button to 1 for fakeKeyDown call


### PR DESCRIPTION
Fix more sonar issues 

- Refactor: ActionDialog to use proper method in place of lambda
- PriorityQueue: use std::ranges version of heap methods 
- KeyMap::mapCommandKey and keysToRestoreModifier use ranged loops
- More Enum Classes
   - KeyMap's `EType` => `KeyMap::KeyType`
- Explicit constructor for `Event's` not default constructors.