### PR TITLE
Set Filter log with QString

### DIFF
--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -264,18 +264,19 @@ void Log::pop_front(bool alwaysAtHead)
   }
 }
 
-bool Log::setFilter(const char *maxPriority)
+bool Log::setFilter(const QString &maxPriority)
 {
-  if (maxPriority != nullptr) {
-    for (int i = 0; i < g_numPriority; ++i) {
-      if (strcmp(maxPriority, g_priority[i]) == 0) {
-        setFilter(static_cast<LogLevel>(i));
-        return true;
-      }
-    }
+  if (maxPriority.isEmpty()) {
     return false;
   }
-  return true;
+
+  for (int i = 0; i < g_numPriority; ++i) {
+    if (maxPriority == QString(g_priority[i])) {
+      setFilter(static_cast<LogLevel>(i));
+      return true;
+    }
+  }
+  return false;
 }
 
 void Log::setFilter(LogLevel maxPriority)

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <QString>
+
 #include "arch/Arch.h"
 #include "arch/IArchMultithread.h"
 
@@ -83,7 +85,7 @@ public:
   true if the priority \c name was recognized;  if \c name is nullptr
   then it simply returns true.
   */
-  bool setFilter(const char *name);
+  bool setFilter(const QString &name);
 
   //! Set the minimum priority filter (by ordinal).
   void setFilter(LogLevel);

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -143,8 +143,11 @@ void App::initApp(int argc, const char **argv)
   parseArgs();
 
   // set log filter
-  if (const auto logLevel = qPrintable(Settings::logLevelText()); !CLOG->setFilter(logLevel)) {
-    LOG_CRIT("%s: unrecognized log level `%s'" BYE, qPrintable(processName()), logLevel, qPrintable(processName()));
+  if (const auto logLevel = Settings::logLevelText(); !CLOG->setFilter(logLevel)) {
+    LOG_CRIT(
+        "%s: unrecognized log level `%s'" BYE, qPrintable(processName()), qPrintable(logLevel),
+        qPrintable(processName())
+    );
     m_bye(s_exitArgs);
   }
   loggingFilterWarning();


### PR DESCRIPTION
Fixes: #8999
 -  mac os does not like the char pointer for `CLOG->setFilter` change it to take a QString instead
