### PR TITLE
Sonar Cleanup 11

### DIFF
--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -16,7 +16,10 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <iostream>
+
+#ifndef __APPLE__
+#include <format>
+#endif
 
 const int kPriorityPrefixLength = 3;
 
@@ -69,10 +72,17 @@ void makeTimeString(std::vector<char> &buffer)
   localtime_r(&t, &tm);
 #endif
 
+#ifndef __APPLE__
+  std::format_to_n(
+      buffer.data(), buffer.size(), "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}", tm.tm_year + yearOffset,
+      tm.tm_mon + monthOffset, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec
+  );
+#else
   snprintf(
       buffer.data(), buffer.size(), "%04i-%02i-%02iT%02i:%02i:%02i", tm.tm_year + yearOffset, tm.tm_mon + monthOffset,
       tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec
   );
+#endif
 }
 
 std::vector<char> makeMessage(const char *filename, int lineNumber, const char *message, LogLevel priority)
@@ -100,14 +110,25 @@ std::vector<char> makeMessage(const char *filename, int lineNumber, const char *
     bufferSize += filenameLength + lineNumberLength;
 
     std::vector<char> buffer(bufferSize);
+#ifndef __APPLE__
+    std::format_to_n(
+        buffer.data(), bufferSize, "[{}] {}: {}\n\t{}:{}", timeBuffer.data(), g_priority[currentPriority], message,
+        filename, lineNumber
+    );
+#else
     snprintf(
         buffer.data(), bufferSize, "[%s] %s: %s\n\t%s:%d", timeBuffer.data(), g_priority[currentPriority], message,
         filename, lineNumber
     );
+#endif
     return buffer;
   } else {
     std::vector<char> buffer(bufferSize);
+#ifndef __APPLE__
+    std::format_to_n(buffer.data(), bufferSize, "[{}] {}: {}", timeBuffer.data(), g_priority[currentPriority], message);
+#else
     snprintf(buffer.data(), bufferSize, "[%s] %s: %s", timeBuffer.data(), g_priority[currentPriority], message);
+#endif
     return buffer;
   }
 }

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -830,7 +830,7 @@ void ServerProxy::setServerLanguages()
 
 void ServerProxy::setActiveServerLanguage(const std::string &language)
 {
-  if (!language.empty() && std::strlen(language.c_str()) > 0) {
+  if (!language.empty() && (language.size() > 0)) {
     if (m_serverLanguage != language) {
       m_isUserNotifiedAboutLanguageSyncError = false;
       m_serverLanguage = language;

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -828,7 +828,7 @@ void ServerProxy::setServerLanguages()
   m_languageManager.setRemoteLanguages(serverLanguages);
 }
 
-void ServerProxy::setActiveServerLanguage(const std::string &language)
+void ServerProxy::setActiveServerLanguage(const std::string_view &language)
 {
   if (!language.empty() && (language.size() > 0)) {
     if (m_serverLanguage != language) {

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -98,7 +98,7 @@ private:
   void infoAcknowledgment();
   void secureInputNotification();
   void setServerLanguages();
-  void setActiveServerLanguage(const std::string &language);
+  void setActiveServerLanguage(const std::string_view &language);
   void checkMissedLanguages() const;
 
 private:

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -15,7 +15,7 @@
 // IKeyState
 //
 
-IKeyState::IKeyState(const IEventQueue *events)
+IKeyState::IKeyState(const IEventQueue *)
 {
   // do nothing
 }

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -127,14 +127,14 @@ void IKeyState::KeyInfo::split(const char *screens, std::set<std::string> &dst)
     return;
   }
   if (screens[0] == '*') {
-    dst.insert("*");
+    dst.emplace("*");
     return;
   }
 
   const char *i = screens + 1;
   while (*i != '\0') {
     const char *j = strchr(i, ':');
-    dst.insert(std::string(i, j - i));
+    dst.emplace(std::string(i, j - i));
     i = j + 1;
   }
 }

--- a/src/lib/deskflow/unix/X11LayoutsParser.cpp
+++ b/src/lib/deskflow/unix/X11LayoutsParser.cpp
@@ -95,7 +95,7 @@ std::vector<X11LayoutsParser::Lang> X11LayoutsParser::getAllLanguageData(const s
 void X11LayoutsParser::appendVectorUniq(const std::vector<std::string> &source, std::vector<std::string> &dst)
 {
   for (const auto &elem : source) {
-    if (std::find_if(dst.begin(), dst.end(), [elem](const std::string_view &s) { return s == elem; }) == dst.end()) {
+    if (std::ranges::find_if(dst, [elem](const std::string_view &s) { return s == elem; }) == dst.end()) {
       dst.push_back(elem);
     }
   }
@@ -117,8 +117,7 @@ void X11LayoutsParser::convertLayoutToISO639_2(
       continue;
     }
 
-    auto langIter =
-        std::find_if(allLang.begin(), allLang.end(), [&layoutName](const Lang &l) { return l.name == layoutName; });
+    auto langIter = std::ranges::find_if(allLang, [&layoutName](const Lang &l) { return l.name == layoutName; });
     if (langIter == allLang.end()) {
       LOG((CLOG_WARN "language \"%s\" is unknown", layoutNames[i].c_str()));
       continue;
@@ -131,9 +130,7 @@ void X11LayoutsParser::convertLayoutToISO639_2(
       } else {
         const auto &variantName = layoutVariantNames[i];
         auto langVariantIter =
-            std::find_if(langIter->variants.begin(), langIter->variants.end(), [&variantName](const Lang &l) {
-              return l.name == variantName;
-            });
+            std::ranges::find_if(langIter->variants, [&variantName](const Lang &l) { return l.name == variantName; });
         if (langVariantIter == langIter->variants.end()) {
           LOG(
               (CLOG_WARN "variant \"%s\" of language \"%s\" is unknown", layoutVariantNames[i].c_str(),
@@ -202,10 +199,9 @@ std::vector<std::string> X11LayoutsParser::convertISO639_2ToISO639_1(const std::
 {
   std::vector<std::string> result;
   for (const auto &isoCode : iso639_2Codes) {
-    const auto &tableIter =
-        std::find_if(ISO_Table.begin(), ISO_Table.end(), [&isoCode](const std::pair<std::string, std::string> &c) {
-          return c.first == isoCode;
-        });
+    const auto &tableIter = std::ranges::find_if(ISO_Table, [&isoCode](const std::pair<std::string, std::string> &c) {
+      return c.first == isoCode;
+    });
     if (tableIter == ISO_Table.end()) {
       LOG((CLOG_WARN "the ISO 639-2 code \"%s\" is missed in table", isoCode.c_str()));
       continue;

--- a/src/lib/gui/ScreenSetupModel.cpp
+++ b/src/lib/gui/ScreenSetupModel.cpp
@@ -156,8 +156,6 @@ void ScreenSetupModel::addScreen(const Screen &newScreen)
 
 bool ScreenSetupModel::isFull() const
 {
-  auto emptyScreen =
-      std::find_if(m_Screens.cbegin(), m_Screens.cend(), [](const Screen &item) { return item.isNull(); });
-
+  auto emptyScreen = std::ranges::find_if(m_Screens, [](const Screen &item) { return item.isNull(); });
   return (emptyScreen == m_Screens.cend());
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -152,7 +152,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->screenSetupView->setModel(&m_ScreenSetupModel);
 
   auto &screens = serverConfig().screens();
-  auto server = std::find_if(screens.begin(), screens.end(), [this](const Screen &screen) {
+  auto server = std::ranges::find_if(screens, [this](const Screen &screen) {
     return (screen.name() == serverConfig().getServerName());
   });
 

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -108,11 +108,6 @@ bool Thread::operator==(const Thread &thread) const
   return ARCH->isSameThread(m_thread, thread.m_thread);
 }
 
-bool Thread::operator!=(const Thread &thread) const
-{
-  return !ARCH->isSameThread(m_thread, thread.m_thread);
-}
-
 void *Thread::threadFunc(void *vjob)
 {
   // get this thread's id for logging

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -180,13 +180,6 @@ public:
   Returns true if two Thread objects refer to the same thread.
   */
   bool operator==(const Thread &) const;
-
-  //! Compare thread handles
-  /*!
-  Returns true if two Thread objects do not refer to the same thread.
-  */
-  bool operator!=(const Thread &) const;
-
   //@}
 
 private:

--- a/src/lib/net/Fingerprint.h
+++ b/src/lib/net/Fingerprint.h
@@ -11,7 +11,6 @@
 
 struct Fingerprint
 {
-private:
   Q_GADGET
   inline static QString m_type_sha1 = QStringLiteral("sha1");
   inline static QString m_type_sha256 = QStringLiteral("sha256");

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -176,11 +176,6 @@ bool NetworkAddress::operator==(const NetworkAddress &addr) const
   return m_address == addr.m_address || ARCH->isEqualAddr(m_address, addr.m_address);
 }
 
-bool NetworkAddress::operator!=(const NetworkAddress &addr) const
-{
-  return !operator==(addr);
-}
-
 bool NetworkAddress::isValid() const
 {
   return (m_address != nullptr);

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -70,12 +70,6 @@ public:
   */
   bool operator==(const NetworkAddress &address) const;
 
-  //! Check address inequality
-  /*!
-  Returns true if this address is not equal to \p address.
-  */
-  bool operator!=(const NetworkAddress &address) const;
-
   //! Check address validity
   /*!
   Returns true if this is not the invalid address.

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <format>
 #include <vector>
 
 //
@@ -643,7 +644,7 @@ void XWindowsClipboard::motifFillCache()
   // get the Motif item property from the root window
   static const int buffer_size = 18 + 20;
   char name[buffer_size];
-  snprintf(name, buffer_size, "_MOTIF_CLIP_ITEM_%d", header.m_item);
+  std::format_to_n(name, buffer_size, "_MOTIF_CLIP_ITEM_{}", header.m_item);
   Atom atomItem = XInternAtom(m_display, name, False);
   data = "";
   if (!XWindowsUtil::getWindowProperty(m_display, root, atomItem, &data, &target, &format, False)) {
@@ -668,7 +669,7 @@ void XWindowsClipboard::motifFillCache()
   MotifFormatMap motifFormats;
   for (int32_t i = 0; i < numFormats; ++i) {
     // get Motif format property from the root window
-    snprintf(name, buffer_size, "_MOTIF_CLIP_ITEM_%d", formats[i]);
+    std::format_to_n(name, buffer_size, "_MOTIF_CLIP_ITEM_{}", formats[i]);
     Atom atomFormat = XInternAtom(m_display, name, False);
     std::string data;
     if (!XWindowsUtil::getWindowProperty(m_display, root, atomFormat, &data, &target, &format, False)) {
@@ -743,7 +744,7 @@ bool XWindowsClipboard::motifGetSelection(const MotifClipFormat *format, Atom *a
   // part that i don't know.
   static const int buffer_size = 18 + 20;
   char name[buffer_size];
-  snprintf(name, buffer_size, "_MOTIF_CLIP_ITEM_%d", format->m_data);
+  std::format_to_n(name, buffer_size, "_MOTIF_CLIP_ITEM_{}", format->m_data);
   Atom target = XInternAtom(m_display, name, False);
   Window root = RootWindow(m_display, DefaultScreen(m_display));
   return XWindowsUtil::getWindowProperty(m_display, root, target, data, actualTarget, nullptr, False);

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1020,7 +1020,7 @@ bool XWindowsClipboard::sendReply(Reply *reply)
         const std::string hex_digits = "0123456789abcdef";
         std::string tmp;
         tmp.reserve(data.length() * 3);
-        std::for_each(data.begin(), data.end(), [hex_digits, &tmp](const unsigned char &c) {
+        std::ranges::for_each(data, [&hex_digits, &tmp](const unsigned char &c) {
           tmp += hex_digits[c >> 16];
           tmp += hex_digits[c & 15];
           tmp += ' ';

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -1016,8 +1016,7 @@ bool XWindowsClipboard::sendReply(Reply *reply)
       LOG((CLOG_DEBUG2 "  %s: <can't read property>", name));
     } else {
       // convert to hex if contains non ascii symbols
-      if (std::find_if(data.begin(), data.end(), [](const unsigned char &c) { return c < 32 || c > 126; }) !=
-          data.end()) {
+      if (std::ranges::find_if(data, [](const unsigned char &c) { return c < 32 || c > 126; }) != data.end()) {
         const std::string hex_digits = "0123456789abcdef";
         std::string tmp;
         tmp.reserve(data.length() * 3);

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -338,7 +338,7 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
 
   // prepare map from X modifier to KeyModifierMask.  certain bits
   // are predefined.
-  std::fill(m_modifierFromX.begin(), m_modifierFromX.end(), 0);
+  std::ranges::fill(m_modifierFromX, 0);
   m_modifierFromX[ShiftMapIndex] = KeyModifierShift;
   m_modifierFromX[LockMapIndex] = KeyModifierCapsLock;
   m_modifierFromX[ControlMapIndex] = KeyModifierControl;

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -917,7 +917,8 @@ void XWindowsScreen::saveShape()
   // screen instead of the logical screen.
   m_xinerama = false;
 #if HAVE_X11_EXTENSIONS_XINERAMA_H
-  int eventBase, errorBase;
+  int eventBase;
+  int errorBase;
   if (XineramaQueryExtension(m_display, &eventBase, &errorBase) && XineramaIsActive(m_display)) {
     int numScreens;
     XineramaScreenInfo *screens;
@@ -962,7 +963,8 @@ void XWindowsScreen::setShape(int32_t width, int32_t height)
   // screen instead of the logical screen.
   m_xinerama = false;
 #if HAVE_X11_EXTENSIONS_XINERAMA_H
-  int eventBase, errorBase;
+  int eventBase;
+  int errorBase;
   if ((XineramaQueryExtension(m_display, &eventBase, &errorBase) != 0) && (XineramaIsActive(m_display) != 0)) {
     int numScreens;
     XineramaScreenInfo *screens;
@@ -990,7 +992,10 @@ Window XWindowsScreen::openWindow() const
   attr.cursor = createBlankCursor();
 
   // adjust attributes and get size and shape
-  int32_t x, y, w, h;
+  int32_t x;
+  int32_t y;
+  int32_t w;
+  int32_t h;
   if (m_isPrimary) {
     // grab window attributes.  this window is used to capture user
     // input when the user is focused on another client.  it covers

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1438,11 +1438,6 @@ bool Config::CellEdge::operator==(const CellEdge &x) const
   return (m_side == x.m_side && m_interval == x.m_interval);
 }
 
-bool Config::CellEdge::operator!=(const CellEdge &x) const
-{
-  return !operator==(x);
-}
-
 //
 // Config::Cell
 //
@@ -1564,11 +1559,6 @@ bool Config::Cell::operator==(const Cell &x) const
   }
 
   return true;
-}
-
-bool Config::Cell::operator!=(const Cell &x) const
-{
-  return !operator==(x);
 }
 
 Config::Cell::const_iterator Config::Cell::begin() const

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -81,7 +81,6 @@ public:
 
     // compares side and interval
     bool operator==(const CellEdge &) const;
-    bool operator!=(const CellEdge &) const;
 
   private:
     void init(const std::string_view &name, Direction side, const Interval &);
@@ -125,7 +124,6 @@ private:
     bool getLink(Direction side, float position, const CellEdge *&src, const CellEdge *&dst) const;
 
     bool operator==(const Cell &) const;
-    bool operator!=(const Cell &) const;
 
     const_iterator begin() const;
     const_iterator end() const;
@@ -188,10 +186,6 @@ public:
     bool operator==(const const_iterator &i) const
     {
       return (m_i == i.m_i);
-    }
-    bool operator!=(const const_iterator &i) const
-    {
-      return (m_i != i.m_i);
     }
 
   private:

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -873,11 +873,6 @@ bool InputFilter::operator==(const InputFilter &x) const
   return (aList == bList);
 }
 
-bool InputFilter::operator!=(const InputFilter &x) const
-{
-  return !operator==(x);
-}
-
 void InputFilter::handleEvent(const Event &event)
 {
   // copy event and adjust target

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -868,8 +868,8 @@ bool InputFilter::operator==(const InputFilter &x) const
   for (auto i = x.m_ruleList.begin(); i != x.m_ruleList.end(); ++i) {
     bList.push_back(i->format());
   }
-  std::partial_sort(aList.begin(), aList.end(), aList.end());
-  std::partial_sort(bList.begin(), bList.end(), bList.end());
+  std::ranges::partial_sort(aList, aList.end());
+  std::ranges::partial_sort(bList, bList.end());
   return (aList == bList);
 }
 

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -383,8 +383,6 @@ public:
 
   //! Compare filters
   bool operator==(const InputFilter &) const;
-  //! Compare filters
-  bool operator!=(const InputFilter &) const;
 
 private:
   // event handling


### PR DESCRIPTION
Next batch of sonar cleanup contains

 - Log: Replace use of `snprintf` with `std::format_to_n` (for non macOS builds)
 - Use `std::ranges` version of methods in most places where a container is used
 - XWindowsClipboard: Replace uses of `snprintf` with `std::format_to_n`
 - Remove redundant `private` section in Fingerprint Struct
 - Declare Variables on separate lines (XWindowsScreen)
 - Remove redundant `!=` operator. In c++20 as long as a class has the `==` operator  a `!=` operator of `!(a==b)` will be generated. 