### PR TITLE
fix: translate MainWindow::coreProcessError warning

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -407,9 +407,9 @@ void MainWindow::coreProcessError(CoreProcess::Error error)
     show();
     QMessageBox::warning(
         this, tr("Core cannot be started"),
-        "The Core executable could not be successfully started, "
-        "although it does exist. "
-        "Please check if you have sufficient permissions to run this program."
+        tr("The Core executable could not be successfully started, "
+           "although it does exist. "
+           "Please check if you have sufficient permissions to run this program.")
     );
   }
 }

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -528,6 +528,10 @@ Nombres válidos:
         <source>This computer&apos;s name:</source>
         <translation type="unfinished">Nombre de esta computadora:</translation>
     </message>
+    <message>
+        <source>The Core executable could not be successfully started, although it does exist. Please check if you have sufficient permissions to run this program.</source>
+        <translation type="unfinished">No se pudo iniciar el archivo ejecutable principal, aunque existe. Compruebe si tiene permisos suficientes para ejecutar este programa.</translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -528,6 +528,10 @@ Nomi validi:
         <translation>Usa mouse e tastiera di un altro computer
 (imposta questo computer come client)</translation>
     </message>
+    <message>
+        <source>The Core executable could not be successfully started, although it does exist. Please check if you have sufficient permissions to run this program.</source>
+        <translation type="unfinished">Non è stato possibile avviare correttamente l&apos;eseguibile Core, sebbene esista. Verifica di disporre delle autorizzazioni necessarie per eseguire questo programma.</translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -321,7 +321,7 @@ Do you want to connect to the server?
     </message>
     <message>
         <source>Core cannot be started</source>
-        <translation>Coreが起動できません</translation>
+        <translation>コアが起動できません</translation>
     </message>
     <message>
         <source>Save server configuration as...</source>
@@ -526,6 +526,10 @@ Valid names:
  %1</source>
         <translation>クライアント:
  %1</translation>
+    </message>
+    <message>
+        <source>The Core executable could not be successfully started, although it does exist. Please check if you have sufficient permissions to run this program.</source>
+        <translation>コア実行ファイルは存在していますが、起動できませんでした。このプログラムを実行するのに十分な権限があることを確認してください。</translation>
     </message>
 </context>
 <context>
@@ -911,7 +915,7 @@ Valid names:
     </message>
     <message>
         <source>&amp;Dead corners (for this computer)</source>
-        <translation>無効領域(&amp;D) (このコンピュータ)</translation>
+        <translation>無効領域(&amp;D) (このコンピューター)</translation>
     </message>
     <message>
         <source>&amp;Bottom-left</source>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -531,6 +531,10 @@ Valid names:
         <translation>Клиент:
  %1</translation>
     </message>
+    <message>
+        <source>The Core executable could not be successfully started, although it does exist. Please check if you have sufficient permissions to run this program.</source>
+        <translation type="unfinished">Не удалось запустить исполняемый файл Core, хотя он существует. Проверьте, есть ли у вас достаточные права для запуска этой программы.</translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -527,6 +527,10 @@ Valid names:
         <translation>客户端：
  %1</translation>
     </message>
+    <message>
+        <source>The Core executable could not be successfully started, although it does exist. Please check if you have sufficient permissions to run this program.</source>
+        <translation type="unfinished">Core 可执行文件虽然存在，但无法成功启动。请检查您是否拥有运行此程序的足够权限。</translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>


### PR DESCRIPTION
The warning was not enclosed by tr(...).
I added Japanese translation, but other languages are not translated yet.
While I'm here, I also fixed some Japanese translations.
