### PR TITLE
Sonar cleanup 18

### DIFF
--- a/src/lib/base/LogOutputters.cpp
+++ b/src/lib/base/LogOutputters.cpp
@@ -153,7 +153,7 @@ bool FileLogOutputter::write(LogLevel level, const QString &message)
   if (file.size() > s_logFileSizeLimit) {
     const auto oldFile = QStringLiteral("%1.1").arg(m_fileName);
     QFile::remove(m_fileName);
-    file.rename(m_fileName, oldFile);
+    QFile::rename(m_fileName, oldFile);
   }
 
   return true;

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -126,5 +126,5 @@ public:
 
 private:
   Container c;
-  Compare comp;
+  [[no_unique_address]] Compare comp;
 };

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -664,7 +664,7 @@ bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
   return true;
 }
 
-ISocketMultiplexerJob *SecureSocket::serviceConnect(ISocketMultiplexerJob *, bool, bool, bool)
+ISocketMultiplexerJob *SecureSocket::serviceConnect(ISocketMultiplexerJob *const, bool, bool, bool)
 {
   Lock lock(&getMutex());
 
@@ -692,7 +692,7 @@ ISocketMultiplexerJob *SecureSocket::serviceConnect(ISocketMultiplexerJob *, boo
   );
 }
 
-ISocketMultiplexerJob *SecureSocket::serviceAccept(ISocketMultiplexerJob *, bool, bool, bool)
+ISocketMultiplexerJob *SecureSocket::serviceAccept(ISocketMultiplexerJob *const, bool, bool, bool)
 {
   Lock lock(&getMutex());
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -80,9 +80,9 @@ private:
   void disconnect();
   bool verifyCertFingerprint(const QString &FingerprintDatabasePath) const;
 
-  ISocketMultiplexerJob *serviceConnect(ISocketMultiplexerJob *, bool, bool, bool);
+  ISocketMultiplexerJob *serviceConnect(ISocketMultiplexerJob *const socket, bool, bool, bool);
 
-  ISocketMultiplexerJob *serviceAccept(ISocketMultiplexerJob *, bool, bool, bool);
+  ISocketMultiplexerJob *serviceAccept(ISocketMultiplexerJob *const socket, bool, bool, bool);
 
   void handleTCPConnected(const Event &event);
 

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -189,7 +189,7 @@ private:
   using HotKeyMap = std::map<KeyID, HotKeySet>;
 
   HotKeyMap m_hotkeys;
-  XDGPowerManager m_powerManager;
+  [[no_unique_address]] XDGPowerManager m_powerManager;
 };
 
 } // namespace deskflow

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -19,8 +19,7 @@
 //
 
 ClientProxy1_5::ClientProxy1_5(const std::string &name, deskflow::IStream *stream, Server *server, IEventQueue *events)
-    : ClientProxy1_4(name, stream, server, events),
-      m_events(events)
+    : ClientProxy1_4(name, stream, server, events)
 {
   // do nothing
 }

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -30,7 +30,4 @@ public:
   bool parseMessage(const uint8_t *code) override;
   void fileChunkReceived() const;
   void dragInfoReceived() const;
-
-private:
-  IEventQueue *m_events;
 };

--- a/src/lib/server/ClientProxy1_7.cpp
+++ b/src/lib/server/ClientProxy1_7.cpp
@@ -15,8 +15,7 @@
 //
 
 ClientProxy1_7::ClientProxy1_7(const std::string &name, deskflow::IStream *stream, Server *server, IEventQueue *events)
-    : ClientProxy1_6(name, stream, server, events),
-      m_events(events)
+    : ClientProxy1_6(name, stream, server, events)
 {
   // do nothing
 }

--- a/src/lib/server/ClientProxy1_7.h
+++ b/src/lib/server/ClientProxy1_7.h
@@ -16,7 +16,4 @@ public:
   ~ClientProxy1_7() override = default;
 
   void secureInputNotification(const std::string &app) const override;
-
-private:
-  IEventQueue *m_events;
 };

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1110,7 +1110,7 @@ void Config::parseAction(
       }
     }
 
-    action = new InputFilter::RestartServer(m_events, mode);
+    action = new InputFilter::RestartServer(mode);
   }
 
   else if (name == "keyboardBroadcast") {

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -237,7 +237,7 @@ void InputFilter::LockCursorToScreenAction::perform(const Event &event)
   );
 }
 
-InputFilter::RestartServer::RestartServer(IEventQueue *events, Mode mode) : m_mode(mode), m_events(events)
+InputFilter::RestartServer::RestartServer(Mode mode) : m_mode(mode)
 {
   // do nothing
 }

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -161,7 +161,7 @@ public:
       restart
     };
 
-    explicit RestartServer(IEventQueue *events, Mode = restart);
+    explicit RestartServer(Mode = restart);
 
     Mode getMode() const;
 
@@ -172,7 +172,6 @@ public:
 
   private:
     Mode m_mode;
-    IEventQueue *m_events;
   };
 
   // SwitchToScreenAction


### PR DESCRIPTION
 Various Sonar cleanup  

 - remove unused InputFilter::RestartServer::m_events
 - remove unused ClientProxy1_7::m_events
 - remove unused ClientProxy1_5::m_events
 - EiScreen::m_powerManager add no_unique_address
 - SecureSocket serviceConnect / serviceAccept make anonymous ISocketMultiplexer *const 
 - FileLogOutputter::write use static `QFile::rename`
 - PriorityQueue:comp add no_unique_address