### PR TITLE
Make user agent RFC 9110, add popularity contest, improve update check dialog

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -67,6 +67,7 @@ public:
     inline static const auto AutoStartCore = QStringLiteral("gui/startCoreWithGui");
     inline static const auto AutoUpdateCheck = QStringLiteral("gui/enableUpdateCheck");
     inline static const auto UpdateCheckUrl = QStringLiteral("gui/updateCheckUrl");
+    inline static const auto JoinPopularityContest = QStringLiteral("gui/joinPopularityContest");
     inline static const auto CloseReminder = QStringLiteral("gui/closeReminder");
     inline static const auto CloseToTray = QStringLiteral("gui/closeToTray");
     inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
@@ -207,6 +208,7 @@ private:
     , Settings::Gui::AutoStartCore
     , Settings::Gui::AutoUpdateCheck
     , Settings::Gui::UpdateCheckUrl
+    , Settings::Gui::JoinPopularityContest
     , Settings::Gui::CloseReminder
     , Settings::Gui::CloseToTray
     , Settings::Gui::LogExpanded
@@ -229,6 +231,7 @@ private:
     , Settings::Gui::AutoStartCore
     , Settings::Gui::ShownFirstConnectedMessage
     , Settings::Gui::ShownServerFirstStartMessage
+    , Settings::Gui::JoinPopularityContest
     , Settings::Core::PreventSleep
     , Settings::Core::UseWlClipboard
     , Settings::Server::ExternalConfig

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -639,7 +639,11 @@ void MainWindow::open()
   QTimer::singleShot(kCriticalDialogDelay, this, &messages::raiseCriticalDialog);
 
   if (!Settings::value(Settings::Gui::AutoUpdateCheck).isValid()) {
-    Settings::setValue(Settings::Gui::AutoUpdateCheck, messages::showUpdateCheckOption(this));
+    const auto onlineServices = messages::showOnlineServicesOptions(this);
+    qDebug() << "check for updates:" << onlineServices.checkForUpdates;
+    qDebug() << "join popularity contest:" << onlineServices.joinPopularityContest;
+    Settings::setValue(Settings::Gui::AutoUpdateCheck, onlineServices.checkForUpdates);
+    Settings::setValue(Settings::Gui::JoinPopularityContest, onlineServices.joinPopularityContest);
   }
 
   if (Settings::value(Settings::Gui::AutoUpdateCheck).toBool()) {

--- a/src/lib/gui/Messages.h
+++ b/src/lib/gui/Messages.h
@@ -15,6 +15,19 @@ class QWidget;
 
 namespace deskflow::gui::messages {
 
+enum class ClientError
+{
+  AlreadyConnected,
+  HostnameError,
+  GenericError
+};
+
+struct OnlineServicesOptions
+{
+  bool checkForUpdates;
+  bool joinPopularityContest;
+};
+
 void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 
 void raiseCriticalDialog();
@@ -35,7 +48,7 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
 
 void showWaylandLibraryError(QWidget *parent);
 
-bool showUpdateCheckOption(QWidget *parent);
+OnlineServicesOptions showOnlineServicesOptions(QWidget *parent);
 
 bool showDaemonOffline(QWidget *parent);
 

--- a/src/lib/gui/VersionChecker.h
+++ b/src/lib/gui/VersionChecker.h
@@ -15,11 +15,15 @@ class QNetworkReply;
 class VersionChecker : public QObject
 {
   Q_OBJECT
+
 public:
   explicit VersionChecker(QObject *parent = nullptr);
   void checkLatest() const;
+  static QString getUserAgent(bool popularityContestEnabled = false);
+
 public Q_SLOTS:
   void replyFinished(QNetworkReply *reply);
+
 Q_SIGNALS:
   void updateFound(const QString &version);
 

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -178,6 +178,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
   Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
   Settings::setValue(Settings::Gui::AutoUpdateCheck, ui->cbAutoUpdate->isChecked());
+  Settings::setValue(Settings::Gui::JoinPopularityContest, ui->cbPopularityContest->isChecked());
   Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
   Settings::setValue(Settings::Security::Certificate, ui->lineTlsCertPath->text());
   Settings::setValue(Settings::Security::KeySize, ui->comboTlsKeyLength->currentText().toInt());
@@ -218,6 +219,7 @@ void SettingsDialog::loadFromConfig()
   ui->sbScrollSpeed->setValue(Settings::value(Settings::Client::ScrollSpeed).toInt());
   ui->cbGuiDebug->setChecked(Settings::value(Settings::Log::GuiDebug).toBool());
   ui->cbUseWlClipboard->setChecked(Settings::value(Settings::Core::UseWlClipboard).toBool());
+  ui->cbPopularityContest->setChecked(Settings::value(Settings::Gui::JoinPopularityContest).toBool());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
   ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -112,6 +112,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="cbPopularityContest">
+            <property name="text">
+             <string>Participate in popularity contest (send extra user-agent data)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="cbAutoHide">
             <property name="text">
              <string>Hide the window when the app starts</string>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1311,6 +1311,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <source>Automatic</source>
         <translation type="unfinished">Automática</translation>
     </message>
+    <message>
+        <source>Participate in popularity contest (send extra user-agent data)</source>
+        <translation type="unfinished">Participar en el concurso de popularidad (enviar datos adicionales del user-agent)</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -708,14 +708,6 @@ Nombres válidos:
         <translation type="unfinished">No, gracias</translation>
     </message>
     <message>
-        <source>Check for updates</source>
-        <translation type="unfinished">Buscar actualizaciones</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Would you like to check for updates when %1 starts?&lt;/p&gt;&lt;p&gt;Checking for updates requires an Internet connection.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;¿Desea comprobar si hay actualizaciones cuando se inicie %1?&lt;/p&gt;&lt;p&gt;Para comprobar si hay actualizaciones se requiere una conexión a Internet.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Background service offline</source>
         <translation type="unfinished">Servicio en segundo plano sin conexión</translation>
     </message>
@@ -749,6 +741,34 @@ Nombres válidos:
         <source>failed to read RSA key from certificate file: %1</source>
         <extracomment>%1 will be replaced by the certificate path</extracomment>
         <translation type="unfinished">No se pudo leer la clave RSA del archivo de certificado: %1</translation>
+    </message>
+    <message>
+        <source>Some optional %1 features require an Internet connection. Would you like to enable them?</source>
+        <translation type="unfinished">Algunas funciones opcionales de %1 requieren una conexión a Internet. ¿Desea activarlas?</translation>
+    </message>
+    <message>
+        <source>Choose which features to enable:</source>
+        <translation type="unfinished">Elija qué funciones activar:</translation>
+    </message>
+    <message>
+        <source>Check for new versions when app starts</source>
+        <translation type="unfinished">Comprobar si hay nuevas versiones al iniciar la aplicación</translation>
+    </message>
+    <message>
+        <source>Participate in popularity contest</source>
+        <translation type="unfinished">Participar en el concurso de popularidad</translation>
+    </message>
+    <message>
+        <source>Requires the version check. The popularity contest is based on the user agent.</source>
+        <translation type="unfinished">Requiere la comprobación de versión. El concurso de popularidad se basa en el user-agent.</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -708,14 +708,6 @@ L&apos;interfaccia non è attiva. Impossibile avviare il server.</translation>
         <translation>No, grazie</translation>
     </message>
     <message>
-        <source>Check for updates</source>
-        <translation>Controlla aggiornamenti</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Would you like to check for updates when %1 starts?&lt;/p&gt;&lt;p&gt;Checking for updates requires an Internet connection.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Vuoi controllare gli aggiornamenti all&apos;avvio di %1?&lt;/p&gt;&lt;p&gt;Il controllo degli aggiornamenti richiede una connessione Internet.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Background service offline</source>
         <translation>Servizio in background offline</translation>
     </message>
@@ -749,6 +741,34 @@ L&apos;interfaccia non è attiva. Impossibile avviare il server.</translation>
         <source>failed to read RSA key from certificate file: %1</source>
         <extracomment>%1 will be replaced by the certificate path</extracomment>
         <translation type="unfinished">impossibile leggere la chiave RSA dal file del certificato: %1</translation>
+    </message>
+    <message>
+        <source>Some optional %1 features require an Internet connection. Would you like to enable them?</source>
+        <translation type="unfinished">Alcune funzionalità opzionali di %1 richiedono una connessione Internet. Vuoi abilitarle?</translation>
+    </message>
+    <message>
+        <source>Choose which features to enable:</source>
+        <translation type="unfinished">Scegli quali funzionalità abilitare:</translation>
+    </message>
+    <message>
+        <source>Check for new versions when app starts</source>
+        <translation type="unfinished">Controlla la disponibilità di nuove versioni all’avvio dell’app</translation>
+    </message>
+    <message>
+        <source>Participate in popularity contest</source>
+        <translation type="unfinished">Partecipa al concorso di popolarità</translation>
+    </message>
+    <message>
+        <source>Requires the version check. The popularity contest is based on the user agent.</source>
+        <translation type="unfinished">Richiede il controllo della versione. Il concorso di popolarità si basa sullo user-agent.</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1311,6 +1311,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <source>Automatic</source>
         <translation type="unfinished">Automatica</translation>
     </message>
+    <message>
+        <source>Participate in popularity contest (send extra user-agent data)</source>
+        <translation type="unfinished">Partecipare al concorso di popolarità (inviare dati aggiuntivi dello user-agent)</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1312,6 +1312,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Automatic</source>
         <translation type="unfinished">自動</translation>
     </message>
+    <message>
+        <source>Participate in popularity contest (send extra user-agent data)</source>
+        <translation type="unfinished">人気投票に参加する（追加のユー-agent データを送信）</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -709,14 +709,6 @@ Interface is not active. Unable to start server.</source>
         <translation>不要です</translation>
     </message>
     <message>
-        <source>Check for updates</source>
-        <translation>更新を確認する</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Would you like to check for updates when %1 starts?&lt;/p&gt;&lt;p&gt;Checking for updates requires an Internet connection.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;%1 の起動時にソフトウェア更新を確認しますか？&lt;/p&gt;&lt;p&gt;更新の確認にはインターネット接続が必要です。&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Background service offline</source>
         <translation>バックグラウンドサービス停止中</translation>
     </message>
@@ -750,6 +742,34 @@ Interface is not active. Unable to start server.</source>
         <source>failed to read RSA key from certificate file: %1</source>
         <extracomment>%1 will be replaced by the certificate path</extracomment>
         <translation type="unfinished">証明書ファイルから RSA キーを読み取ることができませんでした: %1</translation>
+    </message>
+    <message>
+        <source>Some optional %1 features require an Internet connection. Would you like to enable them?</source>
+        <translation type="unfinished">いくつかの %1 のオプション機能はインターネット接続を必要とします。有効にしますか？</translation>
+    </message>
+    <message>
+        <source>Choose which features to enable:</source>
+        <translation type="unfinished">有効にする機能を選択:</translation>
+    </message>
+    <message>
+        <source>Check for new versions when app starts</source>
+        <translation type="unfinished">アプリ起動時に新しいバージョンを確認する</translation>
+    </message>
+    <message>
+        <source>Participate in popularity contest</source>
+        <translation type="unfinished">人気投票に参加する</translation>
+    </message>
+    <message>
+        <source>Requires the version check. The popularity contest is based on the user agent.</source>
+        <translation type="unfinished">バージョンチェックが必要です。人気投票はユーザーエージェントに基づきます。</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;ユーザーエージェント:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1316,6 +1316,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Automatic</source>
         <translation type="unfinished">Автоматический</translation>
     </message>
+    <message>
+        <source>Participate in popularity contest (send extra user-agent data)</source>
+        <translation type="unfinished">Участвовать в конкурсе популярности (отправлять дополнительные данные user-agent)</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -711,14 +711,6 @@ Interface is not active. Unable to start server.</source>
         <translation>Нет спасибо</translation>
     </message>
     <message>
-        <source>Check for updates</source>
-        <translation>Проверка обновлений</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Would you like to check for updates when %1 starts?&lt;/p&gt;&lt;p&gt;Checking for updates requires an Internet connection.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Хотите проверять наличие обновлений при запуске %1 ?&lt;/p&gt;&lt;p&gt;Проверка обновлений требует Интернет соединение.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Background service offline</source>
         <translation>Фоновый процесс не в сети</translation>
     </message>
@@ -752,6 +744,34 @@ Interface is not active. Unable to start server.</source>
         <source>failed to read RSA key from certificate file: %1</source>
         <extracomment>%1 will be replaced by the certificate path</extracomment>
         <translation type="unfinished">не удалось прочитать ключ RSA из файла сертификата: %1</translation>
+    </message>
+    <message>
+        <source>Some optional %1 features require an Internet connection. Would you like to enable them?</source>
+        <translation type="unfinished">Некоторые дополнительные функции %1 требуют подключения к Интернету. Включить их?</translation>
+    </message>
+    <message>
+        <source>Choose which features to enable:</source>
+        <translation type="unfinished">Выберите функции для включения:</translation>
+    </message>
+    <message>
+        <source>Check for new versions when app starts</source>
+        <translation type="unfinished">Проверять наличие новых версий при запуске приложения</translation>
+    </message>
+    <message>
+        <source>Participate in popularity contest</source>
+        <translation type="unfinished">Участвовать в конкурсе популярности</translation>
+    </message>
+    <message>
+        <source>Requires the version check. The popularity contest is based on the user agent.</source>
+        <translation type="unfinished">Требуется проверка версии. Конкурс популярности основан на user-agent.</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;User-agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -709,14 +709,6 @@ Interface is not active. Unable to start server.</source>
         <translation>不，谢谢</translation>
     </message>
     <message>
-        <source>Check for updates</source>
-        <translation>检查更新</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Would you like to check for updates when %1 starts?&lt;/p&gt;&lt;p&gt;Checking for updates requires an Internet connection.&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;您希望在 %1 启动时检查更新吗？&lt;/p&gt;&lt;p&gt;检查更新需要互联网连接。&lt;/p&gt;&lt;p&gt;URL: &lt;pre&gt;%2&lt;/pre&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Background service offline</source>
         <translation>后台服务离线</translation>
     </message>
@@ -750,6 +742,34 @@ Interface is not active. Unable to start server.</source>
         <source>failed to read RSA key from certificate file: %1</source>
         <extracomment>%1 will be replaced by the certificate path</extracomment>
         <translation type="unfinished">无法从证书文件中读取 RSA 密钥：%1</translation>
+    </message>
+    <message>
+        <source>Some optional %1 features require an Internet connection. Would you like to enable them?</source>
+        <translation type="unfinished">某些可选的 %1 功能需要互联网连接。&lt;br /&gt;是否启用它们？</translation>
+    </message>
+    <message>
+        <source>Choose which features to enable:</source>
+        <translation type="unfinished">选择要启用的功能：</translation>
+    </message>
+    <message>
+        <source>Check for new versions when app starts</source>
+        <translation type="unfinished">应用启动时检查新版本</translation>
+    </message>
+    <message>
+        <source>Participate in popularity contest</source>
+        <translation type="unfinished">参与人气竞赛</translation>
+    </message>
+    <message>
+        <source>Requires the version check. The popularity contest is based on the user agent.</source>
+        <translation type="unfinished">需要进行版本检查。人气竞赛基于 user-agent。</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;User agent:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;用户代理：&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;URL:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</source>
+        <translation type="unfinished">&lt;b&gt;URL：&lt;/b&gt;&amp;nbsp;&amp;nbsp;&lt;code&gt;%1&lt;/code&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1312,6 +1312,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Automatic</source>
         <translation type="unfinished">自动的</translation>
     </message>
+    <message>
+        <source>Participate in popularity contest (send extra user-agent data)</source>
+        <translation type="unfinished">参与人气竞赛（发送额外的 user-agent 数据）</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>


### PR DESCRIPTION
- Fixes user agent header not being RFC 9110 10.1.5
- Only send extra user agent data in popularity contest mode
- Fixes update check URL settings key (should be GUI, not Core)
- Remove custom tab stops from settings dialog and use default

New design for version/update check dialog:
<img width="414" height="334" alt="image" src="https://github.com/user-attachments/assets/d9c7ba7e-e08c-4914-bf5a-dded37b595b6" />
