### PR TITLE
Sonar cleanup 12

### DIFF
--- a/src/lib/base/FunctionEventJob.h
+++ b/src/lib/base/FunctionEventJob.h
@@ -17,7 +17,7 @@ class FunctionEventJob : public IEventJob
 {
 public:
   //! run() invokes \c func(arg)
-  FunctionEventJob(void (*func)(const Event &, void *), void *arg = nullptr);
+  explicit FunctionEventJob(void (*func)(const Event &, void *), void *arg = nullptr);
   ~FunctionEventJob() override = default;
 
   // IEventJob overrides

--- a/src/lib/base/FunctionJob.h
+++ b/src/lib/base/FunctionJob.h
@@ -17,7 +17,7 @@ class FunctionJob : public IJob
 {
 public:
   //! run() invokes \c func(arg)
-  FunctionJob(void (*func)(void *), void *arg = nullptr);
+  explicit FunctionJob(void (*func)(void *), void *arg = nullptr);
   ~FunctionJob() override = default;
 
   // IJob overrides

--- a/src/lib/base/Stopwatch.cpp
+++ b/src/lib/base/Stopwatch.cpp
@@ -75,11 +75,6 @@ double Stopwatch::getTime()
   }
 }
 
-Stopwatch::operator double()
-{
-  return getTime();
-}
-
 bool Stopwatch::isStopped() const
 {
   return m_stopped;
@@ -92,9 +87,4 @@ double Stopwatch::getTime() const
   } else {
     return Arch::time() - m_mark;
   }
-}
-
-Stopwatch::operator double() const
-{
-  return getTime();
 }

--- a/src/lib/base/Stopwatch.h
+++ b/src/lib/base/Stopwatch.h
@@ -66,8 +66,6 @@ public:
   returns zero if the trigger is set).
   */
   double getTime();
-  //! Same as getTime()
-  operator double();
   //@}
   //! @name accessors
   //@{
@@ -85,8 +83,6 @@ public:
   stopwatch to start and will not clear the trigger.
   */
   double getTime() const;
-  //! Same as getTime() const
-  operator double() const;
   //@}
 
 private:

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -184,6 +184,12 @@ void App::initApp(int argc, const char **argv)
   loadConfig();
 }
 
+void App::handleScreenError() const
+{
+  LOG((CLOG_CRIT "error on screen"));
+  getEvents()->addEvent(Event(EventTypes::Quit));
+}
+
 void App::runEventsLoop(void *)
 {
   m_events->loop();

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -109,10 +109,9 @@ public:
     return *s_instance;
   }
 
-  void (*m_bye)(int);
-
 protected:
   void runEventsLoop(void *);
+  void (*m_bye)(int);
 
 private:
   IEventQueue *m_events = nullptr;

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -109,6 +109,8 @@ public:
     return *s_instance;
   }
 
+  void handleScreenError() const;
+
 protected:
   void runEventsLoop(void *);
   void (*m_bye)(int);

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -114,9 +114,8 @@ public:
 protected:
   void runEventsLoop(void *);
 
-  IEventQueue *m_events = nullptr;
-
 private:
+  IEventQueue *m_events = nullptr;
   deskflow::ArgsBase *m_args;
   static App *s_instance;
   FileLogOutputter *m_fileLog = nullptr;

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -200,12 +200,6 @@ void ClientApp::updateStatus(const std::string_view &) const
   // do nothing
 }
 
-void ClientApp::handleScreenError()
-{
-  LOG((CLOG_CRIT "error on screen"));
-  getEvents()->addEvent(Event(EventTypes::Quit));
-}
-
 deskflow::Screen *ClientApp::openClientScreen()
 {
   deskflow::Screen *screen = createScreen();

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -65,7 +65,6 @@ public:
 
   void updateStatus() const;
   void updateStatus(const std::string_view &) const;
-  void handleScreenError();
   deskflow::Screen *openClientScreen();
   void closeClientScreen(deskflow::Screen *screen);
   void handleClientRestart(const Event &, EventQueueTimer *vtimer);

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -62,9 +62,6 @@ public:
   //
   // Regular functions
   //
-
-  void updateStatus() const;
-  void updateStatus(const std::string_view &) const;
   deskflow::Screen *openClientScreen();
   void closeClientScreen(deskflow::Screen *screen);
   void handleClientRestart(const Event &, EventQueueTimer *vtimer);

--- a/src/lib/deskflow/PlatformScreen.h
+++ b/src/lib/deskflow/PlatformScreen.h
@@ -21,7 +21,7 @@ subclasses to implement the rest.
 class PlatformScreen : public IPlatformScreen
 {
 public:
-  PlatformScreen(
+  explicit PlatformScreen(
       IEventQueue *events, deskflow::ClientScrollDirection scrollDirection = deskflow::ClientScrollDirection::Normal
   );
   ~PlatformScreen() override = default;

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -519,12 +519,6 @@ PrimaryClient *ServerApp::openPrimaryClient(const std::string &name, deskflow::S
   return new PrimaryClient(name, screen);
 }
 
-void ServerApp::handleScreenError()
-{
-  LOG((CLOG_CRIT "error on screen"));
-  getEvents()->addEvent(Event(EventTypes::Quit));
-}
-
 void ServerApp::handleSuspend()
 {
   if (!m_suspended) {

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -98,7 +98,6 @@ public:
   void retryHandler();
   deskflow::Screen *openServerScreen();
   PrimaryClient *openPrimaryClient(const std::string &name, deskflow::Screen *screen);
-  void handleScreenError();
   void handleSuspend();
   void handleResume();
   ClientListener *openClientListener(const NetworkAddress &address);

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -87,8 +87,6 @@ public:
   void handleClientConnected(const Event &e, ClientListener *listener);
   void closeServer(Server *server);
   void stopRetryTimer();
-  void updateStatus() const;
-  void updateStatus(const std::string_view &msg) const;
   void closeClientListener(ClientListener *listen);
   void stopServer();
   void closePrimaryClient(PrimaryClient *primaryClient);

--- a/src/lib/gui/FileTail.h
+++ b/src/lib/gui/FileTail.h
@@ -18,7 +18,7 @@ class FileTail : public QObject
   Q_OBJECT
 
 public:
-  FileTail(const QString &filePath, QObject *parent = nullptr);
+  explicit FileTail(const QString &filePath, QObject *parent = nullptr);
 
 Q_SIGNALS:
   void newLine(const QString &line);

--- a/src/lib/gui/ServerConfig.h
+++ b/src/lib/gui/ServerConfig.h
@@ -46,7 +46,7 @@ class ServerConfig : public ScreenConfig, public deskflow::gui::IServerConfig
   friend QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);
 
 public:
-  ServerConfig(MainWindow &mainWindow, int columns = kDefaultColumns, int rows = kDefaultRows);
+  explicit ServerConfig(MainWindow &mainWindow, int columns = kDefaultColumns, int rows = kDefaultRows);
   ~ServerConfig() override = default;
 
   bool operator==(const ServerConfig &sc) const;

--- a/src/lib/gui/dialogs/AddClientDialog.h
+++ b/src/lib/gui/dialogs/AddClientDialog.h
@@ -29,7 +29,7 @@ class AddClientDialog : public QDialog
 {
   Q_OBJECT
 public:
-  AddClientDialog(const QString &clientName, QWidget *parent = nullptr);
+  explicit AddClientDialog(const QString &clientName, QWidget *parent = nullptr);
   ~AddClientDialog() override;
 
   AddAction addResult() const

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.h
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.h
@@ -24,7 +24,7 @@ class ScreenSettingsDialog : public QDialog
   Q_OBJECT
 
 public:
-  ScreenSettingsDialog(QWidget *parent, Screen *pScreen = nullptr, const ScreenList *pScreens = nullptr);
+  explicit ScreenSettingsDialog(QWidget *parent, Screen *pScreen = nullptr, const ScreenList *pScreens = nullptr);
   ~ScreenSettingsDialog() override;
 
 public Q_SLOTS:

--- a/src/lib/gui/widgets/KeySequenceWidget.h
+++ b/src/lib/gui/widgets/KeySequenceWidget.h
@@ -16,7 +16,7 @@ class KeySequenceWidget : public QPushButton
   Q_OBJECT
 
 public:
-  KeySequenceWidget(QWidget *parent, const KeySequence &seq = KeySequence());
+  explicit KeySequenceWidget(QWidget *parent, const KeySequence &seq = KeySequence());
 
 Q_SIGNALS:
   void keySequenceChanged();

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -38,7 +38,7 @@ public:
   is thrown with an error of \c XSocketAddress::kBadPort.  The hostname
   is not resolved by the c'tor;  use \c resolve to do that.
   */
-  NetworkAddress(const std::string &hostname, int port = 0);
+  explicit NetworkAddress(const std::string &hostname, int port = 0);
 
   NetworkAddress(const NetworkAddress &);
 

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -34,12 +34,12 @@ SecureListenSocket::SecureListenSocket(
 
 std::unique_ptr<IDataSocket> SecureListenSocket::accept()
 {
-  std::unique_ptr<SecureSocket> socket;
+  std::unique_ptr<SecureSocket> secureSocket;
   try {
-    socket = std::make_unique<SecureSocket>(
-        m_events, m_socketMultiplexer, ARCH->acceptSocket(m_socket, nullptr), m_securityLevel
+    secureSocket = std::make_unique<SecureSocket>(
+        events(), socketMultiplexer(), ARCH->acceptSocket(socket(), nullptr), m_securityLevel
     );
-    socket->initSsl(true);
+    secureSocket->initSsl(true);
 
     setListeningJob();
 
@@ -51,20 +51,20 @@ std::unique_ptr<IDataSocket> SecureListenSocket::accept()
       certificateFilename = ArgParser::argsBase().m_tlsCertFile;
     }
 
-    if (!socket->loadCertificates(certificateFilename)) {
+    if (!secureSocket->loadCertificates(certificateFilename)) {
       return nullptr;
     }
 
-    socket->secureAccept();
+    secureSocket->secureAccept();
 
-    return socket;
+    return secureSocket;
   } catch (XArchNetwork &) {
-    if (socket) {
+    if (secureSocket) {
       setListeningJob();
     }
     return nullptr;
   } catch (std::exception &ex) {
-    if (socket) {
+    if (secureSocket) {
       setListeningJob();
     }
     throw ex;

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -78,7 +78,7 @@ void SecureSocket::close()
 
 void SecureSocket::connect(const NetworkAddress &addr)
 {
-  m_events->addHandler(EventTypes::DataSocketConnected, getEventTarget(), [this](const auto &e) {
+  getEvents()->addHandler(EventTypes::DataSocketConnected, getEventTarget(), [this](const auto &e) {
     handleTCPConnected(e);
   });
   TCPSocket::connect(addr);

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -44,10 +44,24 @@ public:
 protected:
   void setListeningJob();
 
-  IEventQueue *m_events;
-  ArchSocket m_socket;
-  SocketMultiplexer *m_socketMultiplexer;
+  ArchSocket socket() const
+  {
+    return m_socket;
+  }
+
+  IEventQueue *events() const
+  {
+    return m_events;
+  }
+
+  SocketMultiplexer *socketMultiplexer() const
+  {
+    return m_socketMultiplexer;
+  }
 
 private:
+  ArchSocket m_socket;
+  IEventQueue *m_events;
+  SocketMultiplexer *m_socketMultiplexer;
   std::mutex m_mutex;
 };

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -123,7 +123,6 @@ protected:
   void sendEvent(EventTypes);
   void discardWrittenData(int bytesWrote);
 
-  IEventQueue *m_events;
   StreamBuffer m_inputBuffer;
   StreamBuffer m_outputBuffer;
 
@@ -144,6 +143,7 @@ private:
   bool m_connected;
   Mutex m_mutex;
   ArchSocket m_socket;
+  IEventQueue *m_events;
   CondVar<bool> m_flushed;
   SocketMultiplexer *m_socketMultiplexer;
 };

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -488,7 +488,7 @@ class ConfigReadContext
 public:
   using ArgList = std::vector<std::string>;
 
-  ConfigReadContext(std::istream &, int32_t firstLine = 1);
+  explicit ConfigReadContext(std::istream &, int32_t firstLine = 1);
   ~ConfigReadContext() = default;
 
   bool readLine(std::string &);

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -139,7 +139,7 @@ public:
       kToggle
     };
 
-    LockCursorToScreenAction(IEventQueue *events, Mode = kToggle);
+    explicit LockCursorToScreenAction(IEventQueue *events, Mode = kToggle);
 
     Mode getMode() const;
 
@@ -161,7 +161,7 @@ public:
       restart
     };
 
-    RestartServer(IEventQueue *events, Mode = restart);
+    explicit RestartServer(IEventQueue *events, Mode = restart);
 
     Mode getMode() const;
 
@@ -222,8 +222,8 @@ public:
       kToggle
     };
 
-    KeyboardBroadcastAction(IEventQueue *events, Mode = kToggle);
-    KeyboardBroadcastAction(IEventQueue *events, Mode, const std::set<std::string> &screens);
+    explicit KeyboardBroadcastAction(IEventQueue *events, Mode = kToggle);
+    explicit KeyboardBroadcastAction(IEventQueue *events, Mode, const std::set<std::string> &screens);
 
     Mode getMode() const;
     std::set<std::string> getScreens() const;


### PR DESCRIPTION
Next round of sonar "issues"  cleanup 

 - Add `explicit` for a bunch of constructiors
 - Remove unused `StopWatch::double()`
 - Make `App::m_events` private, access it from existing `App::getEvents()` in the sub classes
 - Make `TCPListenSocket` protected var's private and access via protected methods in subclasses
 - Make `TCPSocket::m_events` private access it from getEvents() in sub classes.
     - Note Attempting to make `TcpSocket::outputBuffer` / `TcpSocket::inputBuffer` private with protected member access did build but resulted in failure to connect.  
 - Unify `ClientApp::handleScreenError` and `ServerApp::handleScreenError` into `App::handleScreenError`
 - Make `App::m_bye` protected member
 - Remove `do nothing` methods `ClientApp::updateStatus(...)` and `ServerApp::updateStatus(...)` (was even calling it in places)