### PR TITLE
chore: Improve logging for active sides

### DIFF
--- a/src/lib/base/DirectionTypes.h
+++ b/src/lib/base/DirectionTypes.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+
 /**
  * @brief Screen edge directions for mouse movement
  *

--- a/src/lib/deskflow/PlatformScreen.cpp
+++ b/src/lib/deskflow/PlatformScreen.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "deskflow/PlatformScreen.h"
+#include "base/DirectionTypes.h"
 #include "deskflow/App.h"
-#include "deskflow/ArgsBase.h"
 
 PlatformScreen::PlatformScreen(IEventQueue *events, deskflow::ClientScrollDirection scrollDirection)
     : IPlatformScreen(events),
@@ -87,4 +87,23 @@ void PlatformScreen::pollPressedKeys(KeyButtonSet &pressedKeys) const
 int32_t PlatformScreen::mapClientScrollDirection(int32_t x) const
 {
   return (x * static_cast<int>(m_clientScrollDirection));
+}
+
+std::string PlatformScreen::sidesMaskToString(uint32_t sides)
+{
+  using enum DirectionMask;
+  std::string sidesText;
+  if ((sides & static_cast<int>(LeftMask)) != 0) {
+    sidesText += "L";
+  }
+  if ((sides & static_cast<int>(RightMask)) != 0) {
+    sidesText += "R";
+  }
+  if ((sides & static_cast<int>(TopMask)) != 0) {
+    sidesText += "T";
+  }
+  if ((sides & static_cast<int>(BottomMask)) != 0) {
+    sidesText += "B";
+  }
+  return sidesText;
 }

--- a/src/lib/deskflow/PlatformScreen.h
+++ b/src/lib/deskflow/PlatformScreen.h
@@ -106,6 +106,11 @@ protected:
    */
   virtual int32_t mapClientScrollDirection(int32_t) const;
 
+  /*!
+  Converts a sides mask (e.g. LeftMask | RightMask) to a string representation (e.g. "LR").
+   */
+  static std::string sidesMaskToString(uint32_t sides);
+
 private:
   /*!
    * \brief m_clientScrollDirection

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -179,7 +179,8 @@ void EiScreen::getCursorPos(int32_t &x, int32_t &y) const
 
 void EiScreen::reconfigure(uint32_t activeSides)
 {
-  LOG((CLOG_DEBUG "active sides: %x", activeSides));
+  const static auto sidesText = sidesMaskToString(activeSides);
+  LOG_DEBUG("active sides: %s (0x%02x)", sidesText.c_str(), activeSides);
   m_activeSides = activeSides;
 }
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -507,7 +507,8 @@ void MSWindowsScreen::reconfigure(uint32_t activeSides)
 {
   assert(m_isPrimary);
 
-  LOG((CLOG_DEBUG "active sides: %x", activeSides));
+  const static auto sidesText = sidesMaskToString(activeSides);
+  LOG_DEBUG("active sides: %s (0x%02x)", sidesText.c_str(), activeSides);
   m_hook.setSides(activeSides);
 }
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -246,7 +246,8 @@ void OSXScreen::getCursorPos(int32_t &x, int32_t &y) const
 
 void OSXScreen::reconfigure(uint32_t activeSides)
 {
-  LOG((CLOG_DEBUG "active sides: %x", activeSides));
+  const static auto sidesText = sidesMaskToString(activeSides);
+  LOG_DEBUG("active sides: %s (0x%02x)", sidesText.c_str(), activeSides);
   m_activeSides = activeSides;
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -479,6 +479,8 @@ void XWindowsScreen::getCursorPos(int32_t &x, int32_t &y) const
 
 void XWindowsScreen::reconfigure(uint32_t activeSides)
 {
+  const static auto sidesText = sidesMaskToString(activeSides);
+  LOG_DEBUG("active sides: %s (0x%02x)", sidesText.c_str(), activeSides);
   m_activeSides = activeSides;
 }
 


### PR DESCRIPTION
For the longest time, this log line has bugged me:
```
active sides: e
```

It's hex, but it looks like a bug, since there's no `0x` prefix. Also, most humans can't read hex, so I added a string representation.

New version:
```
[2025-08-06T11:56:00] DEBUG: active sides: LRT (0x0e)
```