### PR TITLE
various small fixes

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 
   // If we can create 1 byte of SHM we are the only instance
   if (!sharedMemory.create(1)) {
-    LOG_WARN("an instance of deskflow core (server or client) is already running");
+    LOG_WARN("an instance of deskflow core is already running");
     return s_exitDuplicate;
   }
 #if SYSAPI_WIN32

--- a/src/apps/deskflow-daemon/deskflow-daemon.cpp
+++ b/src/apps/deskflow-daemon/deskflow-daemon.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
   // useful for troubleshooting Windows services.
   // It's important to write the version number to the log file so we can be certain the old daemon
   // was uninstalled, since sometimes Windows services can get stuck and fail to be removed.
-  LOG_PRINT("%s v%s", QCoreApplication::applicationName().toStdString().c_str(), kDisplayVersion);
+  LOG_PRINT("%s v%s", qPrintable(QCoreApplication::applicationName()), kDisplayVersion);
 
   // Default log level to system setting (found in Registry).
   auto logLevel = Settings::value(Settings::Daemon::LogLevel).toString().toStdString();
@@ -105,8 +105,7 @@ int main(int argc, char **argv)
       return s_exitSuccess;
     }
 
-    const auto ipcServer =
-        new ipc::DaemonIpcServer(&app, DaemonApp::logFilename().toStdString().c_str()); // NOSONAR - Qt managed
+    const auto ipcServer = new ipc::DaemonIpcServer(&app, qPrintable(DaemonApp::logFilename())); // NOSONAR - Qt managed
     ipcServer->listen();
     daemon.connectIpcServer(ipcServer);
 

--- a/src/apps/res/deskflow.qrc
+++ b/src/apps/res/deskflow.qrc
@@ -6,6 +6,8 @@
         <file>icons/deskflow-dark/actions/16/document-open.svg</file>
         <file>icons/deskflow-dark/actions/16/document-save-as.svg</file>
         <file>icons/deskflow-dark/actions/16/help-about.svg</file>
+        <file>icons/deskflow-dark/actions/16/network-connect.svg</file>
+        <file>icons/deskflow-dark/actions/16/network-disconnect.svg</file>
         <file>icons/deskflow-dark/actions/16/process-stop.svg</file>
         <file>icons/deskflow-dark/actions/16/system-run.svg</file>
         <file>icons/deskflow-dark/actions/16/tools-report-bug.svg</file>
@@ -17,6 +19,8 @@
         <file>icons/deskflow-dark/actions/22/document-save-as.svg</file>
         <file>icons/deskflow-dark/actions/22/fingerprint.svg</file>
         <file>icons/deskflow-dark/actions/22/help-about.svg</file>
+        <file>icons/deskflow-dark/actions/22/network-connect.svg</file>
+        <file>icons/deskflow-dark/actions/22/network-disconnect.svg</file>
         <file>icons/deskflow-dark/actions/22/process-stop.svg</file>
         <file>icons/deskflow-dark/actions/22/system-run.svg</file>
         <file>icons/deskflow-dark/actions/22/tools-report-bug.svg</file>
@@ -29,6 +33,8 @@
         <file>icons/deskflow-dark/actions/24/edit-clear-all.svg</file>
         <file>icons/deskflow-dark/actions/24/fingerprint.svg</file>
         <file>icons/deskflow-dark/actions/24/help-about.svg</file>
+        <file>icons/deskflow-dark/actions/24/network-connect.svg</file>
+        <file>icons/deskflow-dark/actions/24/network-disconnect.svg</file>
         <file>icons/deskflow-dark/actions/24/process-stop.svg</file>
         <file>icons/deskflow-dark/actions/24/system-run.svg</file>
         <file>icons/deskflow-dark/actions/24/tools-report-bug.svg</file>
@@ -63,6 +69,8 @@
         <file>icons/deskflow-light/actions/16/document-open.svg</file>
         <file>icons/deskflow-light/actions/16/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/16/help-about.svg</file>
+        <file>icons/deskflow-light/actions/16/network-connect.svg</file>
+        <file>icons/deskflow-light/actions/16/network-disconnect.svg</file>
         <file>icons/deskflow-light/actions/16/process-stop.svg</file>
         <file>icons/deskflow-light/actions/16/system-run.svg</file>
         <file>icons/deskflow-light/actions/16/tools-report-bug.svg</file>
@@ -74,6 +82,8 @@
         <file>icons/deskflow-light/actions/22/document-open.svg</file>
         <file>icons/deskflow-light/actions/22/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/22/fingerprint.svg</file>
+        <file>icons/deskflow-light/actions/22/network-connect.svg</file>
+        <file>icons/deskflow-light/actions/22/network-disconnect.svg</file>
         <file>icons/deskflow-light/actions/22/help-about.svg</file>
         <file>icons/deskflow-light/actions/22/process-stop.svg</file>
         <file>icons/deskflow-light/actions/22/system-run.svg</file>
@@ -87,6 +97,8 @@
         <file>icons/deskflow-light/actions/24/document-open.svg</file>
         <file>icons/deskflow-light/actions/24/document-save-as.svg</file>
         <file>icons/deskflow-light/actions/24/help-about.svg</file>
+        <file>icons/deskflow-light/actions/24/network-connect.svg</file>
+        <file>icons/deskflow-light/actions/24/network-disconnect.svg</file>
         <file>icons/deskflow-light/actions/24/process-stop.svg</file>
         <file>icons/deskflow-light/actions/24/system-run.svg</file>
         <file>icons/deskflow-light/actions/24/tools-report-bug.svg</file>

--- a/src/apps/res/icons/deskflow-dark/actions/16/network-connect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/16/network-connect.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 13.300781 2 L 10.650391 4.6503906 L 9.5859375 3.5859375 L 3.5859375 9.5859375 L 4.6503906 10.650391 L 2 13.300781 L 2.6992188 14 L 5.3496094 11.349609 L 6.4140625 12.414062 L 12.414062 6.4140625 L 11.349609 5.3496094 L 14 2.6992188 L 13.300781 2 z " class="ColorScheme-Text"/>
+</svg>

--- a/src/apps/res/icons/deskflow-dark/actions/16/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/16/network-disconnect.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-NegativeText { color: #da4453; } .ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 13.300781 2 L 10.650391 4.6503906 L 9.5859375 3.5859375 L 6.5859375 6.5859375 L 9.4140625 9.4140625 L 12.414062 6.4140625 L 11.349609 5.3496094 L 14 2.6992188 L 13.300781 2 z M 5.5859375 7.5859375 L 3.5859375 9.5859375 L 4.6503906 10.650391 L 2 13.300781 L 2.6992188 14 L 5.3496094 11.349609 L 6.4140625 12.414062 L 8.4140625 10.414062 L 5.5859375 7.5859375 z " class="ColorScheme-Text"/>
+   <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 9,9.83 10.667,11.497 9,13.164 9.833,13.997 11.5,12.33 13.167,13.997 14,13.164 12.333,11.497 14,9.83 13.167,8.997 11.5,10.664 9.833,8.997 Z" class="ColorScheme-NegativeText"/>
+</svg>

--- a/src/apps/res/icons/deskflow-dark/actions/22/network-connect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/22/network-connect.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z " class="ColorScheme-Text"/>
+</svg>

--- a/src/apps/res/icons/deskflow-dark/actions/22/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/22/network-disconnect.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-NegativeText { color: #da4453; } .ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 9.5 8.7929688 L 11 10.292969 L 11.707031 11 L 13.207031 12.5 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z M 8.7929688 9.5 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 12.5 13.207031 L 11 11.707031 L 10.292969 11 L 8.7929688 9.5 z " class="ColorScheme-Text"/>
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 14.833984 14 L 14 14.833984 L 15.666016 16.5 L 14 18.166016 L 14.833984 19 L 16.5 17.333984 L 18.166016 19 L 19 18.166016 L 17.333984 16.5 L 19 14.833984 L 18.166016 14 L 16.5 15.666016 L 14.833984 14 z " class="ColorScheme-NegativeText"/>
+</svg>

--- a/src/apps/res/icons/deskflow-dark/actions/24/network-connect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/24/network-connect.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+  <g transform="translate(1,1)">
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z " class="ColorScheme-Text"/>
+  </g>
+</svg>

--- a/src/apps/res/icons/deskflow-dark/actions/24/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-dark/actions/24/network-disconnect.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">.ColorScheme-NegativeText { color: #da4453; } .ColorScheme-Text { color: #fcfcfc; } </style>
+  </defs>
+  <g transform="translate(1,1)">
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 9.5 8.7929688 L 11 10.292969 L 11.707031 11 L 13.207031 12.5 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z M 8.7929688 9.5 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 12.5 13.207031 L 11 11.707031 L 10.292969 11 L 8.7929688 9.5 z " class="ColorScheme-Text"/>
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 14.833984 14 L 14 14.833984 L 15.666016 16.5 L 14 18.166016 L 14.833984 19 L 16.5 17.333984 L 18.166016 19 L 19 18.166016 L 17.333984 16.5 L 19 14.833984 L 18.166016 14 L 16.5 15.666016 L 14.833984 14 z " class="ColorScheme-NegativeText"/>
+  </g>
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/16/network-connect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/16/network-connect.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 13.300781 2 L 10.650391 4.6503906 L 9.5859375 3.5859375 L 3.5859375 9.5859375 L 4.6503906 10.650391 L 2 13.300781 L 2.6992188 14 L 5.3496094 11.349609 L 6.4140625 12.414062 L 12.414062 6.4140625 L 11.349609 5.3496094 L 14 2.6992188 L 13.300781 2 z "
+     class="ColorScheme-Text"
+     />
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/16/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/16/network-disconnect.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      .ColorScheme-NegativeText {
+        color:#da4453;
+      }
+      </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 13.300781 2 L 10.650391 4.6503906 L 9.5859375 3.5859375 L 6.5859375 6.5859375 L 9.4140625 9.4140625 L 12.414062 6.4140625 L 11.349609 5.3496094 L 14 2.6992188 L 13.300781 2 z M 5.5859375 7.5859375 L 3.5859375 9.5859375 L 4.6503906 10.650391 L 2 13.300781 L 2.6992188 14 L 5.3496094 11.349609 L 6.4140625 12.414062 L 8.4140625 10.414062 L 5.5859375 7.5859375 z "
+     class="ColorScheme-Text"
+     />
+   <path
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 9,9.83 10.667,11.497 9,13.164 9.833,13.997 11.5,12.33 13.167,13.997 14,13.164 12.333,11.497 14,9.83 13.167,8.997 11.5,10.664 9.833,8.997 Z" 
+     class="ColorScheme-NegativeText"
+     />
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/22/network-connect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/22/network-connect.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      </style>
+  </defs>
+ <path 
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z "
+     class="ColorScheme-Text"
+     />
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/22/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/22/network-disconnect.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      .ColorScheme-NegativeText {
+        color:#da4453;
+      }
+      </style>
+  </defs>
+ <path 
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 9.5 8.7929688 L 11 10.292969 L 11.707031 11 L 13.207031 12.5 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z M 8.7929688 9.5 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 12.5 13.207031 L 11 11.707031 L 10.292969 11 L 8.7929688 9.5 z "
+     class="ColorScheme-Text"
+     />
+    <path
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 14.833984 14 L 14 14.833984 L 15.666016 16.5 L 14 18.166016 L 14.833984 19 L 16.5 17.333984 L 18.166016 19 L 19 18.166016 L 17.333984 16.5 L 19 14.833984 L 18.166016 14 L 16.5 15.666016 L 14.833984 14 z "
+     class="ColorScheme-NegativeText"
+     />
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/24/network-connect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/24/network-connect.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      </style>
+  </defs>
+  <g transform="translate(1,1)">
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z " class="ColorScheme-Text"/>
+  </g>
+</svg>

--- a/src/apps/res/icons/deskflow-light/actions/24/network-disconnect.svg
+++ b/src/apps/res/icons/deskflow-light/actions/24/network-disconnect.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      .ColorScheme-NegativeText {
+        color:#da4453;
+      }
+      </style>
+  </defs>
+  <g transform="translate(1,1)">
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 18.292969 3 L 14.792969 6.5 L 13.292969 5 L 11.292969 7 L 9.5 8.7929688 L 11 10.292969 L 11.707031 11 L 13.207031 12.5 L 15 10.707031 L 17 8.7070312 L 15.5 7.2070312 L 19 3.7070312 L 18.292969 3 z M 8.7929688 9.5 L 8 10.292969 L 6 12.292969 L 7.5 13.792969 L 3 18.292969 L 3.7070312 19 L 8.2070312 14.5 L 9.7070312 16 L 11.707031 14 L 12.5 13.207031 L 11 11.707031 L 10.292969 11 L 8.7929688 9.5 z " class="ColorScheme-Text"/>
+    <path style="fill:currentColor;fill-opacity:1;stroke:none" d="M 14.833984 14 L 14 14.833984 L 15.666016 16.5 L 14 18.166016 L 14.833984 19 L 16.5 17.333984 L 18.166016 19 L 19 18.166016 L 17.333984 16.5 L 19 14.833984 L 18.166016 14 L 16.5 15.666016 L 14.833984 14 z " class="ColorScheme-NegativeText"/>
+  </g>
+</svg>

--- a/src/lib/deskflow/DaemonApp.cpp
+++ b/src/lib/deskflow/DaemonApp.cpp
@@ -250,7 +250,7 @@ void DaemonApp::initLogging()
   }
 #endif
 
-  m_pFileLogOutputter = new FileLogOutputter(logFilename().toStdString().c_str()); // NOSONAR - Adopted by `Log`
+  m_pFileLogOutputter = new FileLogOutputter(qPrintable(logFilename())); // NOSONAR - Adopted by `Log`
   CLOG->insert(m_pFileLogOutputter);
 }
 

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -609,8 +609,8 @@ void MainWindow::updateModeControlLabels()
   } else {
     startText = tr("Connect");
     stopText = tr("Disconnect");
-    startIcon = QIcon::fromTheme(QIcon::ThemeIcon::CallStart);
-    stopIcon = QIcon::fromTheme(QIcon::ThemeIcon::CallStop);
+    startIcon = QIcon::fromTheme(QStringLiteral("network-connect"));
+    stopIcon = QIcon::fromTheme(QStringLiteral("network-disconnect"));
   }
 
   m_actionStartCore->setText(startText);

--- a/src/lib/gui/VersionChecker.cpp
+++ b/src/lib/gui/VersionChecker.cpp
@@ -31,7 +31,7 @@ void VersionChecker::checkLatest() const
   auto userAgent = QString("%1 %2 on %3").arg(kAppName, kVersion, QSysInfo::prettyProductName());
   request.setHeader(QNetworkRequest::UserAgentHeader, userAgent);
   request.setRawHeader("X-Deskflow-Version", kVersion);
-  request.setRawHeader("X-Deskflow-Language", QLocale::system().name().toStdString().c_str());
+  request.setRawHeader("X-Deskflow-Language", qPrintable(QLocale::system().name()));
   m_network->get(request);
 }
 

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -13,6 +13,7 @@
 #include "base/Path.h"
 #include "base/String.h"
 #include "common/Settings.h"
+#include "io/Filesystem.h"
 #include "mt/Lock.h"
 #include "net/FingerprintDatabase.h"
 #include "net/TCPSocket.h"

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -636,7 +636,7 @@ bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
     return false;
 
   // Gui Must Parse this line, DO NOT CHANGE
-  LOG_NOTE("peer fingerprint: %s", deskflow::formatSSLFingerprint(sha256.data, false).toStdString().c_str());
+  LOG_NOTE("peer fingerprint: %s", qPrintable(deskflow::formatSSLFingerprint(sha256.data, false)));
 
   QFile file(FingerprintDatabasePath);
 
@@ -646,12 +646,12 @@ bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
 
   const auto &path = FingerprintDatabasePath;
   if (file.exists() && emptyDB) {
-    LOG_ERR("failed to open trusted fingerprints file: %s", path.toStdString().c_str());
+    LOG_ERR("failed to open trusted fingerprints file: %s", qPrintable(path));
     return false;
   }
 
   if (!emptyDB) {
-    LOG_DEBUG("read %d fingerprint(s) from file: %s", db.fingerprints().size(), path.toStdString().c_str());
+    LOG_DEBUG("read %d fingerprint(s) from file: %s", db.fingerprints().size(), qPrintable(path));
   }
 
   if (!db.isTrusted(sha256)) {

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "io/Filesystem.h"
 #include "net/SecurityLevel.h"
 #include "net/SocketException.h"
 #include "net/TCPSocket.h"

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -242,10 +242,7 @@ bool XWindowsKeyState::setCurrentLanguageWithDBus(int32_t group) const
 
   if (!reply.isValid()) {
     auto qerror = reply.error();
-    LOG(
-        (CLOG_WARN "keyboard layout fail %s : %s", qerror.name().toStdString().c_str(),
-         qerror.message().toStdString().c_str())
-    );
+    LOG((CLOG_WARN "keyboard layout fail %s : %s", qPrintable(qerror.name()), qPrintable(qerror.message())));
     return true;
   }
 


### PR DESCRIPTION
A couple of unrelated changes i didn't feel like making separate PRS for 

 - Where possible use qPrintable in place of `QString::toStdString().c_str()` 
 - Include `io/FileSystem.h` in SecureSocket cpp instead of header. 
 - Adjust CoreProcess::onProcessFinished , do no restart the core if it stopped because an instance has already started.
 - Adjust the message for when the core exits due to a duplicate
 - Add fallback icons for the connect / disconnect buttons. 

@nbolton  This changes the daemon a little please take a bit of extra time testing the windows daemon on this branch. 