### PR TITLE
Conform EI files to our naming convention

### DIFF
--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -45,7 +45,7 @@ EiEventQueueBuffer::~EiEventQueueBuffer()
   close(m_pipeWrite);
 }
 
-void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
+void EiEventQueueBuffer::waitForEvent(double msTimeout)
 {
   Thread::testCancel();
 
@@ -59,7 +59,7 @@ void EiEventQueueBuffer::waitForEvent(double timeout_in_ms)
   pfds[s_pipeFd].fd = m_pipeRead;
   pfds[s_pipeFd].events = POLLIN;
 
-  int timeout = (timeout_in_ms < 0.0) ? -1 : static_cast<int>(1000.0 * timeout_in_ms);
+  int timeout = (msTimeout < 0.0) ? -1 : static_cast<int>(1000.0 * msTimeout);
 
   if (int retval = poll(pfds, s_pollFdCount, timeout); retval > 0) {
     if (pfds[s_eiFd].revents & POLLIN) {

--- a/src/lib/platform/EiEventQueueBuffer.h
+++ b/src/lib/platform/EiEventQueueBuffer.h
@@ -31,7 +31,7 @@ public:
   {
     // do nothing
   }
-  void waitForEvent(double timeout_in_ms) override;
+  void waitForEvent(double msTimeout) override;
   Type getEvent(Event &event, uint32_t &dataID) override;
   bool addEvent(uint32_t dataID) override;
   bool isEmpty() const override;

--- a/src/lib/platform/EiKeyState.h
+++ b/src/lib/platform/EiKeyState.h
@@ -32,7 +32,7 @@ public:
   std::int32_t pollActiveGroup() const override;
   void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
   KeyID mapKeyFromKeyval(std::uint32_t keyval) const;
-  void updateXkbState(std::uint32_t keyval, bool is_pressed);
+  void updateXkbState(std::uint32_t keyval, bool isPressed);
 
 protected:
   // KeyState overrides
@@ -40,7 +40,7 @@ protected:
   void fakeKey(const Keystroke &keystroke) override;
 
 private:
-  std::uint32_t convertModMask(std::uint32_t xkb_mask) const;
+  std::uint32_t convertModMask(std::uint32_t xkbMask) const;
   void assignGeneratedModifiers(std::uint32_t keycode, KeyMap::KeyItem &item);
 
   EiScreen *m_screen = nullptr;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -680,7 +680,7 @@ void EiScreen::onMotionEvent(ei_event *event)
   if (m_isOnScreen) {
     LOG_DEBUG("event: motion on primary x=%i y=%i)", m_cursorX, m_cursorY);
     sendEvent(EventTypes::PrimaryScreenMotionOnPrimary, MotionInfo::alloc(m_cursorX, m_cursorY));
-    if (m_portalInputCapture->is_active()) {
+    if (m_portalInputCapture->isActive()) {
       m_portalInputCapture->release();
     }
   } else {
@@ -776,7 +776,7 @@ void EiScreen::handleSystemEvent(const Event &sysevent)
       if (m_isPrimary) {
         LOG_DEBUG("re-allocating portal input capture connection and releasing active captures");
         if (m_portalInputCapture) {
-          if (m_portalInputCapture->is_active()) {
+          if (m_portalInputCapture->isActive()) {
             m_portalInputCapture->release();
           }
           delete m_portalInputCapture;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -311,14 +311,14 @@ void EiScreen::fakeMouseWheel(int32_t xDelta, int32_t yDelta) const
   ei_device_frame(m_eiPointer, ei_now(m_ei));
 }
 
-void EiScreen::fakeKey(uint32_t keycode, bool is_down) const
+void EiScreen::fakeKey(uint32_t keycode, bool isDown) const
 {
   if (!m_eiKeyboard)
     return;
 
-  auto xkb_keycode = keycode + 8;
-  m_keyState->updateXkbState(xkb_keycode, is_down);
-  ei_device_keyboard_key(m_eiKeyboard, keycode, is_down);
+  auto xkbKeycode = keycode + 8;
+  m_keyState->updateXkbState(xkbKeycode, isDown);
+  ei_device_keyboard_key(m_eiKeyboard, keycode, isDown);
   ei_device_frame(m_eiKeyboard, ei_now(m_ei));
 }
 
@@ -540,7 +540,7 @@ ButtonID EiScreen::mapButtonFromEvdev(ei_event *event) const
   return kButtonNone;
 }
 
-bool EiScreen::onHotkey(KeyID keyid, bool is_pressed, KeyModifierMask mask)
+bool EiScreen::onHotkey(KeyID keyid, bool isPressed, KeyModifierMask mask)
 {
   auto it = m_hotkeys.find(keyid);
 
@@ -552,7 +552,7 @@ bool EiScreen::onHotkey(KeyID keyid, bool is_pressed, KeyModifierMask mask)
   // but we don't put a limitation on modifiers in the hotkeys. So some
   // key combinations may not work correctly, more effort is needed here.
   if (auto id = it->second.findByMask(mask); id != 0) {
-    EventTypes type = is_pressed ? EventTypes::PrimaryScreenHotkeyDown : EventTypes::PrimaryScreenHotkeyUp;
+    EventTypes type = isPressed ? EventTypes::PrimaryScreenHotkeyDown : EventTypes::PrimaryScreenHotkeyUp;
     sendEvent(type, HotKeyInfo::alloc(id));
     return true;
   }
@@ -606,12 +606,12 @@ void EiScreen::onPointerScrollEvent(ei_event *event)
 {
   // Ratio of 10 pixels == one wheel click because that's what mutter/gtk
   // use (for historical reasons).
-  const int PIXELS_PER_WHEEL_CLICK = 10;
+  static const int s_pixelsPerWheelClick = 10;
   // Our logical wheel clicks are multiples 120, so we
   // convert between the two and keep the remainders because
   // we will very likely get subpixel scroll events.
-  // This means a single pixel is 120/PIXEL_TO_WHEEL_RATIO in wheel values.
-  const int PIXEL_TO_WHEEL_RATIO = 120 / PIXELS_PER_WHEEL_CLICK;
+  // This means a single pixel is 120/s_pixelToWheelRation in wheel values.
+  const int s_pixelToWheelRatio = 120 / s_pixelsPerWheelClick;
 
   assert(m_isPrimary);
 
@@ -644,7 +644,7 @@ void EiScreen::onPointerScrollEvent(ei_event *event)
   if (x != 0 || y != 0)
     sendEvent(
         EventTypes::PrimaryScreenWheel,
-        WheelInfo::alloc((int32_t)-x * PIXEL_TO_WHEEL_RATIO, (int32_t)-y * PIXEL_TO_WHEEL_RATIO)
+        WheelInfo::alloc((int32_t)-x * s_pixelToWheelRatio, (int32_t)-y * s_pixelToWheelRatio)
     );
 
   remainder->x = rx;
@@ -686,13 +686,13 @@ void EiScreen::onMotionEvent(ei_event *event)
   } else {
     m_bufferDX += dx;
     m_bufferDY += dy;
-    auto pixel_dx = static_cast<std::int32_t>(m_bufferDX);
-    auto pixel_dy = static_cast<std::int32_t>(m_bufferDY);
-    if (pixel_dx || pixel_dy) {
-      LOG_DEBUG1("event: motion on secondary x=%d y=%d", pixel_dx, pixel_dy);
-      sendEvent(EventTypes::PrimaryScreenMotionOnSecondary, MotionInfo::alloc(pixel_dx, pixel_dy));
-      m_bufferDX -= pixel_dx;
-      m_bufferDY -= pixel_dy;
+    auto pixelDx = static_cast<std::int32_t>(m_bufferDX);
+    auto pixelDy = static_cast<std::int32_t>(m_bufferDY);
+    if (pixelDx || pixelDy) {
+      LOG_DEBUG1("event: motion on secondary x=%d y=%d", pixelDx, pixelDy);
+      sendEvent(EventTypes::PrimaryScreenMotionOnSecondary, MotionInfo::alloc(pixelDx, pixelDy));
+      m_bufferDX -= pixelDx;
+      m_bufferDY -= pixelDy;
     }
   }
 }

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -58,7 +58,7 @@ public:
   void fakeMouseMove(std::int32_t x, std::int32_t y) override;
   void fakeMouseRelativeMove(std::int32_t dx, std::int32_t dy) const override;
   void fakeMouseWheel(std::int32_t xDelta, std::int32_t yDelta) const override;
-  void fakeKey(std::uint32_t keycode, bool is_down) const;
+  void fakeKey(std::uint32_t keycode, bool isDown) const;
 
   // IPlatformScreen overrides
   void enable() override;
@@ -99,7 +99,7 @@ private:
   void onPointerScrollDiscreteEvent(ei_event *event);
   void onMotionEvent(ei_event *event);
   void onAbsMotionEvent(const ei_event *) const;
-  bool onHotkey(KeyID key, bool is_press, KeyModifierMask mask);
+  bool onHotkey(KeyID key, bool isPressed, KeyModifierMask mask);
   void eiLogEvent(ei_log_priority priority, const char *message) const;
 
   void handleConnectedToEisEvent(const Event &event);

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -27,7 +27,7 @@ public:
   void disable();
   void release();
   void release(double x, double y);
-  bool is_active() const
+  bool isActive() const
   {
     return m_isActive;
   }


### PR DESCRIPTION
fixes: #8818

update our variable and methods names to match our naming conventions

Some `snake_case` remains but these are types or methods outside of our code. 