### PR TITLE
feat: Support Remote Desktop token persistance

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -37,6 +37,7 @@ public:
     inline static const auto InvertScrollDirection = QStringLiteral("client/invertScrollDirection");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
+    inline static const auto XdpRestoreToken = QStringLiteral("client/xdpRestoreToken");
   };
   struct Core
   {


### PR DESCRIPTION
Fixes #8869 for Remote Desktop (i.e client) 

IMHO There is no reason to ever allow input capture always (i.e server).

Besides, When / If The Input Capture portal gains support for a restore token it should be trivial to use this PR as an example enabling it for that portal. 

Edit by @nbolton: Thanks to @whot for work upstream which made this possible.
