### PR TITLE
ci: fix names of suse and  arch architecture postfix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -191,7 +191,7 @@ jobs:
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "opensuse-x86_84"
+          - name: "opensuse-x86_64"
             runs-on: ubuntu-latest
             container: opensuse/tumbleweed:latest
             like: "suse"
@@ -205,7 +205,7 @@ jobs:
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "archlinux-x86_84"
+          - name: "archlinux-x86_64"
             runs-on: ubuntu-latest
             container: archlinux:latest
             like: "arch"


### PR DESCRIPTION
rename `x86_84` =>  `x86_64` for suse / arch