### PR TITLE
GUI: Move the shown ip location, only show when in server mode

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -1008,10 +1008,10 @@ QString MainWindow::getIPAddresses() const
         !address.isInSubnet(QHostAddress::parseSubnet("169.254.0.0/16"))) {
 
       // usually 192.168.x.x is a useful ip for the user, so indicate
-      // this by making it bold.
+      // this by coloring it in the "link" color.
       if (!hinted && address.isInSubnet(localnet)) {
         QString format = R"(<span style="color:%1;">%2</span>)";
-        result.append(format.arg(kColorTertiary, address.toString()));
+        result.append(format.arg(palette().link().color().name(), address.toString()));
         hinted = true;
       } else {
         result.append(address.toString());

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -113,6 +113,7 @@ private:
 
   void showMyFingerprint();
   void updateSecurityIcon(bool visible);
+  void updateNetworkInfo();
 
   void coreModeToggled();
   void updateModeControls(bool serverMode);
@@ -126,7 +127,6 @@ private:
   void setIcon();
   void setStatus(const QString &status);
   void updateFromLogLine(const QString &line);
-  [[nodiscard]] QString getIPAddresses() const;
   void checkConnected(const QString &line);
   void checkFingerprint(const QString &line);
   [[nodiscard]] QString getTimeStamp() const;

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>735</width>
-    <height>515</height>
+    <width>781</width>
+    <height>483</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -131,29 +131,23 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>40</width>
+           <width>6</width>
            <height>20</height>
           </size>
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QLabel" name="lblIpAddresses">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QLabel" name="lblIpAddresses">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="toolTip">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The highlighted IP is the one we think you should use. The server listens on all IPs, so the other IPs may work as well.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="text">
-       <string notr="true">This computer's IP addresses:</string>
-      </property>
      </widget>
     </item>
     <item>

--- a/src/lib/gui/Styles.h
+++ b/src/lib/gui/Styles.h
@@ -12,7 +12,6 @@ namespace deskflow::gui {
 
 const auto kColorWhite = "#ffffff";
 const auto kColorSecondary = "#4285f4";
-const auto kColorTertiary = "#33b2cc";
 const auto kColorError = "#ec4c47";
 const auto kColorLightGrey = "#666666";
 


### PR DESCRIPTION
GUI
 - Use `Link Color` for coloring the ip to use 
 - Move the gui display to the top right 
 - show ONLY the suggested IP on the gui the rest are in a tooltip. no tooltip for a single ip
 - Only show the IP when in server mode. 

<img width="1062" height="453" alt="Screenshot_20250811_172429" src="https://github.com/user-attachments/assets/8926a88b-5019-4b8d-be22-2ce980c591b2" />

<img width="1062" height="453" alt="Screenshot_20250811_172518" src="https://github.com/user-attachments/assets/a218753a-fb53-4f78-a3af-350d7fa68f71" />

I don't have a screen shot for the tooltip buts its 

```
If connecting via the hostname fails, Try the following Ips:
 SuggestedIP (in color) 
 other ip 
 other ip
...
```