### PR TITLE
feat: Allow suppression of generic client connection error dialog

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -81,7 +81,7 @@ QVariant Settings::defaultValue(const QString &key)
 
   if ((key == Gui::CloseToTray) || (key == Gui::LogExpanded) || (key == Gui::SymbolicTrayIcon) ||
       (key == Gui::CloseReminder) || (key == Security::TlsEnabled) || (key == Security::CheckPeers) ||
-      (key == Client::LanguageSync)) {
+      (key == Client::LanguageSync) || (key == Gui::ShowGenericClientFailureDialog)) {
     return true;
   }
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -67,6 +67,7 @@ public:
     inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
     inline static const auto SymbolicTrayIcon = QStringLiteral("gui/symbolicTrayIcon");
     inline static const auto WindowGeometry = QStringLiteral("gui/windowGeometry");
+    inline static const auto ShowGenericClientFailureDialog = QStringLiteral("gui/showGenericClientFailureDialog");
   };
   struct Log
   {
@@ -185,6 +186,7 @@ private:
     , Settings::Gui::LogExpanded
     , Settings::Gui::SymbolicTrayIcon
     , Settings::Gui::WindowGeometry
+    , Settings::Gui::ShowGenericClientFailureDialog
     , Settings::Security::Certificate
     , Settings::Security::CheckPeers
     , Settings::Security::KeySize


### PR DESCRIPTION
Closes: #8907 

Will need #8906  to show if you log level is below NOTE

added a checkbox and setting to track this,
please note the checkbox is added by the QMessagebox we don't have control over placement w/o making custom dialogs. 


<img width="786" height="413" alt="Screenshot_20250829_154726" src="https://github.com/user-attachments/assets/ee60c5a2-05b6-4815-a79b-f89d70252161" />
