### PR TITLE
fixes AltGr for clients w/windows+finnish-layout.

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -191,7 +191,7 @@ const KeyID MSWindowsKeyState::s_virtualKey[] = {
     /* 0x0a2 */ {kKeyControl_L},        // VK_LCONTROL
     /* 0x0a3 */ {kKeyControl_R},        // VK_RCONTROL
     /* 0x0a4 */ {kKeyAlt_L},            // VK_LMENU
-    /* 0x0a5 */ {kKeyAlt_R},            // VK_RMENU
+    /* 0x0a5 */ {kKeyAltGr},            // VK_RMENU
     /* 0x0a6 */ {kKeyNone},             // VK_BROWSER_BACK
     /* 0x0a7 */ {kKeyNone},             // VK_BROWSER_FORWARD
     /* 0x0a8 */ {kKeyNone},             // VK_BROWSER_REFRESH
@@ -448,7 +448,7 @@ const KeyID MSWindowsKeyState::s_virtualKey[] = {
     /* 0x1a2 */ {kKeyControl_L},    // VK_LCONTROL
     /* 0x1a3 */ {kKeyControl_R},    // VK_RCONTROL
     /* 0x1a4 */ {kKeyAlt_L},        // VK_LMENU
-    /* 0x1a5 */ {kKeyAlt_R},        // VK_RMENU
+    /* 0x1a5 */ {kKeyAltGr},        // VK_RMENU
     /* 0x1a6 */ {kKeyWWWBack},      // VK_BROWSER_BACK
     /* 0x1a7 */ {kKeyWWWForward},   // VK_BROWSER_FORWARD
     /* 0x1a8 */ {kKeyWWWRefresh},   // VK_BROWSER_REFRESH
@@ -1075,7 +1075,7 @@ void MSWindowsKeyState::getKeyMap(deskflow::KeyMap &keyMap)
           static const Modifier modifiers[] = {
               {VK_SHIFT, VK_SHIFT, 0x80u, KeyModifierShift},
               {VK_CAPITAL, VK_CAPITAL, 0x01u, KeyModifierCapsLock},
-              {VK_CONTROL, VK_MENU, 0x80u, KeyModifierControl | KeyModifierAlt}
+              {VK_CONTROL, VK_MENU, 0x80u, KeyModifierAltGr}
           };
           static const size_t s_numModifiers = sizeof(modifiers) / sizeof(modifiers[0]);
           static const size_t s_numCombinations = 1 << s_numModifiers;


### PR DESCRIPTION
## Description
fixes this(AltGr/LVL3 sent by X11 server with fi-layout):
`DEBUG1: key ef7e is not on keyboard`
^as seen from the client log, and so ie. pressing '2' with it doesn't work.

## Disclosure of AI use
no AI was involved with this simple diff, just plenty of logs and experience
of already getting this fixed between X11-to-X11, and the great linux tools
nowadays available on windows thanks to WSL(xev, xkbcli interactive-..).

## Related Issue
atleast related to #4411 but nowadays deskflow does send it correctly over,
and the windows clients needs this to properly separate AltGr from Ctrl+Alt,
which isn't working.

## How Has This Been Tested?
rpi5 server:
(Deskflow: 1.25.0.220 (4200de66)
Qt: 6.8.2
System: Debian GNU/Linux 13 (trixie)
Session: LXDE (x11)

laptop(x64) client:
Deskflow: 1.25.0.224 (ee550587)
Qt: 6.7.3
System: Windows 11 Version 25H2

To reproduce bug:
1. Set Finish layout on Wayland server
2. Set Finish layout on Windows client
3. Move mouse to client
4. Press AltGr + 2

On master: `2` is typed
On this PR: `@` is typed (fix works as intended)

# To do

As is, this would definately belong behind a switch, because this doesn't
consider layouts not using AltGr at all - just wanted to keep this minimal.

- [x] Check if replacing `KeyModifierControl | KeyModifierAlt` with `KeyModifierAltGr` causes issues
- [ ] ~~Move fix into `getKeyMap` so that keymap contains the fix~~