### PR TITLE
feat: Prevent core, client and or server from running at the same time

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
+#include "VersionInfo.h"
 #include "arch/Arch.h"
 #include "base/EventQueue.h"
 #include "base/Log.h"
@@ -20,6 +21,8 @@
 
 #include <QSharedMemory>
 #include <iostream>
+
+const static auto kHeader = QStringLiteral("%1-core: %2\n").arg(kAppId, kDisplayVersion);
 
 void showHelp()
 {
@@ -38,6 +41,20 @@ bool isHelp(int argc, char **argv)
 {
   for (int i = 0; i < argc; ++i) {
     if (argv[i] == std::string("--help") || argv[i] == std::string("-h"))
+      return true;
+  }
+  return false;
+}
+
+void showVersion()
+{
+  std::cout << qPrintable(kHeader) << qPrintable(kCopyright) << std::endl;
+}
+
+bool isVersion(int argc, char **argv)
+{
+  for (int i = 0; i < argc; ++i) {
+    if (argv[i] == std::string("--version") || argv[i] == std::string("-v"))
       return true;
   }
   return false;
@@ -62,6 +79,11 @@ int main(int argc, char **argv)
 
   if (isHelp(argc, argv)) {
     showHelp();
+    return s_exitSuccess;
+  }
+
+  if (isVersion(argc, argv)) {
+    showVersion();
     return s_exitSuccess;
   }
 

--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -9,6 +9,7 @@
 #include "arch/Arch.h"
 #include "base/EventQueue.h"
 #include "base/Log.h"
+#include "common/ExitCodes.h"
 #include "deskflow/ClientApp.h"
 #include "deskflow/ServerApp.h"
 
@@ -61,7 +62,7 @@ int main(int argc, char **argv)
 
   if (isHelp(argc, argv)) {
     showHelp();
-    return 0;
+    return s_exitSuccess;
   }
 
   // Create a shared memory segment with a unique key
@@ -76,7 +77,7 @@ int main(int argc, char **argv)
   // If we can create 1 byte of SHM we are the only instance
   if (!sharedMemory.create(1)) {
     LOG_WARN("an instance of deskflow core (server or client) is already running");
-    return 0;
+    return s_exitDuplicate;
   }
 #if SYSAPI_WIN32
   // HACK to make sure settings gets the correct qApp path
@@ -98,5 +99,5 @@ int main(int argc, char **argv)
     showHelp();
   }
 
-  return 0;
+  return s_exitSuccess;
 }

--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -26,6 +26,7 @@ const static auto kHeader = QStringLiteral("%1-core: %2\n").arg(kAppId, kDisplay
 
 void showHelp()
 {
+  std::cout << qPrintable(kHeader) << qPrintable(kAppDescription) << "\n\n";
   std::cout << "Usage: deskflow-core <server | client> [...options]" << std::endl;
   std::cout << "server - start as a server (deskflow-server)" << std::endl;
   std::cout << "client - start as a client (deskflow-client)" << std::endl;

--- a/src/apps/deskflow-daemon/deskflow-daemon.cpp
+++ b/src/apps/deskflow-daemon/deskflow-daemon.cpp
@@ -9,6 +9,7 @@
 #include "arch/Arch.h"
 #include "base/EventQueue.h"
 #include "base/Log.h"
+#include "common/ExitCodes.h"
 #include "common/Settings.h"
 #include "deskflow/DaemonApp.h"
 #include "deskflow/ipc/DaemonIpcServer.h"

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -8,6 +8,7 @@
 
 #include "VersionInfo.h"
 #include "common/Constants.h"
+#include "common/ExitCodes.h"
 #include "common/UrlConstants.h"
 #include "gui/Diagnostic.h"
 #include "gui/DotEnv.h"
@@ -68,18 +69,18 @@ int main(int argc, char *argv[])
 
   if (!parser.errorText().isEmpty()) {
     qCritical().noquote() << parser.errorText() << "\nUse --help for more information.";
-    return 1;
+    return s_exitArgs;
   }
 
   if (parser.isSet(helpOption)) {
     QTextStream(stdout) << kHeader << QStringLiteral("  %1\n\n").arg(kAppDescription)
                         << parser.helpText().replace(QApplication::applicationFilePath(), kAppId);
-    return 0;
+    return s_exitSuccess;
   }
 
   if (parser.isSet(versionOption)) {
     QTextStream(stdout) << kHeader << kCopyright << Qt::endl;
-    return 0;
+    return s_exitSuccess;
   }
 
   // Create a shared memory segment with a unique key
@@ -102,7 +103,7 @@ int main(int argc, char *argv[])
       QMessageBox::information(nullptr, QObject::tr("Deskflow"), QObject::tr("Deskflow is already running"));
     }
     socket.disconnectFromServer();
-    return 0;
+    return s_exitDuplicate;
   }
 
 #if !defined(Q_OS_MAC)

--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -13,6 +13,7 @@ unset(SERVER_BINARY)
 
 add_library(common STATIC
   Common.h
+  ExitCodes.h
   Settings.h
   Settings.cpp
   QSettingsProxy.cpp

--- a/src/lib/common/Common.h
+++ b/src/lib/common/Common.h
@@ -32,9 +32,3 @@
 #else
 #endif
 #endif
-
-static const int s_exitSuccess = 0;    //!< App successfully completed
-static const int s_exitFailed = 1;     //!< App had a general failure
-static const int s_exitTerminated = 2; //!< App was kill by a signal
-static const int s_exitArgs = 3;       //!< App was unable to run due to bad arguments being passed
-static const int s_exitConfig = 4;     //!< App was unable to read the configuration

--- a/src/lib/common/ExitCodes.h
+++ b/src/lib/common/ExitCodes.h
@@ -1,0 +1,16 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2010 - 2018, 2024 - 2025 Symless Ltd.
+ * SPDX-FileCopyrightText: (C) 2002 - 2007 Chris Schoeneman
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+static const int s_exitSuccess = 0;    //!< App successfully completed
+static const int s_exitFailed = 1;     //!< App had a general failure
+static const int s_exitTerminated = 2; //!< App was kill by a signal
+static const int s_exitArgs = 3;       //!< App was unable to run due to bad arguments being passed
+static const int s_exitConfig = 4;     //!< App was unable to read the configuration
+static const int s_exitDuplicate = 5;  //!< An instance of the app (or core app) is already running

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -13,6 +13,7 @@
 #include "base/Log.h"
 #include "base/LogOutputters.h"
 #include "common/Constants.h"
+#include "common/ExitCodes.h"
 #include "deskflow/ArgsBase.h"
 #include "deskflow/Config.h"
 #include "deskflow/DeskflowException.h"

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -14,6 +14,7 @@
 #include "base/Log.h"
 #include "client/Client.h"
 #include "common/Constants.h"
+#include "common/ExitCodes.h"
 #include "deskflow/ArgParser.h"
 #include "deskflow/ClientArgs.h"
 #include "deskflow/ProtocolTypes.h"

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -9,6 +9,7 @@
 #include "base/IEventQueue.h"
 #include "base/Log.h"
 #include "base/LogOutputters.h"
+#include "common/ExitCodes.h"
 #include "common/Settings.h"
 #include "deskflow/App.h"
 #include "deskflow/ipc/DaemonIpcServer.h"

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -12,6 +12,7 @@
 #include "base/IEventQueue.h"
 #include "base/Log.h"
 #include "base/Path.h"
+#include "common/ExitCodes.h"
 #include "deskflow/App.h"
 #include "deskflow/ArgParser.h"
 #include "deskflow/Screen.h"

--- a/src/lib/platform/MSWindowsProcess.cpp
+++ b/src/lib/platform/MSWindowsProcess.cpp
@@ -11,6 +11,7 @@
 #include "base/Log.h"
 #include "common/Common.h"
 #include "common/Constants.h"
+#include "common/ExitCodes.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>


### PR DESCRIPTION
fixes: #8258

 - Prevents `deskflow-core` from running two instances at the same time
       - `deskflow-core --help` will always return the help message
       - `deskflow-core --version` will always return the version info
       -  Duplicate runs will print `An instance of deskflow core is already running` and exit
 - Intercept `--help` and `-h` in `deskflow-core` to call its `showHelp`
 - Intercept `--version` and `-v` in `deskflow-core` to call  its `showVersion`
 - Move the exit codes to a new `common/ExitCodes.h`
 - Use new exit codes for all exits.
 - Add new exit code `s_exitDuplicate` to return when exiting because of an instance is already running.
