### PR TITLE
fix(macos): prevent automatic termination during memory pressure

### DIFF
--- a/src/apps/res/deskflow.plist.in
+++ b/src/apps/res/deskflow.plist.in
@@ -31,7 +31,9 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>@BUNDLE_COPYRIGHT@</string>
 
-	<!-- Don't Allow Os to kill for memory -->
+	<!-- Prevent macOS from terminating during memory pressure -->
+	<key>NSSupportsAutomaticTermination</key>
+	<false/>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
 

--- a/src/apps/res/deskflow.plist.in
+++ b/src/apps/res/deskflow.plist.in
@@ -30,6 +30,8 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>@BUNDLE_COPYRIGHT@</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 
 	<!-- Prevent macOS from terminating during memory pressure -->
 	<key>NSSupportsAutomaticTermination</key>


### PR DESCRIPTION
Disable macOS Automatic Termination to prevent the server/client from being killed during memory pressure events. Adds NSSupportsAutomaticTermination to Info.plist and programmatically disables termination in the Cocoa app.

Fixes #7329

🤖 Generated with [Claude Code](https://claude.com/claude-code) (But _not_ AI Trash)


Edit: (sithlord48) 
 - Updated to remove code. We only need plist or code change  
 - Added a commit to put deskflow in the "Utilities" category 