### PR TITLE
feat: Remove unused OS based arguments

### DIFF
--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -153,11 +153,9 @@ constexpr static auto s_helpCommonArgs = //
 // system args (windows/unix)
 #if SYSAPI_UNIX
 
-// unix daemon mode args
-constexpr static auto s_helpSysArgs = " [--daemon|--no-daemon]";
-constexpr static auto s_helpSysInfo = //
-    "  -f, --no-daemon          run in the foreground.\n"
-    "*     --daemon             run as a daemon.\n";
+// unix has no system args
+constexpr static auto s_helpSysArgs = "";
+constexpr static auto s_helpSysInfo = "";
 
 #elif SYSAPI_WIN32
 

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -150,24 +150,6 @@ constexpr static auto s_helpCommonArgs = //
     " [--restart|--no-restart]"
     " [--debug <level>]";
 
-// system args (windows/unix)
-#if SYSAPI_UNIX
-
-// unix has no system args
-constexpr static auto s_helpSysArgs = "";
-constexpr static auto s_helpSysInfo = "";
-
-#elif SYSAPI_WIN32
-
-// windows args
-constexpr static auto s_helpSysArgs = " [--service <action>] [--relaunch]";
-constexpr static auto s_helpSysInfo = //
-    "      --service <action>   manage the windows service, valid options are:\n"
-    "                             install/uninstall/start/stop\n"
-    "      --relaunch           persistently relaunches process in current user \n"
-    "                             session (useful for vista and upward).\n";
-#endif
-
 #if !defined(WINAPI_LIBEI) && WINAPI_XWINDOWS
 constexpr static auto s_helpNoWayland = //
     "\nYour Linux distribution does not support Wayland EI (emulated input)\n"

--- a/src/lib/deskflow/ArgParser.cpp
+++ b/src/lib/deskflow/ArgParser.cpp
@@ -129,12 +129,6 @@ bool ArgParser::parseGenericArgs(int argc, const char *const *argv, int &i) cons
     argsBase().m_logFilter = argv[++i];
   } else if (isArg(i, argc, argv, "-l", "--log", 1)) {
     argsBase().m_logFile = argv[++i];
-  } else if (isArg(i, argc, argv, "-f", "--no-daemon")) {
-    // not a daemon
-    argsBase().m_daemon = false;
-  } else if (isArg(i, argc, argv, nullptr, "--daemon")) {
-    // daemonize
-    argsBase().m_daemon = true;
   } else if (isArg(i, argc, argv, "-n", "--name", 1)) {
     // save screen name
     argsBase().m_name = argv[++i];
@@ -339,19 +333,5 @@ void ArgParser::updateCommonArgs(const char *const *argv) const
 
 bool ArgParser::checkUnexpectedArgs() const
 {
-#if SYSAPI_WIN32
-  // suggest that user installs as a windows service. when launched as
-  // service, process should automatically detect that it should run in
-  // daemon mode.
-  if (argsBase().m_daemon) {
-    LOG(
-        (CLOG_ERR "the --daemon argument is not supported on windows. "
-                  "instead, install %s as a service (--service install)",
-         argsBase().m_pname)
-    );
-    return true;
-  }
-#endif
-
   return false;
 }

--- a/src/lib/deskflow/ArgsBase.h
+++ b/src/lib/deskflow/ArgsBase.h
@@ -32,9 +32,6 @@ public:
   /// @brief Stores what type of object this is
   ClassType m_classType = ClassType::Base;
 
-  /// @brief Should run as a daemon
-  bool m_daemon = true;
-
   /// @brief Should the app restart automatically
   bool m_restartable = true;
 

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -109,7 +109,7 @@ void ClientApp::help()
 #ifdef WINAPI_XWINDOWS
        << " [--display <display>]"
 #endif
-       << s_helpSysArgs << s_helpCommonArgs << " <server-address>"
+       << s_helpCommonArgs << " <server-address>"
        << "\n\n"
        << "Connect to a " << kAppName << " mouse/keyboard sharing server.\n"
        << "\n"
@@ -314,14 +314,6 @@ void ClientApp::closeClient(Client *client)
   delete client;
 }
 
-int ClientApp::foregroundStartup(int argc, char **argv)
-{
-  initApp(argc, argv);
-
-  // never daemonize
-  return mainLoop();
-}
-
 bool ClientApp::startClient()
 {
   double retryTime;
@@ -413,13 +405,7 @@ static int daemonMainLoopStatic(int argc, const char **argv)
 int ClientApp::standardStartup(int argc, char **argv)
 {
   initApp(argc, argv);
-
-  // daemonize if requested
-  if (args().m_daemon) {
-    return ARCH->daemonize(daemonName(), &daemonMainLoopStatic);
-  } else {
-    return mainLoop();
-  }
+  return mainLoop();
 }
 
 int ClientApp::runInner(int argc, char **argv, StartupFunc startup)

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -114,7 +114,7 @@ void ClientApp::help()
        << "Connect to a " << kAppName << " mouse/keyboard sharing server.\n"
        << "\n"
        << "  -a, --address <address>  local network interface address.\n"
-       << s_helpGeneralArgs << s_helpSysInfo << "      --yscroll <delta>    defines the vertical scrolling delta,\n"
+       << s_helpGeneralArgs << "      --yscroll <delta>    defines the vertical scrolling delta,\n"
        << "                             which is 120 by default.\n"
        << "      --sync-language      enable language synchronization.\n"
        << "      --invert-scroll      invert scroll direction on this\n"

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -402,7 +402,7 @@ static int daemonMainLoopStatic(int argc, const char **argv)
   return ClientApp::instance().daemonMainLoop(argc, argv);
 }
 
-int ClientApp::standardStartup(int argc, char **argv)
+int ClientApp::start(int argc, char **argv)
 {
   initApp(argc, argv);
   return mainLoop();

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -43,7 +43,6 @@ public:
   {
     return false;
   }
-  int foregroundStartup(int argc, char **argv) override;
   int standardStartup(int argc, char **argv) override;
   int runInner(int argc, char **argv, StartupFunc startup) override;
   deskflow::Screen *createScreen() override;

--- a/src/lib/deskflow/ClientApp.h
+++ b/src/lib/deskflow/ClientApp.h
@@ -43,7 +43,7 @@ public:
   {
     return false;
   }
-  int standardStartup(int argc, char **argv) override;
+  int start(int argc, char **argv) override;
   int runInner(int argc, char **argv, StartupFunc startup) override;
   deskflow::Screen *createScreen() override;
   int mainLoop() override;

--- a/src/lib/deskflow/IApp.h
+++ b/src/lib/deskflow/IApp.h
@@ -30,7 +30,6 @@ public:
   virtual int mainLoop() = 0;
   virtual void initApp(int argc, const char **argv) = 0;
   virtual const char *daemonName() const = 0;
-  virtual int foregroundStartup(int argc, char **argv) = 0;
   virtual deskflow::Screen *createScreen() = 0;
   virtual IEventQueue *getEvents() const = 0;
 };

--- a/src/lib/deskflow/IApp.h
+++ b/src/lib/deskflow/IApp.h
@@ -23,7 +23,7 @@ public:
   virtual ~IApp() = default;
   virtual void setByeFunc(void (*bye)(int)) = 0;
   virtual deskflow::ArgsBase &argsBase() const = 0;
-  virtual int standardStartup(int argc, char **argv) = 0;
+  virtual int start(int argc, char **argv) = 0;
   virtual int runInner(int argc, char **argv, StartupFunc startup) = 0;
   virtual void startNode() = 0;
   virtual void bye(int error) = 0;

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -678,20 +678,6 @@ int daemonMainLoopStatic(int argc, const char **argv)
 int ServerApp::standardStartup(int argc, char **argv)
 {
   initApp(argc, argv);
-
-  // daemonize if requested
-  if (args().m_daemon) {
-    return ARCH->daemonize(daemonName(), daemonMainLoopStatic);
-  } else {
-    return mainLoop();
-  }
-}
-
-int ServerApp::foregroundStartup(int argc, char **argv)
-{
-  initApp(argc, argv);
-
-  // never daemonize
   return mainLoop();
 }
 

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -675,7 +675,7 @@ int daemonMainLoopStatic(int argc, const char **argv)
   return ServerApp::instance().daemonMainLoop(argc, argv);
 }
 
-int ServerApp::standardStartup(int argc, char **argv)
+int ServerApp::start(int argc, char **argv)
 {
   initApp(argc, argv);
   return mainLoop();

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -110,13 +110,13 @@ void ServerApp::help()
        << " [--display <display>]"
 #endif
 
-       << s_helpSysArgs << s_helpCommonArgs << "\n"
+       << s_helpCommonArgs << "\n"
        << "  -a, --address <address>  listen for clients on the given address.\n"
        << "  -c, --config <pathname>  path of the configuration file\n"
        << s_helpGeneralArgs
        << "      --disable-client-cert-check disable client SSL certificate \n"
           "                                     checking (deprecated)\n"
-       << s_helpSysInfo << s_helpVersionArgs << "\n"
+       << s_helpVersionArgs << "\n"
 
 #if WINAPI_XWINDOWS
        << "      --display <display>  when in X mode, connect to the X server\n"

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -65,7 +65,6 @@ public:
   int mainLoop() override;
   int runInner(int argc, char **argv, StartupFunc startup) override;
   int standardStartup(int argc, char **argv) override;
-  int foregroundStartup(int argc, char **argv) override;
   void startNode() override;
 
   //

--- a/src/lib/deskflow/ServerApp.h
+++ b/src/lib/deskflow/ServerApp.h
@@ -64,7 +64,7 @@ public:
   deskflow::Screen *createScreen() override;
   int mainLoop() override;
   int runInner(int argc, char **argv, StartupFunc startup) override;
-  int standardStartup(int argc, char **argv) override;
+  int start(int argc, char **argv) override;
   void startNode() override;
 
   //

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -26,14 +26,14 @@ AppUtilUnix::AppUtilUnix(const IEventQueue *)
   // do nothing
 }
 
-int standardStartupStatic(int argc, char **argv)
+int startStatic(int argc, char **argv)
 {
-  return AppUtil::instance().app().standardStartup(argc, argv);
+  return AppUtil::instance().app().start(argc, argv);
 }
 
 int AppUtilUnix::run(int argc, char **argv)
 {
-  return app().runInner(argc, argv, &standardStartupStatic);
+  return app().runInner(argc, argv, &startStatic);
 }
 
 void AppUtilUnix::startNode()

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -100,7 +100,7 @@ static int daemonNTStartupStatic(int argc, char **argv)
 
 static int foregroundStartupStatic(int argc, char **argv)
 {
-  return AppUtil::instance().app().foregroundStartup(argc, argv);
+  return AppUtil::instance().app().standardStartup(argc, argv);
 }
 
 int AppUtilWindows::run(int argc, char **argv)
@@ -120,7 +120,6 @@ int AppUtilWindows::run(int argc, char **argv)
     startup = &daemonNTStartupStatic;
   } else {
     startup = &foregroundStartupStatic;
-    app().argsBase().m_daemon = false;
   }
 
   return app().runInner(argc, argv, startup);

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -100,7 +100,7 @@ static int daemonNTStartupStatic(int argc, char **argv)
 
 static int foregroundStartupStatic(int argc, char **argv)
 {
-  return AppUtil::instance().app().standardStartup(argc, argv);
+  return AppUtil::instance().app().start(argc, argv);
 }
 
 int AppUtilWindows::run(int argc, char **argv)

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -461,8 +461,7 @@ void CoreProcess::cleanup()
 
 bool CoreProcess::addGenericArgs(QStringList &args) const
 {
-  args << "-f"
-       << "--debug" << Settings::logLevelText();
+  args << "--debug" << Settings::logLevelText();
 
   args << "--name" << Settings::value(Settings::Core::ScreenName).toString();
 

--- a/src/unittests/deskflow/ArgParserTests.cpp
+++ b/src/unittests/deskflow/ArgParserTests.cpp
@@ -196,7 +196,6 @@ void ArgParserTests::server_unexpectedParam()
 void ArgParserTests::serverArgs()
 {
   deskflow::ServerArgs args;
-  args.m_daemon = false;
   char const *argv[] = {"deskflow", "--help", "--res-w", "888"};
 
   QVERIFY(m_parser.parseServerArgs(args, sizeof(argv) / sizeof(argv[0]), argv));
@@ -206,7 +205,6 @@ void ArgParserTests::serverArgs()
 void ArgParserTests::clientArgs()
 {
   deskflow::ClientArgs args;
-  args.m_daemon = false;
   char const *argv[] = {kAppId, "--help", "--res-w", "888", "127.0.0.1"};
 
   QVERIFY(m_parser.parseClientArgs(args, sizeof(argv) / sizeof(argv[0]), argv));
@@ -337,30 +335,6 @@ void ArgParserTests::generic_logFileWithSpace()
 
   QCOMPARE(m_parser.argsBase().m_logFile, "mo ck_filename");
   QCOMPARE(i, 2);
-}
-
-void ArgParserTests::generic_foreground()
-{
-  int i = 1;
-  const int argc = 2;
-  const char *kNoDeamonCmd[argc] = {"stub", "-f"};
-
-  m_parser.parseGenericArgs(argc, kNoDeamonCmd, i);
-
-  QVERIFY(!m_parser.argsBase().m_daemon);
-  QCOMPARE(i, 1);
-}
-
-void ArgParserTests::generic_daemon()
-{
-  int i = 1;
-  const int argc = 2;
-  const char *kDeamonCmd[argc] = {"stub", "--daemon"};
-
-  m_parser.parseGenericArgs(argc, kDeamonCmd, i);
-
-  QVERIFY(m_parser.argsBase().m_daemon);
-  QCOMPARE(i, 1);
 }
 
 void ArgParserTests::generic_name()

--- a/src/unittests/deskflow/ArgParserTests.cpp
+++ b/src/unittests/deskflow/ArgParserTests.cpp
@@ -344,7 +344,7 @@ void ArgParserTests::generic_name()
   const char *kNameCmd[argc] = {"stub", "--name", "mock"};
   // Somehow cause a dump if not made here.
   ArgParser parser(nullptr);
-  deskflow::ArgsBase base;
+  static deskflow::ArgsBase base;
 
   parser.setArgsBase(base);
   parser.parseGenericArgs(argc, kNameCmd, i);

--- a/src/unittests/deskflow/ArgParserTests.h
+++ b/src/unittests/deskflow/ArgParserTests.h
@@ -37,8 +37,6 @@ private Q_SLOTS:
   void generic_logLevel();
   void generic_logFile();
   void generic_logFileWithSpace();
-  void generic_foreground();
-  void generic_daemon();
   void generic_name();
   void generic_noRestart();
   void generic_restart();


### PR DESCRIPTION
 - Removes the `--daemon` and `--no-daemon / -f `  option. Deskflow will now by default start in foreground like all other unix apps. 
 - Remove unused `--service` and `--relaunch` options for windows. 
 - Removes `IApp::foregroundStartup`  (as its now unused)
 - Rename  `IApp::standardStartup` => `IApp::start`
 - Fix Broken Arg Test on arm64 fedora (args must be static removing soon so not too worried) 

Does not remove `Arch->daemonize` this should be looked at to see if we need this in Arch since its  only used on windows with the daemon process now. We should also look to redo  IApp::runInner to not require the startupMethod (both of these are tangled into the daemon on windows)
