### PR TITLE
refactor: ScreenConfigDialog, make sure to populate the screen model after server config

### DIFF
--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -27,8 +27,8 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
       m_originalServerConfig(config),
       m_originalServerConfigIsExternal(config.useExternalConfig()),
       m_originalServerConfigUsesExternalFile(config.configFile()),
-      m_screenSetupModel(config.screens(), config.numColumns(), config.numRows()),
-      m_serverConfig(config)
+      m_serverConfig(config),
+      m_screenSetupModel(m_serverConfig.screens(), m_serverConfig.numColumns(), m_serverConfig.numRows())
 {
   ui->setupUi(this);
 

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -99,8 +99,8 @@ private:
   ServerConfig &m_originalServerConfig;
   bool m_originalServerConfigIsExternal;
   QString m_originalServerConfigUsesExternalFile;
-  ScreenSetupModel m_screenSetupModel;
   ServerConfig m_serverConfig;
+  ScreenSetupModel m_screenSetupModel;
 
 private Q_SLOTS:
   void onChange();


### PR DESCRIPTION
This should correct the inability to write to the server config