### PR TITLE
Cleanup the CoreProcess

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -103,12 +103,6 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Log::Level)
     return 4; // INFO
 
-  if (key == Client::Binary)
-    return kCoreBinName;
-
-  if (key == Server::Binary)
-    return kCoreBinName;
-
   if (key == Daemon::Elevate)
     return Settings::isNativeMode();
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -33,7 +33,6 @@ public:
 
   struct Client
   {
-    inline static const auto Binary = QStringLiteral("client/binary");
     inline static const auto InvertScrollDirection = QStringLiteral("client/invertScrollDirection");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
@@ -84,7 +83,6 @@ public:
   };
   struct Server
   {
-    inline static const auto Binary = QStringLiteral("server/binary");
     inline static const auto ConfigVisible = QStringLiteral("server/configVisible");
     inline static const auto ExternalConfig = QStringLiteral("server/externalConfig");
     inline static const auto ExternalConfigFile = QStringLiteral("server/externalConfigFile");
@@ -159,8 +157,7 @@ private:
   };
 
   inline static const QStringList m_validKeys = {
-      Settings::Client::Binary
-    , Settings::Client::InvertScrollDirection
+      Settings::Client::InvertScrollDirection
     , Settings::Client::LanguageSync
     , Settings::Client::RemoteHost
     , Settings::Client::XdpRestoreToken
@@ -191,7 +188,6 @@ private:
     , Settings::Security::CheckPeers
     , Settings::Security::KeySize
     , Settings::Security::TlsEnabled
-    , Settings::Server::Binary
     , Settings::Server::ConfigVisible
     , Settings::Server::ExternalConfig
     , Settings::Server::ExternalConfigFile

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -116,8 +116,8 @@ private:
   void stopForegroundProcess() const;
   void stopProcessFromDaemon();
   bool addGenericArgs(QStringList &args) const;
-  bool addServerArgs(QStringList &args, QString &app);
-  bool addClientArgs(QStringList &args, QString &app);
+  bool addServerArgs(QStringList &args);
+  bool addClientArgs(QStringList &args);
   QString persistServerConfig() const;
   QString modeString() const;
   QString processModeString() const;

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -55,7 +55,6 @@ public:
 
   explicit CoreProcess(const IServerConfig &serverConfig);
 
-  void extracted(QString &app, QStringList &args);
   void start(std::optional<ProcessMode> processMode = std::nullopt);
   void stop(std::optional<ProcessMode> processMode = std::nullopt);
   void restart();

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -111,8 +111,8 @@ private Q_SLOTS:
   void daemonIpcClientConnected();
 
 private:
-  void startForegroundProcess(const QString &app, const QStringList &args);
-  void startProcessFromDaemon(const QString &app, const QStringList &args);
+  void startForegroundProcess(const QStringList &args);
+  void startProcessFromDaemon(const QStringList &args);
   void stopForegroundProcess() const;
   void stopProcessFromDaemon();
   bool addGenericArgs(QStringList &args) const;


### PR DESCRIPTION
Clean up items not needed after merging deskflow-client and deskflow-server into deskflow-core 

 - Remove `Settings::Client::Binary` and `Settings::Server::Binary`, use kCoreBinName in its place
 - Clean up `CoreProcess` so it sets m_appPath and uses it in place of local app it passes around between methods
 - Remove unused `CoreProcess::extract`
