### PR TITLE
[WIP] Scale client mouse speed

### DIFF
--- a/doc/user/configuration.md
+++ b/doc/user/configuration.md
@@ -50,10 +50,10 @@ option=value
 This section contains options used when in client mode. 
 It will begin with `[client]`
 
-
 | Option                |    Valid Values    | Description |
 |:----------------------|:------------------:|:-----------|
 | binary                | Filename           | The filename of the binary to call for client mode. This binary exists in the same path as the GUI |
+| cursorMovementScale   | Double 0.1 - 10.0  | Cursor movement will be scaled by this amount on the client. [default: 1.0] |
 | invertScrollDirection | `true` or `false`  | Invert scroll on this client [default: false] |
 | languageSync          | `true` or `false`  | Sync to server language [default: true] |
 | remoteHost            | `IP` or `hostname` | The remote host(s) to connect to. Use a comma seperated list when you want to try severial hosts |

--- a/src/lib/common/Coordinate.h
+++ b/src/lib/common/Coordinate.h
@@ -19,3 +19,4 @@ public:
 };
 
 using ScrollDelta = Coordinate;
+using MouseDelta = Coordinate;

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -204,7 +204,7 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Daemon::LogFile)
     return QStringLiteral("%1/%2-daemon.log").arg(Settings::settingsPath(), kAppId);
 
-  if (key == Client::YScrollScale)
+  if (key == Client::YScrollScale || key == Client::CursorMovementScale)
     return 1.0;
 
   return QVariant();

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -34,11 +34,12 @@ public:
 
   struct Client
   {
+    inline static const auto CursorMovementScale = QStringLiteral("client/cursorMovementScale");
     inline static const auto InvertScrollDirection = QStringLiteral("client/invertScrollDirection");
-    inline static const auto YScrollScale = QStringLiteral("client/yScrollScale");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
     inline static const auto XdpRestoreToken = QStringLiteral("client/xdpRestoreToken");
+    inline static const auto YScrollScale = QStringLiteral("client/yScrollScale");
   };
   struct Core
   {
@@ -191,7 +192,8 @@ private:
   };
 
   inline static const QStringList m_validKeys = {
-      Settings::Client::InvertScrollDirection
+      Settings::Client::CursorMovementScale
+    , Settings::Client::InvertScrollDirection
     , Settings::Client::LanguageSync
     , Settings::Client::RemoteHost
     , Settings::Client::YScrollScale

--- a/src/lib/deskflow/ISecondaryScreen.h
+++ b/src/lib/deskflow/ISecondaryScreen.h
@@ -24,6 +24,7 @@ public:
   {
     m_invertScroll = Settings::value(Settings::Client::InvertScrollDirection).toBool();
     m_scrollScale = std::clamp(Settings::value(Settings::Client::YScrollScale).toDouble(), 0.1, 10.0);
+    m_cursorScale = std::clamp(Settings::value(Settings::Client::CursorMovementScale).toDouble(), 0.1, 10.0);
   }
 
   virtual ~ISecondaryScreen() = default;
@@ -67,6 +68,19 @@ public:
     return delta;
   }
 
+  /**
+   * @brief Applies any scroll cursor movement scale to the provided delta, This should only be done inside the
+   * subclasses fakeMouseMove impl
+   * @param delta a ScrollDelta to be modified
+   * @return the delta with the scale applied
+   */
+  MouseDelta applyCursorScale(MouseDelta delta) const
+  {
+    delta.x = static_cast<int32_t>(delta.x * m_cursorScale);
+    delta.y = static_cast<int32_t>(delta.y * m_cursorScale);
+    return delta;
+  }
+
 private:
   /**
    * @brief this member is used to modify the scroll direction.
@@ -79,5 +93,11 @@ private:
    * It is used in the applyScrollModifier method
    */
   double m_scrollScale = 1.0;
+
+  /**
+   * @brief this member is used to modify the cursor scroll scale.
+   * It is used in the applyCursorScale method
+   */
+  double m_cursorScale = 1.0;
   //@}
 };

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -191,6 +191,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Log::GuiDebug, ui->cbGuiDebug->isChecked());
   Settings::setValue(Settings::Core::UseWlClipboard, ui->cbUseWlClipboard->isChecked());
   Settings::setValue(Settings::Gui::ShowVersionInTitle, ui->cbShowVersion->isChecked());
+  Settings::setValue(Settings::Client::CursorMovementScale, ui->sbCursorMoveScale->value());
 
   Settings::ProcessMode mode;
   if (ui->groupService->isChecked())
@@ -219,6 +220,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbGuiDebug->setChecked(Settings::value(Settings::Log::GuiDebug).toBool());
   ui->cbUseWlClipboard->setChecked(Settings::value(Settings::Core::UseWlClipboard).toBool());
   ui->cbShowVersion->setChecked(Settings::value(Settings::Gui::ShowVersionInTitle).toBool());
+  ui->sbCursorMoveScale->setValue(Settings::value(Settings::Client::CursorMovementScale).toDouble());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
   ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -53,6 +53,67 @@
            </widget>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="lblCursorMoveScale">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Cursor Movement Scale</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="sbCursorMoveScale">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="accelerated">
+               <bool>true</bool>
+              </property>
+              <property name="correctionMode">
+               <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+              </property>
+              <property name="minimum">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QCheckBox" name="cbScrollDirection">
             <property name="text">
              <string>Invert vertical scroll direction on this computer</string>

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -292,8 +292,9 @@ void EiScreen::fakeMouseMove(int32_t x, int32_t y)
 {
   // We get one motion event before enter() with the target position
   if (!m_isOnScreen) {
-    m_cursorX = x;
-    m_cursorY = y;
+    auto delta = applyCursorScale({x, y});
+    m_cursorX = delta.x;
+    m_cursorY = delta.y;
     return;
   }
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -698,7 +698,8 @@ void MSWindowsScreen::fakeMouseButton(ButtonID id, bool press)
 
 void MSWindowsScreen::fakeMouseMove(int32_t x, int32_t y)
 {
-  m_desks->fakeMouseMove(x, y);
+  auto delta = applyCursorScale({x, y});
+  m_desks->fakeMouseMove(delta.x, delta.y);
 }
 
 void MSWindowsScreen::fakeMouseRelativeMove(int32_t dx, int32_t dy) const

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -550,13 +550,14 @@ void OSXScreen::fakeMouseMove(int32_t x, int32_t y)
 {
   // synthesize event
   CGPoint pos;
-  pos.x = x;
-  pos.y = y;
+  auto delta = applyCursorScale({x, y});
+  pos.x = delta.x;
+  pos.y = delta.y;
   postMouseEvent(pos);
 
   // save new cursor position
-  m_xCursor = static_cast<int32_t>(pos.x);
-  m_yCursor = static_cast<int32_t>(pos.y);
+  m_xCursor = delta.x;
+  m_yCursor = delta.y;
   m_cursorPosValid = true;
 }
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -769,10 +769,11 @@ void XWindowsScreen::fakeMouseButton(ButtonID button, bool press)
 
 void XWindowsScreen::fakeMouseMove(int32_t x, int32_t y)
 {
+  auto delta = applyCursorScale({x, y});
   if (m_xinerama && m_xtestIsXineramaUnaware) {
-    XWarpPointer(m_display, None, m_root, 0, 0, 0, 0, x, y);
+    XWarpPointer(m_display, None, m_root, 0, 0, 0, 0, delta.x, delta.y);
   } else {
-    XTestFakeMotionEvent(m_display, DefaultScreen(m_display), x, y, CurrentTime);
+    XTestFakeMotionEvent(m_display, DefaultScreen(m_display), delta.x, delta.y, CurrentTime);
   }
   XFlush(m_display);
 }

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1699,19 +1699,6 @@ void Server::onMouseMoveSecondary(int32_t dx, int32_t dy)
 {
   LOG_DEBUG2("mouse move on secondary: %+d,%+d", dx, dy);
 
-  // TODO: move this to client side and use a qt setting or cli arg instead of env var.
-  const static auto adjustEnv = "DESKFLOW_MOUSE_ADJUSTMENT";
-  if (const char *envVal = std::getenv(adjustEnv); envVal) {
-    try {
-      double multiplier = std::stod(envVal);
-      dx = static_cast<int32_t>(std::round(dx * multiplier));
-      dy = static_cast<int32_t>(std::round(dy * multiplier));
-      LOG_DEBUG2("adjusted mouse x %.2f: %+d,%+d", multiplier, dx, dy);
-    } catch (const std::exception &e) {
-      LOG_ERR("invalid %s value: %s", adjustEnv, e.what());
-    }
-  }
-
   // mouse move on secondary (client's) screen
   assert(m_active != nullptr);
   if (m_active == m_primaryClient) {

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1324,6 +1324,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <source>Vertical Scroll Scale</source>
         <translation type="unfinished">Escala de desplazamiento vertical</translation>
     </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">Escala de movimiento del cursor</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1324,6 +1324,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <source>Vertical Scroll Scale</source>
         <translation type="unfinished">Scala di scorrimento verticale</translation>
     </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">Scala di movimento del cursore</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1325,6 +1325,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Vertical Scroll Scale</source>
         <translation type="unfinished">垂直スクロールスケール</translation>
     </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">カーソル移動スケール</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1323,6 +1323,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Vertical Scroll Scale</source>
         <translation type="unfinished">수직 스크롤 스케일</translation>
     </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">커서 이동 규모</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1323,6 +1323,10 @@ Enabling this setting will disable the server config GUI.</source>
         <source>Vertical Scroll Scale</source>
         <translation type="unfinished">Вертикальная шкала прокрутки</translation>
     </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">Масштаб перемещения курсора</translation>
+    </message>
 </context>
 <context>
     <name>i18n</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1323,7 +1323,11 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>Vertical Scroll Scale</source>
-        <translation type="unfinished">垂直滚动比例</translation>
+        <translation>垂直滚动比例</translation>
+    </message>
+    <message>
+        <source>Cursor Movement Scale</source>
+        <translation type="unfinished">光标移动刻度</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
REQUIRES: #9433 
## Description
<!--- Describe your what your changes do -->
** BROKEN ATM **
This approach does not work since applying it to FakeMouseMove seams to reduce the % of the screen you can access on the client (0.5 = half height and half width of the screen ) . 

Adding this to the relative movements seams to work. Relative movements seam to only be enable if you are locked to a screen (have we documented this somewhere) 

Remove the use of the `DESKFLOW_MOUSE_SCALE` 

 - Adds Mouse speed scaling to mouseMovements, 
   - New: `Settings::CursorMovementScale` (def 1.0 range 0.1-10.0)
   - New: `ISecondaryScreen::applyCursorMoveScale` applies the scale 
   - Use applyCursorMoveScale in `FakeMouseMove`
   - [ ] Todo: Use applyCursorMoveScale in `FakeMouseMove`

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #8207

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Test Plan: 
 - [X] Check scale is not applied to the server
 - [ ] Check on Wayland Client
 - [ ] Check on X11 Client
 - [ ] Check on Windows Client
 - [ ] Check on macOS Client
