### PR TITLE
Disable meta mod (fixes alt key bug)

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -159,12 +159,12 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
       modMaskOut |= (1 << kKeyModifierBitAltGr);
     else if (strcmp(XKB_VMOD_NAME_LEVEL5, name) == 0)
       modMaskOut |= (1 << kKeyModifierBitLevel5Lock);
-    else if (strcmp(XKB_VMOD_NAME_META, name) == 0)
-      modMaskOut |= (1 << kKeyModifierBitMeta);
     else if (strcmp(XKB_VMOD_NAME_NUM, name) == 0)
       modMaskOut |= (1 << kKeyModifierBitNumLock);
     else if (strcmp(XKB_VMOD_NAME_SCROLL, name) == 0)
       modMaskOut |= (1 << kKeyModifierBitScrollLock);
+    else if (strcmp(XKB_VMOD_NAME_META, name) == 0) // possibly the old meta (not the new meta/super/logo key)
+      LOG_DEBUG2("modifier mask %s ignored", name);
     else if (strcmp(XKB_MOD_NAME_MOD2, name) == 0) // spare, sometimes mapped to num lock.
       LOG_DEBUG2("modifier mask %s ignored", name);
     else if (strcmp(XKB_MOD_NAME_MOD3, name) == 0) // spare, could be mapped to alt_r, caps lock, scroll lock, etc.

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -163,11 +163,10 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
       modMaskOut |= (1 << kKeyModifierBitNumLock);
     else if (strcmp(XKB_VMOD_NAME_SCROLL, name) == 0)
       modMaskOut |= (1 << kKeyModifierBitScrollLock);
-    else if (strcmp(XKB_VMOD_NAME_META, name) == 0) // possibly the old meta (not the new meta/super/logo key)
-      LOG_DEBUG2("modifier mask %s ignored", name);
-    else if (strcmp(XKB_MOD_NAME_MOD2, name) == 0) // spare, sometimes mapped to num lock.
-      LOG_DEBUG2("modifier mask %s ignored", name);
-    else if (strcmp(XKB_MOD_NAME_MOD3, name) == 0) // spare, could be mapped to alt_r, caps lock, scroll lock, etc.
+    else if ((strcmp(XKB_VMOD_NAME_META, name) == 0) || // possibly the old meta (not the new meta/super/logo key)
+             (strcmp(XKB_MOD_NAME_MOD2, name) == 0) ||  // spare, sometimes mapped to num lock.
+             (strcmp(XKB_MOD_NAME_MOD3, name) == 0)     // spare, could be mapped to alt_r, caps lock, scroll lock, etc.
+    )
       LOG_DEBUG2("modifier mask %s ignored", name);
     else
       LOG_WARN("modifier mask %s not accounted for, this is a bug", name);


### PR DESCRIPTION
Fixes: #8840

I have no idea why, but removing the [meta key](https://en.wikipedia.org/wiki/Meta_key) mapping fixes the Alt key on my Arch+KDE client.

I do wonder if the [original] meta key is actually used today. It often gets mixed up with the super ("logo") key (which is called meta now by many DE's such as KDE).

My meta/logo/super key works fine with this PR.

<img width="331" height="272" alt="image" src="https://github.com/user-attachments/assets/553f07ae-d419-4979-829e-1c173266a48b" />

CC @wismill @whot
