### PR TITLE
refactor: Calculate level 3 mods with snippet from xkbcommon docs

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -13,6 +13,11 @@
 #include "deskflow/AppUtil.h"
 #include "platform/XDGKeyUtil.h"
 
+// Available since xkbcommon v1.10
+#ifndef HAVE_XKB_KEYMAP_MOD_GET_MASK
+#include <xkbcommon/xkbcommon-names.h>
+#endif
+
 #include <cstddef>
 #include <memory>
 #include <unistd.h>
@@ -120,13 +125,29 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
   for (xkb_mod_index_t xkbModIdx = 0; xkbModIdx < xkb_keymap_num_mods(m_xkbKeymap); xkbModIdx++) {
     const char *name = xkb_keymap_mod_get_name(m_xkbKeymap, xkbModIdx);
 
-#ifdef HAVE_XKB_KEYMAP_MOD_GET_MASK
     // Available since xkbcommon v1.10
+#ifdef HAVE_XKB_KEYMAP_MOD_GET_MASK
     // Note: xkb_keymap_mod_get_mask2 was added in v1.11 which accepts xkb_mod_index_t.
     const auto xkbModMask = xkb_keymap_mod_get_mask(m_xkbKeymap, name);
 #else
-    // HACK: in older xkbcommon we need to create the mask manually from the index.
-    const xkb_mod_mask_t xkbModMask = (1 << xkbModIdx);
+
+#ifndef XKB_VMOD_NAME_LEVEL3
+    static const auto XKB_VMOD_NAME_LEVEL3 = "LevelThree";
+#endif
+
+    // Recommended way from xkbcommon docs for <v1.10:
+    // Find the real modifier mapping of the virtual modifier `LevelThree`
+    const xkb_mod_mask_t xkbModCanonicalMask = UINT32_C(1) << xkbModIdx;
+
+    struct xkb_state *state = xkb_state_new(m_xkbKeymap);
+    if (!state) {
+      LOG_ERR("failed to create temporary xkb state for LevelThree modifier mapping");
+      continue;
+    }
+
+    xkb_state_update_mask(state, xkbModCanonicalMask, 0, 0, 0, 0, 0);
+    const xkb_mod_mask_t xkbModMask = xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
+    xkb_state_unref(state);
 #endif
 
     // Skip modifiers that have no XKB mask (not mapped to any real modifier)
@@ -135,10 +156,55 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
     if (xkbModMask == 0 || (xkbModMaskIn & xkbModMask) != xkbModMask)
       continue;
 
-    /* added in libxkbcommon 1.8.0 in the same commit so we have all or none */
-#ifndef XKB_VMOD_NAME_ALT
+    // Useful advice from wismill (xkbcommon maintainer):
+    //
+    // Meta is usually encoded like Alt, i.e. to Mod1. In that case, both share the same state.
+    // Added to that, if KDE interprets Meta as Super (the logo key), then it might explain the mess.
+    //
+    // If you detect XKB_VMOD_NAME_ALT, then do not use the deprecated[1] constants (e.g. XKB_MOD_NAME_ALT)
+    // nor the XKB_MOD_NAME_MOD* ones. Conversely, if you do not detect them, then do not use the new constants,
+    // because the API < 1.8 will not work as expected.
+    //
+    // [1] https://xkbcommon.org/doc/current/group__legacy-virtual-modifier-names.html
+    //   #define 	XKB_MOD_NAME_ALT   "Mod1"
+    //   #define 	XKB_MOD_NAME_LOGO  "Mod4"
+    //   #define 	XKB_MOD_NAME_NUM   "Mod2"
+
+    /* Macro was added in libxkbcommon 1.8.0 in the same commit, so we have all or none */
+#ifdef XKB_VMOD_NAME_ALT
+
+    if (strcmp(XKB_MOD_NAME_SHIFT, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitShift);
+    else if (strcmp(XKB_MOD_NAME_CAPS, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitCapsLock);
+    else if (strcmp(XKB_MOD_NAME_CTRL, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitControl);
+    else if (strcmp(XKB_VMOD_NAME_ALT, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitAlt);
+    else if (strcmp(XKB_VMOD_NAME_SUPER, name) == 0 || // virtual; usually mapped to logo key
+             strcmp(XKB_VMOD_NAME_HYPER, name) == 0)   // virtual; often mapped to caps lock key
+      modMaskOut |= (1 << kKeyModifierBitSuper);
+    else if (strcmp(XKB_MOD_NAME_MOD5, name) == 0 || strcmp(XKB_VMOD_NAME_LEVEL3, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitAltGr);
+    else if (strcmp(XKB_VMOD_NAME_LEVEL5, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitLevel5Lock);
+    else if (strcmp(XKB_VMOD_NAME_NUM, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitNumLock);
+    else if (strcmp(XKB_VMOD_NAME_SCROLL, name) == 0)
+      modMaskOut |= (1 << kKeyModifierBitScrollLock);
+    else if ((strcmp(XKB_MOD_NAME_ALT, name) == 0) ||   // deprecated, do not use
+             (strcmp(XKB_MOD_NAME_LOGO, name) == 0) ||  // deprecated, do not use
+             (strcmp(XKB_MOD_NAME_NUM, name) == 0) ||   // deprecated, do not use
+             (strcmp(XKB_VMOD_NAME_META, name) == 0) || // virtual; the old meta (not the new meta/super/logo key)
+             (strcmp(XKB_MOD_NAME_MOD2, name) == 0) ||  // spare, sometimes mapped to num lock.
+             (strcmp(XKB_MOD_NAME_MOD3, name) == 0)     // spare, could be mapped to alt_r, caps lock, scroll lock, etc.
+    )
+      LOG_DEBUG2("modifier mask %s ignored", name);
+    else
+      LOG_WARN("modifier mask %s not accounted for, this is a bug", name);
+
+#else
     static const auto XKB_VMOD_NAME_ALT = "Alt";
-    static const auto XKB_VMOD_NAME_LEVEL3 = "LevelThree";
     static const auto XKB_VMOD_NAME_LEVEL5 = "LevelFive";
     static const auto XKB_VMOD_NAME_META = "Meta";
     static const auto XKB_VMOD_NAME_NUM = "NumLock";
@@ -148,11 +214,6 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
     static const auto XKB_MOD_NAME_MOD2 = "Mod2";
     static const auto XKB_MOD_NAME_MOD3 = "Mod3";
     static const auto XKB_MOD_NAME_MOD5 = "Mod5";
-#endif
-
-    // From wismill (xkbcommon maintainer):
-    // Meta is usually encoded like Alt, i.e. to Mod1. In that case, both share the same state.
-    // Added to that, if KDE interprets Meta as Super (the logo key), then it might explain the mess.
 
     if (strcmp(XKB_MOD_NAME_SHIFT, name) == 0)
       modMaskOut |= (1 << kKeyModifierBitShift);
@@ -181,6 +242,7 @@ std::uint32_t EiKeyState::convertModMask(xkb_mod_mask_t xkbModMaskIn) const
       LOG_DEBUG2("modifier mask %s ignored", name);
     else
       LOG_WARN("modifier mask %s not accounted for, this is a bug", name);
+#endif
   }
 
   return modMaskOut;


### PR DESCRIPTION
Fixes: #8897

Todo:
- [ ] Do not use virtual modifier modifiers `*VMOD*` if no `XKB_VMOD_NAME_ALT` defined.

CC @wismill @whot 