### PR TITLE
Feat: Implement Toggle Screen Action (#9135)

### DIFF
--- a/src/lib/gui/Action.cpp
+++ b/src/lib/gui/Action.cpp
@@ -38,6 +38,21 @@ QString Action::text() const
     text.append(m_commandTemplate.arg(commandArgs));
   } break;
 
+  case Type::toggleScreen: {
+    QString commandArgs;
+    const QStringList &screens = typeScreenNames();
+    if (haveScreens() && !screens.isEmpty()) {
+      for (int i = 0; i < screens.size(); i++) {
+        commandArgs.append(screens[i]);
+        if (i != screens.size() - 1)
+          commandArgs.append(QStringLiteral(","));
+      }
+    } else {
+      commandArgs.append(QStringLiteral(",*"));
+    }
+    text.append(m_commandTemplate.arg(commandArgs));
+  } break;
+
   case Type::switchToScreen:
     text.append(m_commandTemplate.arg(m_switchScreenName));
     break;

--- a/src/lib/gui/Action.h
+++ b/src/lib/gui/Action.h
@@ -46,9 +46,10 @@ public:
     switchToNextScreen,
     lockCursorToScreen,
     restartAllConnections,
+    toggleScreen,
     mouseDown,
     mouseUp,
-    mousebutton,
+    mousebutton
   };
   enum class SwitchDirection
   {
@@ -172,6 +173,7 @@ private:
       QStringLiteral("switchToNextScreen"),
       QStringLiteral("lockCursorToScreen"),
       QStringLiteral("restartServer"),
+      QStringLiteral("toggleScreen"),
       QStringLiteral("mouseDown"),
       QStringLiteral("mouseUp"),
       QStringLiteral("mousebutton")

--- a/src/lib/gui/dialogs/ActionDialog.h
+++ b/src/lib/gui/dialogs/ActionDialog.h
@@ -35,12 +35,13 @@ public:
     inline static const auto SwitchToNextScreen = 5;
     inline static const auto ModifyCursorLock = 6;
     inline static const auto RestartServer = 7;
+    inline static const auto ToggleScreen = 8;
   };
 
   ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &hotkey, Action &action);
   ~ActionDialog() override;
 
-protected Q_SLOTS:
+protected:
   void accept() override;
 
 private:
@@ -49,6 +50,7 @@ private:
   void itemToggled() const;
   void actionTypeChanged(int index);
   bool isKeyAction(int index) const;
+  bool isToggleScreenAction(int index) const;
   bool canSave() const;
 
   std::unique_ptr<Ui::ActionDialog> ui;

--- a/src/lib/gui/dialogs/ActionDialog.ui
+++ b/src/lib/gui/dialogs/ActionDialog.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ActionDialog</class>
  <widget class="QDialog" name="ActionDialog">
@@ -78,6 +78,11 @@
          <string>Restart the server</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>Toggle screen</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>
@@ -151,7 +156,7 @@
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
-      </sizepolicy>
+       </sizepolicy>
      </property>
      <property name="title">
       <string>Computers to receive this event</string>
@@ -167,6 +172,34 @@
      </layout>
     </widget>
    </item>
+    <item>
+     <widget class="QGroupBox" name="groupToggleScreenOrder">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Screen toggle order, drag to reorder</string>
+      </property>
+      <layout class="QHBoxLayout" name="_4">
+       <item>
+        <widget class="QListWidget" name="listToggleScreenOrder">
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
+         </property>
+         <property name="defaultDropAction">
+          <enum>Qt::DropAction::MoveAction</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContentsOnFirstShow</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1072,6 +1072,20 @@ void Config::parseAction(
     action = new InputFilter::SwitchToNextScreenAction(m_events);
   }
 
+  else if (name == "toggleScreen") {
+    std::vector<std::string> screens;
+    for (const auto &arg : args) {
+      std::string screen = arg;
+      if (isScreen(screen)) {
+        screen = getCanonicalName(screen);
+      } else {
+        throw ServerConfigReadException(s, "unknown screen name \"%{1}\" in toggleScreen", arg);
+      }
+      screens.push_back(screen);
+    }
+    action = new InputFilter::ToggleScreenAction(m_events, screens);
+  }
+
   else if (name == "lockCursorToScreen") {
     if (args.size() > 1) {
       throw ServerConfigReadException(s, "syntax for action: lockCursorToScreen([{off|on|toggle}])");

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -358,6 +358,47 @@ void InputFilter::SwitchToNextScreenAction::perform(const Event &event)
   );
 }
 
+InputFilter::ToggleScreenAction::ToggleScreenAction(IEventQueue *events, const std::vector<std::string> &screens)
+    : m_screens(screens),
+      m_events(events)
+{
+  // do nothing
+}
+
+const std::vector<std::string> &InputFilter::ToggleScreenAction::getScreens() const
+{
+  return m_screens;
+}
+
+InputFilter::Action *InputFilter::ToggleScreenAction::clone() const
+{
+  return new ToggleScreenAction(*this);
+}
+
+std::string InputFilter::ToggleScreenAction::format() const
+{
+  if (m_screens.empty()) {
+    return "toggleScreen()";
+  }
+  std::string s = "toggleScreen(";
+  for (size_t i = 0; i < m_screens.size(); ++i) {
+    if (i > 0) {
+      s += ",";
+    }
+    s += m_screens[i];
+  }
+  s += ")";
+  return s;
+}
+
+void InputFilter::ToggleScreenAction::perform(const Event &event)
+{
+  auto *info = new Server::ToggleScreenInfo(m_screens);
+  m_events->addEvent(
+      Event(EventTypes::ServerToggleScreen, event.getTarget(), info, Event::EventFlags::DeliverImmediately)
+  );
+}
+
 InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(IEventQueue *events, Mode mode)
     : m_mode(mode),
       m_events(events)

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -224,6 +224,24 @@ public:
     IEventQueue *m_events;
   };
 
+  // ToggleScreenAction
+  class ToggleScreenAction : public Action
+  {
+  public:
+    explicit ToggleScreenAction(IEventQueue *events, const std::vector<std::string> &screens);
+
+    const std::vector<std::string> &getScreens() const;
+
+    // Action overrides
+    Action *clone() const override;
+    std::string format() const override;
+    void perform(const Event &) override;
+
+  private:
+    std::vector<std::string> m_screens;
+    IEventQueue *m_events;
+  };
+
   // KeyboardBroadcastAction
   class KeyboardBroadcastAction : public Action
   {

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1333,35 +1333,46 @@ void Server::handleSwitchInDirectionEvent(const Event &event)
   }
 }
 
-void Server::handleToggleScreenEvent(const Event &)
+void Server::handleToggleScreenEvent(const Event &event)
 {
-  // Get the list of connected screens in config order
   std::vector<std::string> screens;
-  getClients(screens);
+  const auto *info = static_cast<const ToggleScreenInfo *>(event.getData());
 
-  if (screens.size() < 2) {
+  if (info) {
+    screens = info->m_screens;
+  } else {
+    getClients(screens);
+  }
+
+  if (screens.size() == 1) {
+    std::string target = screens[0];
+    ClientList::const_iterator clientIt = m_clients.find(target);
+    if (clientIt != m_clients.end()) {
+      jumpToScreen(clientIt->second);
+    }
+    return;
+  } else if (screens.size() == 0) {
     LOG_ERR("not enough screens to toggle");
     return;
   }
 
-  // Find the current active screen
   std::string currentScreen = getName(m_active);
   auto it = std::ranges::find(screens, currentScreen);
+
+  std::string nextScreenName;
   if (it == screens.end()) {
-    LOG_ERR("current screen not found in list");
-    return;
+    nextScreenName = screens[0];
+  } else {
+    auto nextIt = it + 1;
+    if (nextIt == screens.end()) {
+      nextIt = screens.begin();
+    }
+    nextScreenName = *nextIt;
   }
 
-  // Find the next screen
-  auto nextIt = it + 1;
-  if (nextIt == screens.end()) {
-    nextIt = screens.begin();
-  }
-
-  // Find the client for the next screen
-  ClientList::const_iterator clientIt = m_clients.find(*nextIt);
+  ClientList::const_iterator clientIt = m_clients.find(nextScreenName);
   if (clientIt == m_clients.end()) {
-    LOG_ERR("next screen not active");
+    LOG_ERR("screen \"%s\" not active", nextScreenName.c_str());
     return;
   }
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -77,6 +77,20 @@ public:
     std::string m_screen;
   };
 
+  //! Toggle screen data
+  class ToggleScreenInfo : public EventData
+  {
+  public:
+    explicit ToggleScreenInfo(const std::vector<std::string> &screens) : m_screens(screens)
+    {
+      // do nothing
+    }
+    ~ToggleScreenInfo() override = default; // do nothing
+
+  public:
+    std::vector<std::string> m_screens;
+  };
+
   //! Switch in direction data
   class SwitchInDirectionInfo : public EventData
   {
@@ -318,7 +332,7 @@ private:
   void handleClientCloseTimeout(BaseClientProxy *client);
   void handleSwitchToScreenEvent(const Event &event);
   void handleSwitchInDirectionEvent(const Event &event);
-  void handleToggleScreenEvent(const Event &);
+  void handleToggleScreenEvent(const Event &event);
   void handleKeyboardBroadcastEvent(const Event &event);
   void handleLockCursorToScreenEvent(const Event &event);
 

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -138,6 +138,14 @@ p, li { white-space: pre-wrap; }
         <source>Switch to </source>
         <translation type="unfinished">Cambiar a </translation>
     </message>
+    <message>
+        <source>Toggle screen</source>
+        <translation type="unfinished">Alternar pantalla</translation>
+    </message>
+    <message>
+        <source>Screen toggle order, drag to reorder</source>
+        <translation type="unfinished">Orden de visualización de las pantallas, arrastre para reordenarlas.</translation>
+    </message>
 </context>
 <context>
     <name>FingerprintDialog</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -138,6 +138,14 @@ p, li { white-space: pre-wrap; }
         <source>Switch to </source>
         <translation>Passa a </translation>
     </message>
+    <message>
+        <source>Toggle screen</source>
+        <translation type="unfinished">Attiva/disattiva schermo</translation>
+    </message>
+    <message>
+        <source>Screen toggle order, drag to reorder</source>
+        <translation type="unfinished">Ordine di visualizzazione delle schermate, trascina per riordinarle.</translation>
+    </message>
 </context>
 <context>
     <name>FingerprintDialog</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -138,6 +138,14 @@ p, li { white-space: pre-wrap; }
         <source>Switch to </source>
         <translation>に切り替える</translation>
     </message>
+    <message>
+        <source>Toggle screen</source>
+        <translation type="unfinished">画面を切り替える</translation>
+    </message>
+    <message>
+        <source>Screen toggle order, drag to reorder</source>
+        <translation type="unfinished">画面表示順序の切り替え、ドラッグして順序を変更</translation>
+    </message>
 </context>
 <context>
     <name>FingerprintDialog</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -138,6 +138,14 @@ p, li { white-space: pre-wrap; }
         <source>Switch to </source>
         <translation>Переключиться на </translation>
     </message>
+    <message>
+        <source>Toggle screen</source>
+        <translation type="unfinished">Переключить экран</translation>
+    </message>
+    <message>
+        <source>Screen toggle order, drag to reorder</source>
+        <translation type="unfinished">Порядок переключения экранов: перетащите элементы, чтобы изменить порядок.</translation>
+    </message>
 </context>
 <context>
     <name>FingerprintDialog</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -138,6 +138,14 @@ p, li { white-space: pre-wrap; }
         <source>Switch to </source>
         <translation>切换到 </translation>
     </message>
+    <message>
+        <source>Toggle screen</source>
+        <translation type="unfinished">切换屏幕</translation>
+    </message>
+    <message>
+        <source>Screen toggle order, drag to reorder</source>
+        <translation type="unfinished">屏幕切换顺序，拖动即可重新排序</translation>
+    </message>
 </context>
 <context>
     <name>FingerprintDialog</name>


### PR DESCRIPTION
fixes: #9135 

Implemented the Toggle Screen action as requested in #9135. Allows cycling through a list of screens or all screens.