### PR TITLE
Sonar cleanup 13

### DIFF
--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -113,9 +113,9 @@ public:
 
 protected:
   void runEventsLoop(void *);
-  void (*m_bye)(int);
 
 private:
+  void (*m_bye)(int);
   IEventQueue *m_events = nullptr;
   deskflow::ArgsBase *m_args;
   static App *s_instance;

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -72,9 +72,9 @@ void ClientApp::parseArgs(int argc, const char *const *argv)
 
   if (!result || args().m_shouldExitOk || args().m_shouldExitFail) {
     if (args().m_shouldExitOk) {
-      m_bye(s_exitSuccess);
+      bye(s_exitSuccess);
     } else {
-      m_bye(s_exitArgs);
+      bye(s_exitArgs);
     }
   } else {
     // save server address
@@ -89,7 +89,7 @@ void ClientApp::parseArgs(int argc, const char *const *argv)
         // Priddy.
         if (!args().m_restartable || e.getError() == XSocketAddress::SocketError::BadPort) {
           LOG((CLOG_CRIT "%s: %s" BYE, args().m_pname, e.what(), args().m_pname));
-          m_bye(s_exitFailed);
+          bye(s_exitFailed);
         }
       }
     }
@@ -442,7 +442,7 @@ void ClientApp::startNode()
   // we shouldn't retry.
   LOG((CLOG_DEBUG1 "starting client"));
   if (!startClient()) {
-    m_bye(s_exitFailed);
+    bye(s_exitFailed);
   }
 }
 

--- a/src/lib/deskflow/DisplayInvalidException.h
+++ b/src/lib/deskflow/DisplayInvalidException.h
@@ -11,14 +11,11 @@
 
 class DisplayInvalidException : public std::runtime_error
 {
+#ifdef __APPLE__
 public:
-  explicit DisplayInvalidException(const char *msg) : std::runtime_error(msg)
-  {
-    // do nothing
-  }
-
   explicit DisplayInvalidException(const std::string &msg) : std::runtime_error(msg)
   {
     // do nothing
   }
+#endif
 };

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -26,7 +26,7 @@ IKeyState::IKeyState(const IEventQueue *)
 
 IKeyState::KeyInfo *IKeyState::KeyInfo::alloc(KeyID id, KeyModifierMask mask, KeyButton button, int32_t count)
 {
-  auto *info = (KeyInfo *)malloc(sizeof(KeyInfo));
+  auto *info = new KeyInfo();
   info->m_key = id;
   info->m_mask = mask;
   info->m_button = button;
@@ -44,7 +44,7 @@ IKeyState::KeyInfo *IKeyState::KeyInfo::alloc(
   const char *buffer = screens.c_str();
 
   // build structure
-  auto *info = (KeyInfo *)malloc(sizeof(KeyInfo) + screens.size());
+  auto *info = new KeyInfo();
   info->m_key = id;
   info->m_mask = mask;
   info->m_button = button;
@@ -57,7 +57,7 @@ IKeyState::KeyInfo *IKeyState::KeyInfo::alloc(
 IKeyState::KeyInfo *IKeyState::KeyInfo::alloc(const KeyInfo &x)
 {
   auto bufferLen = strnlen(x.m_screensBuffer, SIZE_MAX);
-  auto info = (KeyInfo *)malloc(sizeof(KeyInfo) + bufferLen);
+  auto *info = new KeyInfo();
   info->m_key = x.m_key;
   info->m_mask = x.m_mask;
   info->m_button = x.m_button;

--- a/src/lib/deskflow/IKeyState.cpp
+++ b/src/lib/deskflow/IKeyState.cpp
@@ -134,7 +134,7 @@ void IKeyState::KeyInfo::split(const char *screens, std::set<std::string> &dst)
   const char *i = screens + 1;
   while (*i != '\0') {
     const char *j = strchr(i, ':');
-    dst.emplace(std::string(i, j - i));
+    dst.emplace(i, j - i);
     i = j + 1;
   }
 }

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -1211,19 +1211,6 @@ void KeyMap::initKeyNameMaps()
 }
 
 //
-// KeyMap::KeyItem
-//
-
-bool KeyMap::KeyItem::operator==(const KeyItem &x) const
-{
-  return (
-      m_id == x.m_id && m_group == x.m_group && m_button == x.m_button && m_required == x.m_required &&
-      m_sensitive == x.m_sensitive && m_generates == x.m_generates && m_dead == x.m_dead && m_lock == x.m_lock &&
-      m_client == x.m_client
-  );
-}
-
-//
 // KeyMap::Keystroke
 //
 

--- a/src/lib/deskflow/KeyMap.h
+++ b/src/lib/deskflow/KeyMap.h
@@ -52,7 +52,7 @@ public:
     uint32_t m_client{};           //!< Client data
 
   public:
-    bool operator==(const KeyItem &) const;
+    bool operator==(const KeyItem &) const = default;
   };
 
   //! The KeyButtons needed to synthesize a KeyID

--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -1110,14 +1110,8 @@ void KeyState::updateModifierKeyState(
   // get the modifier buttons that were pressed or released
   deskflow::KeyMap::ButtonToKeyMap pressed;
   deskflow::KeyMap::ButtonToKeyMap released;
-  std::set_difference(
-      oldKeys.begin(), oldKeys.end(), newKeys.begin(), newKeys.end(), std::inserter(released, released.end()),
-      ButtonToKeyLess()
-  );
-  std::set_difference(
-      newKeys.begin(), newKeys.end(), oldKeys.begin(), oldKeys.end(), std::inserter(pressed, pressed.end()),
-      ButtonToKeyLess()
-  );
+  std::ranges::set_difference(oldKeys, newKeys, std::inserter(released, released.end()), ButtonToKeyLess());
+  std::ranges::set_difference(newKeys, oldKeys, std::inserter(pressed, pressed.end()), ButtonToKeyLess());
 
   // update state
   for (deskflow::KeyMap::ButtonToKeyMap::const_iterator i = released.begin(); i != released.end(); ++i) {

--- a/src/lib/deskflow/KeyTypes.cpp
+++ b/src/lib/deskflow/KeyTypes.cpp
@@ -186,11 +186,8 @@ const KeyNameMapEntry kKeyNameMap[] = {
 const KeyModifierNameMapEntry kModifierNameMap[] = {
     {"Alt", KeyModifierAlt},
     {"AltGr", KeyModifierAltGr},
-    //    { "CapsLock",        KeyModifierCapsLock },
     {"Control", KeyModifierControl},
     {"Meta", KeyModifierMeta},
-    //    { "NumLock",        KeyModifierNumLock },
-    //    { "ScrollLock",        KeyModifierScrollLock },
     {"Shift", KeyModifierShift},
     {"Super", KeyModifierSuper},
     {nullptr, 0},

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -80,9 +80,9 @@ void ServerApp::parseArgs(int argc, const char *const *argv)
 
   if (!result || args().m_shouldExitOk || args().m_shouldExitFail) {
     if (args().m_shouldExitOk) {
-      m_bye(s_exitSuccess);
+      bye(s_exitSuccess);
     } else {
-      m_bye(s_exitArgs);
+      bye(s_exitArgs);
     }
   } else {
     if (!args().m_deskflowAddress.empty()) {
@@ -91,7 +91,7 @@ void ServerApp::parseArgs(int argc, const char *const *argv)
         m_deskflowAddress->resolve();
       } catch (XSocketAddress &e) {
         LOG((CLOG_CRIT "%s: %s" BYE, args().m_pname, e.what(), args().m_pname));
-        m_bye(s_exitArgs);
+        bye(s_exitArgs);
       }
     }
   }
@@ -162,12 +162,12 @@ void ServerApp::loadConfig()
   const auto path = args().m_configFile;
   if (path.empty()) {
     LOG((CLOG_CRIT "no configuration path provided"));
-    m_bye(s_exitConfig);
+    bye(s_exitConfig);
   }
 
   if (!loadConfig(path)) {
     LOG((CLOG_CRIT "%s: failed to load config: %s", args().m_pname, path.c_str()));
-    m_bye(s_exitConfig);
+    bye(s_exitConfig);
   }
 }
 
@@ -721,6 +721,6 @@ void ServerApp::startNode()
   // we shouldn't retry.
   LOG((CLOG_DEBUG1 "starting server"));
   if (!startServer()) {
-    m_bye(s_exitFailed);
+    bye(s_exitFailed);
   }
 }

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -21,7 +21,7 @@
 
 #include <filesystem>
 
-AppUtilUnix::AppUtilUnix(const IEventQueue *events)
+AppUtilUnix::AppUtilUnix(const IEventQueue *)
 {
   // do nothing
 }

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -16,7 +16,7 @@ class IEventQueue;
 class AppUtilUnix : public AppUtil
 {
 public:
-  explicit AppUtilUnix(const IEventQueue *events);
+  explicit AppUtilUnix(const IEventQueue *);
   ~AppUtilUnix() override = default;
 
   int run(int argc, char **argv) override;

--- a/src/lib/gui/Action.cpp
+++ b/src/lib/gui/Action.cpp
@@ -96,14 +96,6 @@ void Action::saveSettings(QSettings &settings) const
   settings.setValue(SettingsKeys::RestartServer, restartServer());
 }
 
-bool Action::operator==(const Action &a) const
-{
-  return m_keySequence == a.m_keySequence && m_type == a.m_type && m_typeScreenNames == a.m_typeScreenNames &&
-         m_switchScreenName == a.m_switchScreenName && m_switchDirection == a.m_switchDirection &&
-         m_lockCursorMode == a.m_lockCursorMode && m_activeOnRelease == a.m_activeOnRelease &&
-         m_hasScreens == a.m_hasScreens && m_restartServer == a.m_restartServer;
-}
-
 QTextStream &operator<<(QTextStream &outStream, const Action &action)
 {
   if (action.activeOnRelease())

--- a/src/lib/gui/Action.h
+++ b/src/lib/gui/Action.h
@@ -105,7 +105,7 @@ public:
     return m_restartServer;
   }
 
-  bool operator==(const Action &a) const;
+  bool operator==(const Action &a) const = default;
 
 protected:
   KeySequence &keySequence()

--- a/src/lib/gui/KeySequence.cpp
+++ b/src/lib/gui/KeySequence.cpp
@@ -218,8 +218,3 @@ QString KeySequence::keyToString(int key)
   // give up, deskflow probably won't handle this
   return "";
 }
-
-bool KeySequence::operator==(const KeySequence &ks) const
-{
-  return m_Sequence == ks.m_Sequence && m_Modifiers == ks.m_Modifiers && m_IsValid == ks.m_IsValid;
-}

--- a/src/lib/gui/KeySequence.h
+++ b/src/lib/gui/KeySequence.h
@@ -36,7 +36,7 @@ public:
     return m_Sequence;
   }
 
-  bool operator==(const KeySequence &ks) const;
+  bool operator==(const KeySequence &ks) const = default;
 
 private:
   void setValid(bool b)

--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -247,15 +247,13 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   outStream << "section: links" << Qt::endl;
 
   for (int i = 0; const auto &screen : config.screens()) {
-    if (screen.isNull()) {
-      i++;
-      continue;
-    }
-    outStream << "\t" << screen.name() << ":\n";
-    for (const auto &neighbour : std::as_const(neighbourDirs)) {
-      int idx = config.adjacentScreenIndex(i, neighbour.x, neighbour.y);
-      if (idx != -1 && !config.screens()[idx].isNull())
-        outStream << "\t\t" << neighbour.name << " = " << config.screens()[idx].name() << Qt::endl;
+    if (!screen.isNull()) {
+      outStream << "\t" << screen.name() << ":\n";
+      for (const auto &neighbour : std::as_const(neighbourDirs)) {
+        int idx = config.adjacentScreenIndex(i, neighbour.x, neighbour.y);
+        if (idx != -1 && !config.screens()[idx].isNull())
+          outStream << "\t\t" << neighbour.name << " = " << config.screens()[idx].name() << Qt::endl;
+      }
     }
     i++;
   }

--- a/src/lib/gui/ServerConfig.cpp
+++ b/src/lib/gui/ServerConfig.cpp
@@ -246,15 +246,18 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 
   outStream << "section: links" << Qt::endl;
 
-  for (int i = 0; i < config.screens().size(); i++) {
-    if (!config.screens()[i].isNull()) {
-      outStream << "\t" << config.screens()[i].name() << ":" << Qt::endl;
-      for (unsigned int j = 0; j < std::size(neighbourDirs); j++) {
-        int idx = config.adjacentScreenIndex(i, neighbourDirs[j].x, neighbourDirs[j].y);
-        if (idx != -1 && !config.screens()[idx].isNull())
-          outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << Qt::endl;
-      }
+  for (int i = 0; const auto &screen : config.screens()) {
+    if (screen.isNull()) {
+      i++;
+      continue;
     }
+    outStream << "\t" << screen.name() << ":\n";
+    for (const auto &neighbour : std::as_const(neighbourDirs)) {
+      int idx = config.adjacentScreenIndex(i, neighbour.x, neighbour.y);
+      if (idx != -1 && !config.screens()[idx].isNull())
+        outStream << "\t\t" << neighbour.name << " = " << config.screens()[idx].name() << Qt::endl;
+    }
+    i++;
   }
 
   outStream << "end" << Qt::endl << Qt::endl;

--- a/src/lib/net/Fingerprint.cpp
+++ b/src/lib/net/Fingerprint.cpp
@@ -24,11 +24,6 @@ bool Fingerprint::isValid() const
   }
 }
 
-bool Fingerprint::operator==(const Fingerprint &other) const
-{
-  return type == other.type && data == other.data;
-}
-
 QString Fingerprint::toDbLine() const
 {
   if (!isValid()) {

--- a/src/lib/net/Fingerprint.h
+++ b/src/lib/net/Fingerprint.h
@@ -29,7 +29,7 @@ public:
 
   bool isValid() const;
 
-  bool operator==(const Fingerprint &other) const;
+  bool operator==(const Fingerprint &other) const = default;
   QString toDbLine() const;
   static Fingerprint fromDbLine(const QString &line);
   static QString typeToString(Fingerprint::Type type);

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -46,8 +46,8 @@ TCPSocket::TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, 
 
 TCPSocket::TCPSocket(IEventQueue *events, SocketMultiplexer *socketMultiplexer, ArchSocket socket)
     : IDataSocket(events),
-      m_events(events),
       m_socket(socket),
+      m_events(events),
       m_flushed(&m_mutex, true),
       m_socketMultiplexer(socketMultiplexer)
 {

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -226,7 +226,7 @@ void MSWindowsDesks::fakeInputEnd()
 
 void MSWindowsDesks::getCursorPos(int32_t &x, int32_t &y) const
 {
-  POINT pos;
+  POINT pos{0, 0};
   sendMessage(DESKFLOW_MSG_CURSOR_POS, reinterpret_cast<WPARAM>(&pos), 0);
   x = pos.x;
   y = pos.y;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -541,11 +541,6 @@ bool Config::operator==(const Config &x) const
   return true;
 }
 
-bool Config::operator!=(const Config &x) const
-{
-  return !operator==(x);
-}
-
 void Config::read(ConfigReadContext &context)
 {
   Config tmp(m_events);

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -416,8 +416,6 @@ public:
 
   //! Compare configurations
   bool operator==(const Config &) const;
-  //! Compare configurations
-  bool operator!=(const Config &) const;
 
   //! Read configuration
   /*!


### PR DESCRIPTION
 Next round of sonar clean up: 
 - TCPSocket: init `m_socket` before `m_events`
 - ServerConfig: use ranged loops for screens section
 - IKeyState: directly send args for string creation to emplace
 - IKeyState: Remove use of malloc (+ use auto now for the type) 
 - App: make `m_bye` private and access via existing method `bye`
 - DisplayInvalidException remove unneeded constructors on non mac os
 - MSWindowsDesks::getCursorPos, initialize pos to 0,0
 - KeyState::updateModifierState, use `std::ranges::set_difference`
 - KeyTypes::KeyModifierNameMapEntry, remove commented code
 - AppUtilUnix remove name from unused IEventQueue pointer
 - Use default == operator for `KeyMap`, `Action`, `KeySequence`, `Fingerprint`
 - server/Config remove redundant != operator