### PR TITLE
Adjust OS X MouseMove handling to use live cursor position.

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -111,7 +111,7 @@ private:
   void sendClipboardEvent(EventTypes type, ClipboardID id) const;
 
   // message handlers
-  bool onMouseMove(CGFloat mx, CGFloat my);
+  bool onMouseMove();
   // mouse button handler.  pressed is true if this is a mousedown
   // event, false if it is a mouseup event.  macButton is the index
   // of the button pressed using the mac button mapping.


### PR DESCRIPTION
I wrote this patch many years ago so the comments / PR title are based on my recollection of why this is necessary.  The demonstration of the original issue consisted of an OS X Server connected to a Windows 11 Client, you could then center your cursor on the remote system (Windows) and start performing perfect(ish) circles physically with the mouse.  What you would observe is that on the remote system, while the circles would be circular-ish, your cursor would slowly drift away towards one side of the screen, demonstrating that the mouse position information was not being collected accurately.