### PR TITLE
feat: Add switchToNextScreen hotkey to cycle through computers

### DIFF
--- a/doc/user/configuration.md
+++ b/doc/user/configuration.md
@@ -432,6 +432,9 @@ Actions are two lists of individual actions separated by commas. The two lists a
 * `switchInDirection(dir)`
 : Switch to the screen in the direction ''dir'', which may be one of ''left'', ''right'', ''up'' or ''down''.
 
+* `switchToNextScreen()`
+: Cycle to the next screen in the configuration order. If at the last screen, cycles back to the first screen.
+
 ##### Keynames
 Valid key names are:
 

--- a/src/lib/gui/Action.cpp
+++ b/src/lib/gui/Action.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -12,7 +13,7 @@
 
 QString Action::text() const
 {
-  auto text = QString(m_actionTypeNames.at(keySequence().isMouseButton() ? type() + 6 : type()));
+  auto text = QString(m_actionTypeNames.at(type()));
 
   switch (static_cast<Action::Type>(type())) {
     using enum Type;

--- a/src/lib/gui/Action.h
+++ b/src/lib/gui/Action.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -42,6 +43,7 @@ public:
     keystroke,
     switchToScreen,
     switchInDirection,
+    switchToNextScreen,
     lockCursorToScreen,
     restartAllConnections,
     mouseDown,
@@ -162,11 +164,17 @@ private:
 
   inline static const QString m_commandTemplate = QStringLiteral("(%1)");
   inline static const QStringList m_actionTypeNames{
-      QStringLiteral("keyDown"),           QStringLiteral("keyUp"),
-      QStringLiteral("keystroke"),         QStringLiteral("switchToScreen"),
-      QStringLiteral("switchInDirection"), QStringLiteral("lockCursorToScreen"),
-      QStringLiteral("restartServer"),     QStringLiteral("mouseDown"),
-      QStringLiteral("mouseUp"),           QStringLiteral("mousebutton")
+      QStringLiteral("keyDown"),
+      QStringLiteral("keyUp"),
+      QStringLiteral("keystroke"),
+      QStringLiteral("switchToScreen"),
+      QStringLiteral("switchInDirection"),
+      QStringLiteral("switchToNextScreen"),
+      QStringLiteral("lockCursorToScreen"),
+      QStringLiteral("restartServer"),
+      QStringLiteral("mouseDown"),
+      QStringLiteral("mouseUp"),
+      QStringLiteral("mousebutton")
   };
 
   inline static const QStringList m_switchDirectionNames{

--- a/src/lib/gui/dialogs/ActionDialog.h
+++ b/src/lib/gui/dialogs/ActionDialog.h
@@ -1,6 +1,7 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -31,8 +32,9 @@ public:
     inline static const auto ToggleKey = 2;
     inline static const auto SwitchTo = 3;
     inline static const auto SwitchInDirection = 4;
-    inline static const auto ModifyCursorLock = 5;
-    inline static const auto RestartServer = 6;
+    inline static const auto SwitchToNextScreen = 5;
+    inline static const auto ModifyCursorLock = 6;
+    inline static const auto RestartServer = 7;
   };
 
   ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action);

--- a/src/lib/gui/dialogs/ActionDialog.ui
+++ b/src/lib/gui/dialogs/ActionDialog.ui
@@ -65,6 +65,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Switch to next computer</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Modify the cursor lock</string>
         </property>
        </item>

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -1059,6 +1060,14 @@ void Config::parseAction(
     }
 
     action = new InputFilter::SwitchInDirectionAction(m_events, direction);
+  }
+
+  else if (name == "switchToNextScreen") {
+    if (args.size() != 0) {
+      throw ServerConfigReadException(s, "syntax for action: switchToNextScreen");
+    }
+
+    action = new InputFilter::SwitchToNextScreenAction(m_events);
   }
 
   else if (name == "lockCursorToScreen") {

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -336,6 +336,28 @@ void InputFilter::SwitchInDirectionAction::perform(const Event &event)
   );
 }
 
+InputFilter::SwitchToNextScreenAction::SwitchToNextScreenAction(IEventQueue *events) : m_events(events)
+{
+  // do nothing
+}
+
+InputFilter::Action *InputFilter::SwitchToNextScreenAction::clone() const
+{
+  return new SwitchToNextScreenAction(*this);
+}
+
+std::string InputFilter::SwitchToNextScreenAction::format() const
+{
+  return "switchToNextScreen()";
+}
+
+void InputFilter::SwitchToNextScreenAction::perform(const Event &event)
+{
+  m_events->addEvent(
+      Event(EventTypes::ServerToggleScreen, event.getTarget(), nullptr, Event::EventFlags::DeliverImmediately)
+  );
+}
+
 InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(IEventQueue *events, Mode mode)
     : m_mode(mode),
       m_events(events)

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -211,6 +211,21 @@ public:
     IEventQueue *m_events;
   };
 
+  // SwitchToNextScreenAction
+  class SwitchToNextScreenAction : public Action
+  {
+  public:
+    explicit SwitchToNextScreenAction(IEventQueue *events);
+
+    // Action overrides
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
+
+  private:
+    IEventQueue *m_events;
+  };
+
   // KeyboardBroadcastAction
   class KeyboardBroadcastAction : public Action
   {

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -28,6 +28,7 @@
 #include "server/PrimaryClient.h"
 
 #ifdef _WIN32
+#include <algorithm>
 #include <array>
 #endif
 #include <cmath>
@@ -109,6 +110,9 @@ Server::Server(
   });
   m_events->addHandler(EventTypes::ServerSwitchInDirection, m_inputFilter, [this](const auto &e) {
     handleSwitchInDirectionEvent(e);
+  });
+  m_events->addHandler(EventTypes::ServerToggleScreen, m_inputFilter, [this](const auto &e) {
+    handleToggleScreenEvent(e);
   });
   m_events->addHandler(EventTypes::ServerKeyboardBroadcast, m_inputFilter, [this](const auto &e) {
     handleKeyboardBroadcastEvent(e);
@@ -1328,6 +1332,41 @@ void Server::handleSwitchInDirectionEvent(const Event &event)
   } else {
     jumpToScreen(newScreen);
   }
+}
+
+void Server::handleToggleScreenEvent(const Event &event)
+{
+  // Get the list of connected screens in config order
+  std::vector<std::string> screens;
+  getClients(screens);
+
+  if (screens.size() < 2) {
+    LOG_ERR("not enough screens to toggle");
+    return;
+  }
+
+  // Find the current active screen
+  std::string currentScreen = getName(m_active);
+  auto it = std::ranges::find(screens, currentScreen);
+  if (it == screens.end()) {
+    LOG_ERR("current screen not found in list");
+    return;
+  }
+
+  // Find the next screen
+  auto nextIt = it + 1;
+  if (nextIt == screens.end()) {
+    nextIt = screens.begin();
+  }
+
+  // Find the client for the next screen
+  ClientList::const_iterator clientIt = m_clients.find(*nextIt);
+  if (clientIt == m_clients.end()) {
+    LOG_ERR("next screen not active");
+    return;
+  }
+
+  jumpToScreen(clientIt->second);
 }
 
 void Server::handleKeyboardBroadcastEvent(const Event &event)

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -306,6 +306,7 @@ private:
   void handleClientCloseTimeout(BaseClientProxy *client);
   void handleSwitchToScreenEvent(const Event &event);
   void handleSwitchInDirectionEvent(const Event &event);
+  void handleToggleScreenEvent(const Event &event);
   void handleKeyboardBroadcastEvent(const Event &event);
   void handleLockCursorToScreenEvent(const Event &event);
 


### PR DESCRIPTION
- Add switchToNextScreen action type and GUI option
- Implement server-side screen cycling logic
- Update configuration parsing for new action
- Fix Action::text() method indexing bug
- Update copyright headers for 2025

This implements GitHub issue https://github.com/deskflow/deskflow/issues/8006 - a hotkey to cycle through
connected computers in the Deskflow network.

Closes https://github.com/deskflow/deskflow/issues/8006