### PR TITLE
Sonar Cleanup 10

### DIFF
--- a/src/lib/base/CMakeLists.txt
+++ b/src/lib/base/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(base STATIC
   Log.cpp
   Log.h
   LogLevel.h
+  NetworkProtocol.h
   Path.cpp
   Path.h
   PriorityQueue.h

--- a/src/lib/base/NetworkProtocol.h
+++ b/src/lib/base/NetworkProtocol.h
@@ -1,0 +1,13 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+enum class NetworkProtocol
+{
+  Synergy,
+  Barrier
+};

--- a/src/lib/deskflow/Clipboard.cpp
+++ b/src/lib/deskflow/Clipboard.cpp
@@ -27,7 +27,7 @@ bool Clipboard::empty()
   }
 
   // clear all data
-  for (int32_t index = 0; index < kNumFormats; ++index) {
+  for (int32_t index = 0; index < static_cast<int>(Format::TotalFormats); ++index) {
     m_data[index] = "";
     m_added[index] = false;
   }
@@ -41,7 +41,7 @@ bool Clipboard::empty()
   return true;
 }
 
-void Clipboard::add(EFormat format, const std::string &data)
+void Clipboard::add(Format format, const std::string &data)
 {
   if (!m_open) {
     LOG_WARN("cannot add to clipboard, not open");
@@ -53,8 +53,9 @@ void Clipboard::add(EFormat format, const std::string &data)
     return;
   }
 
-  m_data[format] = data;
-  m_added[format] = true;
+  const auto formatID = static_cast<int>(format);
+  m_data[formatID] = data;
+  m_added[formatID] = true;
 }
 
 bool Clipboard::open(Time time) const
@@ -83,22 +84,22 @@ Clipboard::Time Clipboard::getTime() const
   return m_timeOwned;
 }
 
-bool Clipboard::has(EFormat format) const
+bool Clipboard::has(Format format) const
 {
   if (!m_open) {
     LOG_WARN("cannot check for clipboard format, not open");
     return false;
   }
-  return m_added[format];
+  return m_added[static_cast<int>(format)];
 }
 
-std::string Clipboard::get(EFormat format) const
+std::string Clipboard::get(Format format) const
 {
   if (!m_open) {
     LOG_WARN("cannot get clipboard format, not open");
     return "";
   }
-  return m_data[format];
+  return m_data[static_cast<int>(format)];
 }
 
 void Clipboard::unmarshall(const std::string &data, Time time)

--- a/src/lib/deskflow/Clipboard.h
+++ b/src/lib/deskflow/Clipboard.h
@@ -44,18 +44,18 @@ public:
 
   // IClipboard overrides
   bool empty() final;
-  void add(EFormat, const std::string &data) override;
+  void add(Format, const std::string &data) override;
   bool open(Time) const final;
   void close() const override;
   Time getTime() const override;
-  bool has(EFormat) const override;
-  std::string get(EFormat) const override;
+  bool has(Format) const override;
+  std::string get(Format) const override;
 
 private:
   mutable bool m_open = false;
   mutable Time m_time;
   bool m_owner = false;
   Time m_timeOwned;
-  bool m_added[kNumFormats] = {false, false, false};
-  std::string m_data[kNumFormats] = {"", "", ""};
+  bool m_added[static_cast<int>(Format::TotalFormats)] = {false, false, false};
+  std::string m_data[static_cast<int>(Format::TotalFormats)] = {"", "", ""};
 };

--- a/src/lib/deskflow/IClipboard.h
+++ b/src/lib/deskflow/IClipboard.h
@@ -46,12 +46,12 @@ public:
   HTML fragment (but not necessarily a complete HTML document).
   Newlines are LF.
   */
-  enum EFormat
+  enum class Format
   {
-    kText,      //!< Text format, UTF-8, newline is LF
-    kHTML,      //!< HTML format, HTML fragment, UTF-8, newline is LF
-    kBitmap,    //!< Bitmap format, BMP 24/32bpp, BI_RGB
-    kNumFormats //!< The number of clipboard formats
+    Text,        //!< Text format, UTF-8, newline is LF
+    HTML,        //!< HTML format, HTML fragment, UTF-8, newline is LF
+    Bitmap,      //!< Bitmap format, BMP 24/32bpp, BI_RGB
+    TotalFormats //!< The number of clipboard formats supported
   };
 
   //! @name manipulators
@@ -71,7 +71,7 @@ public:
   Add data in the given format to the clipboard.  May only be
   called after a successful empty().
   */
-  virtual void add(EFormat, const std::string &data) = 0;
+  virtual void add(Format, const std::string &data) = 0;
 
   //@}
   //! @name accessors
@@ -109,7 +109,7 @@ public:
   Return true iff the clipboard contains data in the given
   format.  Must be called between a successful open() and close().
   */
-  virtual bool has(EFormat) const = 0;
+  virtual bool has(Format) const = 0;
 
   //! Get data
   /*!
@@ -117,7 +117,7 @@ public:
   if there is no data in that format.  Must be called between
   a successful open() and close().
   */
-  virtual std::string get(EFormat) const = 0;
+  virtual std::string get(Format) const = 0;
 
   //! Marshall clipboard data
   /*!

--- a/src/lib/deskflow/OptionTypes.h
+++ b/src/lib/deskflow/OptionTypes.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "base/EventTypes.h"
+#include "base/NetworkProtocol.h"
 
 #include <vector>
 
@@ -70,15 +71,6 @@ inline static const auto s_topRightCornerMask = 1 << 1;
 inline static const auto s_bottomLeftCornerMask = 1 << 2;
 inline static const auto s_bottomRightCornerMask = 1 << 3;
 inline static const auto s_allCornersMask = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3;
-//@}
-
-//! @name Network protocol
-//@{
-enum class ENetworkProtocol
-{
-  kSynergy,
-  kBarrier
-};
 //@}
 
 #undef OPTION_CODE

--- a/src/lib/deskflow/OptionTypes.h
+++ b/src/lib/deskflow/OptionTypes.h
@@ -62,31 +62,14 @@ static const OptionID kOptionClipboardSharing = OPTION_CODE("CLPS");
 static const OptionID kOptionClipboardSharingSize = OPTION_CODE("CLSZ");
 //@}
 
-//! @name Screen switch corner enumeration
-//@{
-enum EScreenSwitchCorners
-{
-  kNoCorner,
-  kTopLeft,
-  kTopRight,
-  kBottomLeft,
-  kBottomRight,
-  kFirstCorner = kTopLeft,
-  kLastCorner = kBottomRight
-};
-//@}
-
 //! @name Screen switch corner masks
 //@{
-enum EScreenSwitchCornerMasks
-{
-  kNoCornerMask = 0,
-  kTopLeftMask = 1 << (kTopLeft - kFirstCorner),
-  kTopRightMask = 1 << (kTopRight - kFirstCorner),
-  kBottomLeftMask = 1 << (kBottomLeft - kFirstCorner),
-  kBottomRightMask = 1 << (kBottomRight - kFirstCorner),
-  kAllCornersMask = kTopLeftMask | kTopRightMask | kBottomLeftMask | kBottomRightMask
-};
+inline static const auto s_noCornerMask = 0;
+inline static const auto s_topLeftCornerMask = 1 << 0;
+inline static const auto s_topRightCornerMask = 1 << 1;
+inline static const auto s_bottomLeftCornerMask = 1 << 2;
+inline static const auto s_bottomRightCornerMask = 1 << 3;
+inline static const auto s_allCornersMask = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3;
 //@}
 
 //! @name Network protocol

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -19,14 +19,14 @@
 
 #include <memory>
 
-enum EServerState
+enum class ServerState
 {
-  kUninitialized,
-  kInitializing,
-  kInitializingToStart,
-  kInitialized,
-  kStarting,
-  kStarted
+  Uninitialized,
+  Initializing,
+  InitializingToStart,
+  Initialized,
+  Starting,
+  Started
 };
 
 class Server;
@@ -131,7 +131,7 @@ private:
 
   bool m_suspended = false;
   Server *m_server = nullptr;
-  EServerState m_serverState = EServerState::kUninitialized;
+  ServerState m_serverState = ServerState::Uninitialized;
   deskflow::Screen *m_serverScreen = nullptr;
   PrimaryClient *m_primaryClient = nullptr;
   ClientListener *m_listener = nullptr;

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -1037,7 +1037,7 @@ void MainWindow::autoAddScreen(const QString &name)
   if (name.isEmpty())
     return;
 
-  if (m_serverConfig.autoAddScreen(name) == AutoAddScreenManualClient) {
+  if (m_serverConfig.autoAddScreen(name) == ScreenAddResults::AutoAddScreenManualClient) {
     showConfigureServer(
         tr("Please add the client (%1) to the grid.").arg(Settings::value(Settings::Core::ScreenName).toString())
     );

--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -165,7 +165,7 @@ void ServerConfig::recall()
 
   haveHeartbeat(settings().value("hasHeartbeat", false).toBool());
   setHeartbeat(settings().value("heartbeat", 5000).toInt());
-  setProtocol(static_cast<ServerProtocol>(settings().value("protocol", static_cast<int>(protocol())).toInt()));
+  setProtocol(static_cast<NetworkProtocol>(settings().value("protocol", static_cast<int>(protocol())).toInt()));
   setRelativeMouseMoves(settings().value("relativeMouseMoves", false).toBool());
   setWin32KeepForeground(settings().value("win32KeepForeground", false).toBool());
   haveSwitchDelay(settings().value("hasSwitchDelay", false).toBool());
@@ -224,7 +224,7 @@ int ServerConfig::adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) co
 
 QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 {
-  using enum deskflow::gui::ServerProtocol;
+  using enum NetworkProtocol;
 
   outStream << "section: screens" << Qt::endl;
 
@@ -264,9 +264,9 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   if (config.hasHeartbeat())
     outStream << "\t" << "heartbeat = " << config.heartbeat() << Qt::endl;
 
-  if (config.protocol() == kSynergy) {
+  if (config.protocol() == Synergy) {
     outStream << "\t" << "protocol = synergy" << Qt::endl;
-  } else if (config.protocol() == kBarrier) {
+  } else if (config.protocol() == Barrier) {
     outStream << "\t" << "protocol = barrier" << Qt::endl;
   } else {
     qFatal("unrecognized protocol when writing config");

--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -321,9 +321,10 @@ int ServerConfig::numScreens() const
   return rval;
 }
 
-int ServerConfig::autoAddScreen(const QString name)
+ScreenAddResults ServerConfig::autoAddScreen(const QString name)
 {
   using enum AddAction;
+  using enum ScreenAddResults;
 
   int serverIndex = -1;
   int targetIndex = -1;

--- a/src/lib/gui/ServerConfig.h
+++ b/src/lib/gui/ServerConfig.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Hotkey.h"
+#include "base/NetworkProtocol.h"
 #include "gui/config/IServerConfig.h"
 #include "gui/config/ScreenConfig.h"
 #include "gui/config/ScreenList.h"
@@ -26,14 +27,8 @@ class MainWindow;
 
 namespace deskflow::gui {
 
-enum class ServerProtocol
-{
-  kSynergy,
-  kBarrier
-};
-
 // The default protocol was decided by a community vote.
-const auto kDefaultProtocol = ServerProtocol::kBarrier;
+const auto kDefaultProtocol = NetworkProtocol::Barrier;
 
 } // namespace deskflow::gui
 
@@ -47,8 +42,6 @@ enum class ScreenAddResults
 
 class ServerConfig : public ScreenConfig, public deskflow::gui::IServerConfig
 {
-  using ServerProtocol = deskflow::gui::ServerProtocol;
-
   friend class ServerConfigDialog;
   friend QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);
 
@@ -85,7 +78,7 @@ public:
   {
     return m_Heartbeat;
   }
-  ServerProtocol protocol() const
+  NetworkProtocol protocol() const
   {
     return m_Protocol;
   }
@@ -197,7 +190,7 @@ private:
   {
     m_Heartbeat = val;
   }
-  void setProtocol(ServerProtocol val)
+  void setProtocol(NetworkProtocol val)
   {
     m_Protocol = val;
   }
@@ -261,7 +254,7 @@ private:
 private:
   bool m_HasHeartbeat = false;
   int m_Heartbeat = 0;
-  ServerProtocol m_Protocol = deskflow::gui::kDefaultProtocol;
+  NetworkProtocol m_Protocol = deskflow::gui::kDefaultProtocol;
   bool m_RelativeMouseMoves = false;
   bool m_Win32KeepForeground = false;
   bool m_HasSwitchDelay = false;

--- a/src/lib/gui/ServerConfig.h
+++ b/src/lib/gui/ServerConfig.h
@@ -37,6 +37,14 @@ const auto kDefaultProtocol = ServerProtocol::kBarrier;
 
 } // namespace deskflow::gui
 
+enum class ScreenAddResults
+{
+  AutoAddScreenOk,
+  AutoAddScreenManualServer,
+  AutoAddScreenManualClient,
+  AutoAddScreenIgnore
+};
+
 class ServerConfig : public ScreenConfig, public deskflow::gui::IServerConfig
 {
   using ServerProtocol = deskflow::gui::ServerProtocol;
@@ -148,7 +156,7 @@ public:
   //
   void commit();
   int numScreens() const;
-  int autoAddScreen(const QString name);
+  ScreenAddResults autoAddScreen(const QString name);
   const QString getServerName() const;
   void updateServerName();
   const QString configFile() const;
@@ -275,11 +283,3 @@ private:
 };
 
 QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);
-
-enum AddResults
-{
-  AutoAddScreenOk,
-  AutoAddScreenManualServer,
-  AutoAddScreenManualClient,
-  AutoAddScreenIgnore
-};

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -9,6 +9,7 @@
 #include "ServerConfigDialog.h"
 #include "ui_ServerConfigDialog.h"
 
+#include "base/NetworkProtocol.h"
 #include "common/Constants.h"
 #include "dialogs/ActionDialog.h"
 #include "dialogs/HotkeyDialog.h"
@@ -20,7 +21,7 @@
 #include <QMessageBox>
 
 using enum ScreenConfig::SwitchCorner;
-using ServerProtocol = deskflow::gui::ServerProtocol;
+using enum NetworkProtocol;
 
 ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
@@ -67,8 +68,8 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->btnBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
   ui->lineConfigFile->setText(serverConfig().configFile());
 
-  ui->rbProtocolSynergy->setChecked(serverConfig().protocol() == ServerProtocol::kSynergy);
-  ui->rbProtocolBarrier->setChecked(serverConfig().protocol() == ServerProtocol::kBarrier);
+  ui->rbProtocolSynergy->setChecked(serverConfig().protocol() == NetworkProtocol::Synergy);
+  ui->rbProtocolBarrier->setChecked(serverConfig().protocol() == NetworkProtocol::Barrier);
   connect(ui->rbProtocolBarrier, &QRadioButton::toggled, this, &ServerConfigDialog::toggleProtocol);
 
   ui->cbHeartbeat->setChecked(serverConfig().hasHeartbeat());
@@ -359,7 +360,7 @@ void ServerConfigDialog::toggleRelativeMouseMoves(bool enabled)
 
 void ServerConfigDialog::toggleProtocol()
 {
-  ServerProtocol proto = ui->rbProtocolBarrier->isChecked() ? ServerProtocol::kBarrier : ServerProtocol::kSynergy;
+  auto proto = ui->rbProtocolBarrier->isChecked() ? NetworkProtocol::Barrier : NetworkProtocol::Synergy;
   serverConfig().setProtocol(proto);
   onChange();
 }

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -83,7 +83,7 @@ bool MSWindowsClipboard::empty()
   return true;
 }
 
-void MSWindowsClipboard::add(EFormat format, const std::string &data)
+void MSWindowsClipboard::add(Format format, const std::string &data)
 {
   // exit early if there is no data to prevent spurious "failed to convert clipboard data" errors
   if (data.empty()) {
@@ -139,7 +139,7 @@ IClipboard::Time MSWindowsClipboard::getTime() const
   return m_time;
 }
 
-bool MSWindowsClipboard::has(EFormat format) const
+bool MSWindowsClipboard::has(Format format) const
 {
   for (ConverterList::const_iterator index = m_converters.begin(); index != m_converters.end(); ++index) {
     IMSWindowsClipboardConverter *converter = *index;
@@ -152,7 +152,7 @@ bool MSWindowsClipboard::has(EFormat format) const
   return false;
 }
 
-std::string MSWindowsClipboard::get(EFormat format) const
+std::string MSWindowsClipboard::get(Format format) const
 {
   // find the converter for the first clipboard format we can handle
   IMSWindowsClipboardConverter *converter = nullptr;

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -46,19 +46,19 @@ public:
 
   // IClipboard overrides
   bool empty() override;
-  void add(EFormat, const std::string &data) override;
+  void add(Format, const std::string &data) override;
   bool open(Time) const override;
   void close() const override;
   Time getTime() const override;
-  bool has(EFormat) const override;
-  std::string get(EFormat) const override;
+  bool has(Format) const override;
+  std::string get(Format) const override;
 
   void setFacade(IMSWindowsClipboardFacade &facade);
 
 private:
   void clearConverters();
 
-  UINT convertFormatToWin32(EFormat) const;
+  UINT convertFormatToWin32(Format) const;
   HANDLE convertTextToWin32(const std::string &data) const;
   std::string convertTextFromWin32(HANDLE) const;
 
@@ -86,7 +86,7 @@ public:
   // accessors
 
   // return the clipboard format this object converts from/to
-  virtual IClipboard::EFormat getFormat() const = 0;
+  virtual IClipboard::Format getFormat() const = 0;
 
   // return the atom representing the win32 clipboard format that
   // this object converts from/to

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
@@ -11,9 +11,9 @@
 // MSWindowsClipboardAnyTextConverter
 //
 
-IClipboard::EFormat MSWindowsClipboardAnyTextConverter::getFormat() const
+IClipboard::Format MSWindowsClipboardAnyTextConverter::getFormat() const
 {
-  return IClipboard::kText;
+  return IClipboard::Format::Text;
 }
 
 HANDLE

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
@@ -17,7 +17,7 @@ public:
   ~MSWindowsClipboardAnyTextConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   UINT getWin32Format() const override = 0;
   HANDLE fromIClipboard(const std::string &) const override;
   std::string toIClipboard(HANDLE) const override;

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -13,9 +13,9 @@
 // MSWindowsClipboardBitmapConverter
 //
 
-IClipboard::EFormat MSWindowsClipboardBitmapConverter::getFormat() const
+IClipboard::Format MSWindowsClipboardBitmapConverter::getFormat() const
 {
-  return IClipboard::kBitmap;
+  return IClipboard::Format::Bitmap;
 }
 
 UINT MSWindowsClipboardBitmapConverter::getWin32Format() const

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.h
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.h
@@ -17,7 +17,7 @@ public:
   ~MSWindowsClipboardBitmapConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   UINT getWin32Format() const override;
   HANDLE fromIClipboard(const std::string &) const override;
   std::string toIClipboard(HANDLE) const override;

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
@@ -18,9 +18,9 @@ MSWindowsClipboardHTMLConverter::MSWindowsClipboardHTMLConverter()
   m_format = RegisterClipboardFormat("HTML Format");
 }
 
-IClipboard::EFormat MSWindowsClipboardHTMLConverter::getFormat() const
+IClipboard::Format MSWindowsClipboardHTMLConverter::getFormat() const
 {
-  return IClipboard::kHTML;
+  return IClipboard::Format::HTML;
 }
 
 UINT MSWindowsClipboardHTMLConverter::getWin32Format() const

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.h
@@ -17,7 +17,7 @@ public:
   ~MSWindowsClipboardHTMLConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   UINT getWin32Format() const override;
 
 protected:

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -76,17 +76,17 @@ bool OSXClipboard::synchronize()
   return false;
 }
 
-void OSXClipboard::add(EFormat format, const std::string &data)
+void OSXClipboard::add(Format format, const std::string &data)
 {
   if (m_pboard == nullptr)
     return;
 
   LOG((CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format));
-  if (format == IClipboard::kText) {
+  if (format == IClipboard::Format::Text) {
     LOG((CLOG_DEBUG "format of data to be added to clipboard was kText"));
-  } else if (format == IClipboard::kBitmap) {
+  } else if (format == IClipboard::Format::Bitmap) {
     LOG((CLOG_DEBUG "format of data to be added to clipboard was kBitmap"));
-  } else if (format == IClipboard::kHTML) {
+  } else if (format == IClipboard::Format::HTML) {
     LOG((CLOG_DEBUG "format of data to be added to clipboard was kHTML"));
   }
 
@@ -132,7 +132,7 @@ IClipboard::Time OSXClipboard::getTime() const
   return m_time;
 }
 
-bool OSXClipboard::has(EFormat format) const
+bool OSXClipboard::has(Format format) const
 {
   if (m_pboard == nullptr)
     return false;
@@ -157,7 +157,7 @@ bool OSXClipboard::has(EFormat format) const
   return false;
 }
 
-std::string OSXClipboard::get(EFormat format) const
+std::string OSXClipboard::get(Format format) const
 {
   CFStringRef type;
   PasteboardItemID item;

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -26,12 +26,12 @@ public:
 
   // IClipboard overrides
   bool empty() override;
-  void add(EFormat, const std::string &data) override;
+  void add(Format, const std::string &data) override;
   bool open(Time) const override;
   void close() const override;
   Time getTime() const override;
-  bool has(EFormat) const override;
-  std::string get(EFormat) const override;
+  bool has(Format) const override;
+  std::string get(Format) const override;
 
   bool synchronize();
 
@@ -60,7 +60,7 @@ public:
   /*!
   Return the clipboard format this object converts from/to.
   */
-  virtual IClipboard::EFormat getFormat() const = 0;
+  virtual IClipboard::Format getFormat() const = 0;
 
   //! returns the scrap flavor type that this object converts from/to
   virtual CFStringRef getOSXFormat() const = 0;

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
@@ -8,9 +8,9 @@
 #include "platform/OSXClipboardAnyBitmapConverter.h"
 #include <algorithm>
 
-IClipboard::EFormat OSXClipboardAnyBitmapConverter::getFormat() const
+IClipboard::Format OSXClipboardAnyBitmapConverter::getFormat() const
 {
-  return IClipboard::kBitmap;
+  return IClipboard::Format::Bitmap;
 }
 
 std::string OSXClipboardAnyBitmapConverter::fromIClipboard(const std::string &data) const

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.h
@@ -17,7 +17,7 @@ public:
   ~OSXClipboardAnyBitmapConverter() override = default;
 
   // IOSXClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   CFStringRef getOSXFormat() const override = 0;
   std::string fromIClipboard(const std::string &) const override;
   std::string toIClipboard(const std::string &) const override;

--- a/src/lib/platform/OSXClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.cpp
@@ -13,9 +13,9 @@
 // OSXClipboardAnyTextConverter
 //
 
-IClipboard::EFormat OSXClipboardAnyTextConverter::getFormat() const
+IClipboard::Format OSXClipboardAnyTextConverter::getFormat() const
 {
-  return IClipboard::kText;
+  return IClipboard::Format::Text;
 }
 
 std::string OSXClipboardAnyTextConverter::fromIClipboard(const std::string &data) const

--- a/src/lib/platform/OSXClipboardAnyTextConverter.h
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.h
@@ -17,7 +17,7 @@ public:
   ~OSXClipboardAnyTextConverter() override = default;
 
   // IOSXClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   std::string fromIClipboard(const std::string &) const override;
   std::string toIClipboard(const std::string &) const override;
   CFStringRef getOSXFormat() const override = 0;

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -48,9 +48,9 @@ static void toLE(uint8_t *&dst, uint32_t src)
   dst += 4;
 }
 
-IClipboard::EFormat OSXClipboardBMPConverter::getFormat() const
+IClipboard::Format OSXClipboardBMPConverter::getFormat() const
 {
-  return IClipboard::kBitmap;
+  return IClipboard::Format::Bitmap;
 }
 
 CFStringRef OSXClipboardBMPConverter::getOSXFormat() const

--- a/src/lib/platform/OSXClipboardBMPConverter.h
+++ b/src/lib/platform/OSXClipboardBMPConverter.h
@@ -17,7 +17,7 @@ public:
   ~OSXClipboardBMPConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   CFStringRef getOSXFormat() const override;
 
   // OSXClipboardAnyBMPConverter overrides

--- a/src/lib/platform/OSXClipboardHTMLConverter.cpp
+++ b/src/lib/platform/OSXClipboardHTMLConverter.cpp
@@ -9,9 +9,9 @@
 
 #include "base/Unicode.h"
 
-IClipboard::EFormat OSXClipboardHTMLConverter::getFormat() const
+IClipboard::Format OSXClipboardHTMLConverter::getFormat() const
 {
-  return IClipboard::kHTML;
+  return IClipboard::Format::HTML;
 }
 
 CFStringRef OSXClipboardHTMLConverter::getOSXFormat() const

--- a/src/lib/platform/OSXClipboardHTMLConverter.h
+++ b/src/lib/platform/OSXClipboardHTMLConverter.h
@@ -17,7 +17,7 @@ public:
   ~OSXClipboardHTMLConverter() override = default;
 
   // IMSWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   CFStringRef getOSXFormat() const override;
 
 protected:

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -77,12 +77,12 @@ public:
 
   // IClipboard overrides
   bool empty() override;
-  void add(EFormat, const std::string &data) override;
+  void add(Format, const std::string &data) override;
   bool open(Time) const override;
   void close() const override;
   Time getTime() const override;
-  bool has(EFormat) const override;
-  std::string get(EFormat) const override;
+  bool has(Format) const override;
+  std::string get(Format) const override;
 
 private:
   // remove all converters from our list
@@ -95,7 +95,7 @@ private:
   IXWindowsClipboardConverter *getConverter(Atom target, bool onlyIfNotAdded = false) const;
 
   // convert target atom to clipboard format
-  EFormat getFormat(Atom target) const;
+  Format getFormat(Atom target) const;
 
   // add a non-MULTIPLE request.  does not verify that the selection
   // was owned at the given time.  returns true if the conversion
@@ -296,8 +296,8 @@ private:
   mutable bool m_checkCache;
   bool m_cached;
   Time m_cacheTime;
-  bool m_added[kNumFormats];
-  std::string m_data[kNumFormats];
+  bool m_added[static_cast<int>(IClipboard::Format::TotalFormats)];
+  std::string m_data[static_cast<int>(IClipboard::Format::TotalFormats)];
 
   // conversion request replies
   ReplyMap m_replies;
@@ -336,7 +336,7 @@ public:
   /*!
   Return the clipboard format this object converts from/to.
   */
-  virtual IClipboard::EFormat getFormat() const = 0;
+  virtual IClipboard::Format getFormat() const = 0;
 
   //! Get X11 format atom
   /*!

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -74,9 +74,9 @@ static inline uint32_t fromLEU32(const uint8_t *data)
 // XWindowsClipboardAnyBitmapConverter
 //
 
-IClipboard::EFormat XWindowsClipboardAnyBitmapConverter::getFormat() const
+IClipboard::Format XWindowsClipboardAnyBitmapConverter::getFormat() const
 {
-  return IClipboard::kBitmap;
+  return IClipboard::Format::Bitmap;
 }
 
 int XWindowsClipboardAnyBitmapConverter::getDataSize() const

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
@@ -17,7 +17,7 @@ public:
   ~XWindowsClipboardAnyBitmapConverter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override = 0;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/platform/XWindowsClipboardBMPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.cpp
@@ -57,9 +57,9 @@ XWindowsClipboardBMPConverter::XWindowsClipboardBMPConverter(Display *display)
   // do nothing
 }
 
-IClipboard::EFormat XWindowsClipboardBMPConverter::getFormat() const
+IClipboard::Format XWindowsClipboardBMPConverter::getFormat() const
 {
-  return IClipboard::kBitmap;
+  return IClipboard::Format::Bitmap;
 }
 
 Atom XWindowsClipboardBMPConverter::getAtom() const

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -17,7 +17,7 @@ public:
   ~XWindowsClipboardBMPConverter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -19,9 +19,9 @@ XWindowsClipboardHTMLConverter::XWindowsClipboardHTMLConverter(Display *display,
   // do nothing
 }
 
-IClipboard::EFormat XWindowsClipboardHTMLConverter::getFormat() const
+IClipboard::Format XWindowsClipboardHTMLConverter::getFormat() const
 {
-  return IClipboard::kHTML;
+  return IClipboard::Format::HTML;
 }
 
 Atom XWindowsClipboardHTMLConverter::getAtom() const

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -20,7 +20,7 @@ public:
   ~XWindowsClipboardHTMLConverter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/platform/XWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTextConverter.cpp
@@ -19,9 +19,9 @@ XWindowsClipboardTextConverter::XWindowsClipboardTextConverter(Display *display,
   // do nothing
 }
 
-IClipboard::EFormat XWindowsClipboardTextConverter::getFormat() const
+IClipboard::Format XWindowsClipboardTextConverter::getFormat() const
 {
-  return IClipboard::kText;
+  return IClipboard::Format::Text;
 }
 
 Atom XWindowsClipboardTextConverter::getAtom() const

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -20,7 +20,7 @@ public:
   ~XWindowsClipboardTextConverter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
@@ -19,9 +19,9 @@ XWindowsClipboardUCS2Converter::XWindowsClipboardUCS2Converter(Display *display,
   // do nothing
 }
 
-IClipboard::EFormat XWindowsClipboardUCS2Converter::getFormat() const
+IClipboard::Format XWindowsClipboardUCS2Converter::getFormat() const
 {
-  return IClipboard::kText;
+  return IClipboard::Format::Text;
 }
 
 Atom XWindowsClipboardUCS2Converter::getAtom() const

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -20,7 +20,7 @@ public:
   ~XWindowsClipboardUCS2Converter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
@@ -20,9 +20,9 @@ XWindowsClipboardUTF8Converter::XWindowsClipboardUTF8Converter(Display *display,
   // do nothing
 }
 
-IClipboard::EFormat XWindowsClipboardUTF8Converter::getFormat() const
+IClipboard::Format XWindowsClipboardUTF8Converter::getFormat() const
 {
-  return IClipboard::kText;
+  return IClipboard::Format::Text;
 }
 
 Atom XWindowsClipboardUTF8Converter::getAtom() const

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -20,7 +20,7 @@ public:
   ~XWindowsClipboardUTF8Converter() override = default;
 
   // IXWindowsClipboardConverter overrides
-  IClipboard::EFormat getFormat() const override;
+  IClipboard::Format getFormat() const override;
   Atom getAtom() const override;
   int getDataSize() const override;
   std::string fromIClipboard(const std::string &) const override;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1311,11 +1311,11 @@ std::string Config::getOptionValue(OptionID id, OptionValue value)
     return result;
   }
   if (id == kOptionProtocol) {
-    using enum ENetworkProtocol;
-    const auto enumValue = static_cast<ENetworkProtocol>(value);
-    if (enumValue == kSynergy) {
+    using enum NetworkProtocol;
+    const auto enumValue = static_cast<NetworkProtocol>(value);
+    if (enumValue == Synergy) {
       return kSynergyProtocolOption;
-    } else if (enumValue == kBarrier) {
+    } else if (enumValue == Barrier) {
       return kBarrierProtocolOption;
     } else {
       throw XInvalidProtocol();
@@ -1809,9 +1809,9 @@ OptionValue ConfigReadContext::parseCorner(const std::string &arg) const
 OptionValue ConfigReadContext::parseProtocol(const std::string &args) const
 {
   if (CaselessCmp::equal(args, kSynergyProtocolOption)) {
-    return static_cast<OptionValue>(ENetworkProtocol::kSynergy);
+    return static_cast<OptionValue>(NetworkProtocol::Synergy);
   } else if (CaselessCmp::equal(args, kBarrierProtocolOption)) {
-    return static_cast<OptionValue>(ENetworkProtocol::kBarrier);
+    return static_cast<OptionValue>(NetworkProtocol::Barrier);
   }
   throw XConfigRead(*this, "invalid protocol argument \"%{1}\"", args);
 }

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1296,16 +1296,16 @@ std::string Config::getOptionValue(OptionID id, OptionValue value)
   }
   if (id == kOptionScreenSwitchCorners) {
     std::string result("none");
-    if ((value & kTopLeftMask) != 0) {
+    if ((value & s_topLeftCornerMask) != 0) {
       result += " +top-left";
     }
-    if ((value & kTopRightMask) != 0) {
+    if ((value & s_topRightCornerMask) != 0) {
       result += " +top-right";
     }
-    if ((value & kBottomLeftMask) != 0) {
+    if ((value & s_bottomLeftCornerMask) != 0) {
       result += " +bottom-left";
     }
-    if ((value & kBottomRightMask) != 0) {
+    if ((value & s_bottomRightCornerMask) != 0) {
       result += " +bottom-right";
     }
     return result;
@@ -1783,25 +1783,25 @@ OptionValue ConfigReadContext::parseModifierKey(const std::string &arg) const
 OptionValue ConfigReadContext::parseCorner(const std::string &arg) const
 {
   if (CaselessCmp::equal(arg, "left")) {
-    return kTopLeftMask | kBottomLeftMask;
+    return s_topLeftCornerMask | s_bottomLeftCornerMask;
   } else if (CaselessCmp::equal(arg, "right")) {
-    return kTopRightMask | kBottomRightMask;
+    return s_topRightCornerMask | s_bottomRightCornerMask;
   } else if (CaselessCmp::equal(arg, "top")) {
-    return kTopLeftMask | kTopRightMask;
+    return s_topLeftCornerMask | s_topRightCornerMask;
   } else if (CaselessCmp::equal(arg, "bottom")) {
-    return kBottomLeftMask | kBottomRightMask;
+    return s_bottomLeftCornerMask | s_bottomRightCornerMask;
   } else if (CaselessCmp::equal(arg, "top-left")) {
-    return kTopLeftMask;
+    return s_topLeftCornerMask;
   } else if (CaselessCmp::equal(arg, "top-right")) {
-    return kTopRightMask;
+    return s_topRightCornerMask;
   } else if (CaselessCmp::equal(arg, "bottom-left")) {
-    return kBottomLeftMask;
+    return s_bottomLeftCornerMask;
   } else if (CaselessCmp::equal(arg, "bottom-right")) {
-    return kBottomRightMask;
+    return s_bottomRightCornerMask;
   } else if (CaselessCmp::equal(arg, "none")) {
-    return kNoCornerMask;
+    return s_noCornerMask;
   } else if (CaselessCmp::equal(arg, "all")) {
-    return kAllCornersMask;
+    return s_allCornersMask;
   }
   throw XConfigRead(*this, "invalid argument \"%{1}\"", arg);
 }

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -989,22 +989,22 @@ uint32_t Server::getCorner(const BaseClientProxy *client, int32_t x, int32_t y, 
   // if against the left or right then check if y is within size
   if (xSide != 0) {
     if (y < ay + size) {
-      return (xSide < 0) ? kTopLeftMask : kTopRightMask;
+      return (xSide < 0) ? s_topLeftCornerMask : s_topRightCornerMask;
     } else if (y >= ay + ah - size) {
-      return (xSide < 0) ? kBottomLeftMask : kBottomRightMask;
+      return (xSide < 0) ? s_bottomLeftCornerMask : s_bottomRightCornerMask;
     }
   }
 
   // if against the left or right then check if y is within size
   if (ySide != 0) {
     if (x < ax + size) {
-      return (ySide < 0) ? kTopLeftMask : kBottomLeftMask;
+      return (ySide < 0) ? s_topLeftCornerMask : s_bottomLeftCornerMask;
     } else if (x >= ax + aw - size) {
-      return (ySide < 0) ? kTopRightMask : kBottomRightMask;
+      return (ySide < 0) ? s_topRightCornerMask : s_bottomRightCornerMask;
     }
   }
 
-  return kNoCornerMask;
+  return s_noCornerMask;
 }
 
 void Server::stopRelativeMoves()

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -275,10 +275,10 @@ void Server::disconnect()
 
 std::string Server::protocolString() const
 {
-  using enum ENetworkProtocol;
-  if (m_protocol == kSynergy) {
+  using enum NetworkProtocol;
+  if (m_protocol == Synergy) {
     return kSynergyProtocolName;
-  } else if (m_protocol == kBarrier) {
+  } else if (m_protocol == Barrier) {
     return kBarrierProtocolName;
   }
   throw XInvalidProtocol();
@@ -1074,12 +1074,12 @@ void Server::processOptions()
     const OptionID id = optionId;
     const OptionValue value = optionValue;
     if (id == kOptionProtocol) {
-      using enum ENetworkProtocol;
-      const auto enumValue = static_cast<ENetworkProtocol>(value);
-      if (enumValue == kSynergy) {
-        m_protocol = kSynergy;
-      } else if (enumValue == kBarrier) {
-        m_protocol = kBarrier;
+      using enum NetworkProtocol;
+      const auto enumValue = static_cast<NetworkProtocol>(value);
+      if (enumValue == Synergy) {
+        m_protocol = Synergy;
+      } else if (enumValue == Barrier) {
+        m_protocol = Barrier;
       } else {
         throw XInvalidProtocol();
       }

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -358,7 +358,7 @@ private:
   };
 
   // used in hello message sent to the client
-  ENetworkProtocol m_protocol;
+  NetworkProtocol m_protocol;
 
   // the primary screen client
   PrimaryClient *m_primaryClient;

--- a/src/unittests/deskflow/ClipboardTests.cpp
+++ b/src/unittests/deskflow/ClipboardTests.cpp
@@ -60,14 +60,14 @@ void ClipboardTests::basicText()
   clipboard.close();
 }
 
-void ClipboardTests::textSize285()
+void ClipboardTests::longerText()
 {
   std::string text;
-  text.append("Synergy is Free and Open Source Software that lets you ");
+  text.append("Deskflow is Free and Open Source Software that lets you ");
   text.append("easily share your mouse and keyboard between multiple ");
   text.append("computers, where each computer has it's own display. No ");
   text.append("special hardware is required, all you need is a local area ");
-  text.append("network. Synergy is supported on Windows, Mac OS X and Linux.");
+  text.append("network. Deskflow is supported on Windows, Mac OS X and Linux.");
 
   Clipboard clipboard;
   clipboard.open(0);
@@ -77,17 +77,17 @@ void ClipboardTests::textSize285()
   std::string actual = clipboard.marshall();
 
   // 4 asserts here, but that's ok because we're really just asserting 1
-  // thing. the 32-bit size value is split into 4 chars. if the size is 285
-  // (29 more than the 8-bit max size), the last char "rolls over" to 29
+  // thing. the 32-bit size value is split into 4 chars. if the size is 287
+  // (31 more than the 8-bit max size), the last char "rolls over" to 31
   // (this is caused by a bit-wise & on 0xff and 8-bit truncation). each
   // char before the last stores a bit-shifted version of the number, each
   // 1 more power than the last, which is done by bit-shifting [0] by 24,
   // [1] by 16, [2] by 8 ([3] is not bit-shifted).
   qInfo() << actual;
-  QCOMPARE(actual[8], 0);   // 285 >> 24 = 285 / (256^3) = 0
-  QCOMPARE(actual[9], 0);   // 285 >> 16 = 285 / (256^2) = 0
-  QCOMPARE(actual[10], 1);  // 285 >> 8 = 285 / (256^1) = 1(.11328125)
-  QCOMPARE(actual[11], 29); // 285 - 256 = 29
+  QCOMPARE(actual[8], 0);   // 287 >> 24 = 287 / (256^3) = 0
+  QCOMPARE(actual[9], 0);   // 287 >> 16 = 287 / (256^2) = 0
+  QCOMPARE(actual[10], 1);  // 287 >> 8 = 287 / (256^1) = 1(.121)
+  QCOMPARE(actual[11], 31); // 287 - 256 = 31
 }
 
 void ClipboardTests::htmlText()
@@ -148,16 +148,16 @@ void ClipboardTests::unMarshalText()
   clipboard.close();
 }
 
-void ClipboardTests::unMarshalText285()
+void ClipboardTests::unMarshalLongerText()
 {
   Clipboard clipboard;
 
   std::string text;
-  text.append("Synergy is Free and Open Source Software that lets you ");
+  text.append("Deskflow is Free and Open Source Software that lets you ");
   text.append("easily share your mouse and keyboard between multiple ");
   text.append("computers, where each computer has it's own display. No ");
   text.append("special hardware is required, all you need is a local area ");
-  text.append("network. Synergy is supported on Windows, Mac OS X and Linux.");
+  text.append("network. Deskflow is supported on Windows, Mac OS X and Linux.");
 
   std::string data;
   data += (char)0;
@@ -168,10 +168,10 @@ void ClipboardTests::unMarshalText285()
   data += (char)0;
   data += (char)0;
   data += (char)IClipboard::kText;
-  data += (char)0;  // 285 >> 24 = 285 / (256^3) = 0
-  data += (char)0;  // 285 >> 16 = 285 / (256^2) = 0
-  data += (char)1;  // 285 >> 8 = 285 / (256^1) = 1(.11328125)
-  data += (char)29; // 285 - 256 = 29
+  data += (char)0;  // 287 >> 24 = 287 / (256^3) = 0
+  data += (char)0;  // 287 >> 16 = 287 / (256^2) = 0
+  data += (char)1;  // 287 >> 8 = 287 / (256^1) = 1(.121)
+  data += (char)31; // 287 - 256 = 31
   data += text;
 
   clipboard.unmarshall(data, 0);

--- a/src/unittests/deskflow/ClipboardTests.cpp
+++ b/src/unittests/deskflow/ClipboardTests.cpp
@@ -37,26 +37,28 @@ void ClipboardTests::basicFunction()
 
 void ClipboardTests::basicText()
 {
+  using enum IClipboard::Format;
+
   Clipboard clipboard;
   QVERIFY(clipboard.open(0));
-  QVERIFY(!clipboard.has(Clipboard::kText));
-  QCOMPARE(clipboard.get(IClipboard::kText), "");
+  QVERIFY(!clipboard.has(Text));
+  QCOMPARE(clipboard.get(Text), "");
 
-  clipboard.add(Clipboard::kText, kTestString1);
-  QVERIFY(clipboard.has(Clipboard::kText));
-  QCOMPARE(clipboard.get(IClipboard::kText), kTestString1);
+  clipboard.add(Text, kTestString1);
+  QVERIFY(clipboard.has(Text));
+  QCOMPARE(clipboard.get(Text), kTestString1);
 
   std::string actual = clipboard.marshall();
   // string contains other data, but 8th char should be kText.
-  QCOMPARE(IClipboard::kText, actual[7]);
+  QCOMPARE(static_cast<char>(Text), actual.at(7));
   QCOMPARE((int)actual[11], kTestString1.length());
 
   // // marshall closes the clipboard
   QVERIFY(clipboard.open(0));
   QVERIFY(clipboard.empty());
 
-  clipboard.add(Clipboard::kText, kTestString2);
-  QCOMPARE(clipboard.get(IClipboard::kText), kTestString2);
+  clipboard.add(Text, kTestString2);
+  QCOMPARE(clipboard.get(Text), kTestString2);
   clipboard.close();
 }
 
@@ -71,7 +73,7 @@ void ClipboardTests::longerText()
 
   Clipboard clipboard;
   clipboard.open(0);
-  clipboard.add(IClipboard::kText, text);
+  clipboard.add(IClipboard::Format::Text, text);
   clipboard.close();
 
   std::string actual = clipboard.marshall();
@@ -94,21 +96,21 @@ void ClipboardTests::htmlText()
 {
   Clipboard clipboard;
   clipboard.open(0);
-  clipboard.add(IClipboard::kHTML, kTestString1);
+  clipboard.add(IClipboard::Format::HTML, kTestString1);
   clipboard.close();
 
   std::string actual = clipboard.marshall();
 
   // string contains other data, but 8th char should be kHTML.
-  QCOMPARE(IClipboard::kHTML, (int)actual[7]);
+  QCOMPARE(static_cast<int>(IClipboard::Format::HTML), static_cast<int>(actual.at(7)));
 }
 
 void ClipboardTests::dualText()
 {
   Clipboard clipboard;
   clipboard.open(0);
-  clipboard.add(IClipboard::kText, kTestString1);
-  clipboard.add(IClipboard::kHTML, kTestString2);
+  clipboard.add(IClipboard::Format::Text, kTestString1);
+  clipboard.add(IClipboard::Format::HTML, kTestString2);
   clipboard.close();
 
   std::string actual = clipboard.marshall();
@@ -125,7 +127,7 @@ void ClipboardTests::marshalText()
 {
   Clipboard clipboard;
   clipboard.open(0);
-  clipboard.add(IClipboard::kText, kTestString1);
+  clipboard.add(IClipboard::Format::Text, kTestString1);
   clipboard.close();
 
   std::string actual = clipboard.marshall();
@@ -144,7 +146,7 @@ void ClipboardTests::unMarshalText()
   clipboard.unmarshall(data, 0);
   clipboard.open(0);
 
-  QVERIFY(!clipboard.has(IClipboard::kText));
+  QVERIFY(!clipboard.has(IClipboard::Format::Text));
   clipboard.close();
 }
 
@@ -167,7 +169,7 @@ void ClipboardTests::unMarshalLongerText()
   data += (char)0;
   data += (char)0;
   data += (char)0;
-  data += (char)IClipboard::kText;
+  data += (char)IClipboard::Format::Text;
   data += (char)0;  // 287 >> 24 = 287 / (256^3) = 0
   data += (char)0;  // 287 >> 16 = 287 / (256^2) = 0
   data += (char)1;  // 287 >> 8 = 287 / (256^1) = 1(.121)
@@ -176,7 +178,7 @@ void ClipboardTests::unMarshalLongerText()
 
   clipboard.unmarshall(data, 0);
   clipboard.open(0);
-  QCOMPARE(clipboard.get(IClipboard::kText), text);
+  QCOMPARE(clipboard.get(IClipboard::Format::Text), text);
   clipboard.close();
 }
 
@@ -191,7 +193,7 @@ void ClipboardTests::unMarshalTextAndHtml()
   data += (char)0;
   data += (char)0;
   data += (char)0;
-  data += (char)IClipboard::kText;
+  data += (char)IClipboard::Format::Text;
   data += (char)0;
   data += (char)0;
   data += (char)0;
@@ -200,7 +202,7 @@ void ClipboardTests::unMarshalTextAndHtml()
   data += (char)0;
   data += (char)0;
   data += (char)0;
-  data += (char)IClipboard::kHTML;
+  data += (char)IClipboard::Format::HTML;
   data += (char)0;
   data += (char)0;
   data += (char)0;
@@ -209,8 +211,8 @@ void ClipboardTests::unMarshalTextAndHtml()
 
   clipboard.unmarshall(data, 0);
   clipboard.open(0);
-  QCOMPARE(clipboard.get(IClipboard::kText), kTestString1);
-  QCOMPARE(clipboard.get(IClipboard::kHTML), kTestString2);
+  QCOMPARE(clipboard.get(IClipboard::Format::Text), kTestString1);
+  QCOMPARE(clipboard.get(IClipboard::Format::HTML), kTestString2);
   clipboard.close();
 }
 
@@ -218,14 +220,14 @@ void ClipboardTests::equalClipboards()
 {
   Clipboard clipboard1;
   clipboard1.open(0);
-  clipboard1.add(Clipboard::kText, kTestString1);
+  clipboard1.add(IClipboard::Format::Text, kTestString1);
   clipboard1.close();
 
   Clipboard clipboard2;
   Clipboard::copy(&clipboard2, &clipboard1);
 
   clipboard2.open(0);
-  QCOMPARE(clipboard2.get(Clipboard::kText), kTestString1);
+  QCOMPARE(clipboard2.get(IClipboard::Format::Text), kTestString1);
   clipboard2.close();
 }
 

--- a/src/unittests/deskflow/ClipboardTests.h
+++ b/src/unittests/deskflow/ClipboardTests.h
@@ -16,12 +16,12 @@ private Q_SLOTS:
   void initTestCase();
   void basicFunction();
   void basicText();
-  void textSize285();
+  void longerText();
   void htmlText();
   void dualText();
   void marshalText();
   void unMarshalText();
-  void unMarshalText285();
+  void unMarshalLongerText();
   void unMarshalTextAndHtml();
   void equalClipboards();
 

--- a/src/unittests/platform/MSWindowsClipboardTests.cpp
+++ b/src/unittests/platform/MSWindowsClipboardTests.cpp
@@ -45,9 +45,9 @@ void MSWindowsClipboardTests::emptySingleFormat()
   MSWindowsClipboard clipboard(NULL);
   QVERIFY(clipboard.open(0));
 
-  clipboard.add(MSWindowsClipboard::kText, m_testString);
+  clipboard.add(IClipboard::Format::Text, m_testString);
   QVERIFY(clipboard.empty());
-  QVERIFY(!clipboard.has(MSWindowsClipboard::kText));
+  QVERIFY(!clipboard.has(IClipboard::Format::Text));
 }
 
 void MSWindowsClipboardTests::addValue()
@@ -55,19 +55,21 @@ void MSWindowsClipboardTests::addValue()
   MSWindowsClipboard clipboard(NULL);
   QVERIFY(clipboard.open(0));
 
-  clipboard.add(IClipboard::kText, m_testString);
-  QCOMPARE(clipboard.get(IClipboard::kText), m_testString);
+  clipboard.add(IClipboard::Format::Text, m_testString);
+  QCOMPARE(clipboard.get(IClipboard::Format::Text), m_testString);
 }
 
 void MSWindowsClipboardTests::replaceValue()
 {
+  using enum IClipboard::Format;
+
   MSWindowsClipboard clipboard(NULL);
   QVERIFY(clipboard.open(0));
 
-  clipboard.add(IClipboard::kText, m_testString);
-  clipboard.add(IClipboard::kText, m_testString2);
+  clipboard.add(Text, m_testString);
+  clipboard.add(Text, m_testString2);
 
-  QCOMPARE(clipboard.get(IClipboard::kText), m_testString2);
+  QCOMPARE(clipboard.get(Text), m_testString2);
 }
 
 void MSWindowsClipboardTests::openTimeIsOne()
@@ -106,8 +108,8 @@ void MSWindowsClipboardTests::has_withFormatAdded()
   QVERIFY(clipboard.open(0));
   QVERIFY(clipboard.empty());
 
-  clipboard.add(IClipboard::kText, m_testString);
-  QVERIFY(clipboard.has(IClipboard::kText));
+  clipboard.add(IClipboard::Format::Text, m_testString);
+  QVERIFY(clipboard.has(IClipboard::Format::Text));
 }
 
 void MSWindowsClipboardTests::has_withNoFormatAdded()
@@ -115,7 +117,7 @@ void MSWindowsClipboardTests::has_withNoFormatAdded()
   MSWindowsClipboard clipboard(NULL);
   QVERIFY(clipboard.open(0));
   QVERIFY(clipboard.empty());
-  QCOMPARE(clipboard.get(IClipboard::kText), "");
+  QCOMPARE(clipboard.get(IClipboard::Format::Text), "");
 }
 
 void MSWindowsClipboardTests::getNonEmptyText()
@@ -124,8 +126,8 @@ void MSWindowsClipboardTests::getNonEmptyText()
   QVERIFY(clipboard.open(0));
   QVERIFY(clipboard.empty());
 
-  clipboard.add(IClipboard::kText, m_testString);
-  QCOMPARE(clipboard.get(IClipboard::kText), m_testString);
+  clipboard.add(IClipboard::Format::Text, m_testString);
+  QCOMPARE(clipboard.get(IClipboard::Format::Text), m_testString);
 }
 
 void MSWindowsClipboardTests::isOwnedByDeskflow()

--- a/src/unittests/platform/OSXClipboardTests.cpp
+++ b/src/unittests/platform/OSXClipboardTests.cpp
@@ -21,17 +21,19 @@ void OSXClipboardTests::open()
 
 void OSXClipboardTests::singleFormat()
 {
+  using enum IClipboard::Format;
+
   OSXClipboard clipboard;
   QVERIFY(clipboard.empty());
-  clipboard.add(OSXClipboard::kText, m_testString);
-  QVERIFY(clipboard.has(OSXClipboard::kText));
-  QCOMPARE(clipboard.get(OSXClipboard::kText), m_testString);
+  clipboard.add(Text, m_testString);
+  QVERIFY(clipboard.has(Text));
+  QCOMPARE(clipboard.get(Text), m_testString);
 }
 
 void OSXClipboardTests::formatConvert_UTF8()
 {
   OSXClipboardUTF8Converter converter;
-  QCOMPARE(IClipboard::kText, converter.getFormat());
+  QCOMPARE(IClipboard::Format::Text, converter.getFormat());
   QCOMPARE(converter.getOSXFormat(), CFSTR("public.utf8-plain-text"));
   QCOMPARE(converter.fromIClipboard("test data\n"), "test data\r");
   QCOMPARE(converter.toIClipboard("test data\r"), "test data\n");


### PR DESCRIPTION
Next round of Sonar updates, This round includes the following
 - Replace use of Synergy name in clipboard test with Deskflow
 - IClipboard::EFormat => Enum class `IClipbpoard::Format`
 - ServerApp:EServerState => Enum class `ServerApp::ServerState`
 - AddResults => enum class `ScreenAddResults`
 - Remove Screen Corner enums and replace with a set of statics
 - Unify ENetworkProtocol and ServerProtocol in a new enum class NetworkProtocol in file base/Networkprotocol.h