### PR TITLE
fix: MainWindow::setHostName potental error

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -1106,7 +1106,14 @@ void MainWindow::setHostName()
 
   QString text = ui->lineEditName->text();
   const auto screenName = Settings::value(Settings::Core::ScreenName).toString();
-  bool existingScreen = serverConfig().screenExists(text) && (text != screenName);
+
+  if (text == screenName)
+    return;
+
+  const bool isServer = ui->rbModeServer->isChecked();
+  bool existingScreen = false;
+  if (isServer)
+    existingScreen = serverConfig().screenExists(text);
 
   if (!ui->lineEditName->hasAcceptableInput() || text.isEmpty() || existingScreen) {
     blockSignals(true);
@@ -1131,6 +1138,8 @@ void MainWindow::setHostName()
 
   ui->lblComputerName->setText(ui->lineEditName->text());
   Settings::setValue(Settings::Core::ScreenName, ui->lineEditName->text());
+  if (isServer)
+    serverConfig().updateServerName();
   applyConfig();
 }
 


### PR DESCRIPTION
Adjust `MainWindow::setHostName`
 - Return early if the new name is the same as the old name 
 - Only check the server config for an existing screen if we are in server mode.
 - If in server mode make sure to call serverConfig()::upateServerName() when the name changes, Failing todo this can break the server layout as the screen config is not updated. 
