### PR TITLE
fix: server: initialize the m_protocol member with a default value

### DIFF
--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -358,7 +358,7 @@ private:
   };
 
   // used in hello message sent to the client
-  NetworkProtocol m_protocol;
+  NetworkProtocol m_protocol = NetworkProtocol::Barrier;
 
   // the primary screen client
   PrimaryClient *m_primaryClient;


### PR DESCRIPTION
It is likely random whether the server works or not without a manually configured protocol option, which is neither documented nor enforced to be set.
With a random uninitialized value in m_protocol, this can happen: 
[2025-08-03T12:39:57] NOTE: accepted client connection
[2025-08-03T12:39:57] FATAL: a runtime error occurred: XInvalidProtocol

Reports of "it works with debug enabled" are likely due to having parts of the memory space the server object is allocated into being cleared, and thus having a 0 (Synergy) startup value.