### PR TITLE
feat: Use `xkb_keymap_mod_get_mask` in EiKeyState if available

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -162,6 +162,16 @@ macro(configure_unix_libs)
       find_library(LIBM m)
       include_directories(${LIBXKBCOMMON_INCLUDE_DIRS} ${GLIB2_INCLUDE_DIRS}
                           ${LIBM_INCLUDE_DIRS})
+      
+      message(STATUS "xkbcommon version: ${LIBXKBCOMMON_VERSION}")
+
+      # Available since xkbcommon v1.10
+      include(CheckSymbolExists)
+      check_symbol_exists(xkb_keymap_mod_get_mask "xkbcommon/xkbcommon.h" HAVE_XKB_KEYMAP_MOD_GET_MASK)
+      message(VERBOSE "xkb_keymap_mod_get_mask: ${HAVE_XKB_KEYMAP_MOD_GET_MASK}")
+      if (HAVE_XKB_KEYMAP_MOD_GET_MASK)
+        add_definitions(-DHAVE_XKB_KEYMAP_MOD_GET_MASK=1)
+      endif()
     else()
       message(WARNING "pkg-config not found, skipping wayland libraries")
     endif()
@@ -267,6 +277,8 @@ macro(configure_xorg_libs)
   if(HAVE_Xi)
     list(APPEND libs Xi)
   endif()
+
+
 
   add_definitions(-DWINAPI_XWINDOWS=1)
 

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -117,8 +117,16 @@ std::uint32_t EiKeyState::convertModMask(std::uint32_t xkbMask) const
   std::uint32_t modMask = 0;
 
   for (xkb_mod_index_t xkbmod = 0; xkbmod < xkb_keymap_num_mods(m_xkbKeymap); xkbmod++) {
+#ifdef HAVE_XKB_KEYMAP_MOD_GET_MASK
+    // Available since xkbcommon v1.10
+    const auto modMask = xkb_keymap_mod_get_mask(m_xkbKeymap, xkbmod);
+    if ((xkbMask & modMask) == 0)
+      continue;
+#else
+    // HACK: <= xkbcommon v1.7 we need to check the mask manually.
     if ((xkbMask & (1 << xkbmod)) == 0)
       continue;
+#endif
 
     /* added in libxkbcommon 1.8.0 in the same commit so we have all or none */
 #ifndef XKB_VMOD_NAME_ALT


### PR DESCRIPTION
Uses `xkb_keymap_mod_get_mask` introduced in xkbcommon v1.10.0

TODO: Figure out the CMake config and detect xkbcommon v1.10.0 instead of checking for the function.