### PR TITLE
Update the SettingsDialog

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -499,7 +499,7 @@ void MainWindow::openGetNewVersionUrl() const
 
 void MainWindow::openSettings()
 {
-  auto dialog = SettingsDialog(this, m_serverConfig, m_coreProcess);
+  auto dialog = SettingsDialog(this, m_serverConfig);
 
   if (dialog.exec() == QDialog::Accepted) {
     Settings::save();

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -31,6 +31,11 @@ SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfi
 
   ui->setupUi(this);
 
+  // no advanced options on macOS
+  if (deskflow::platform::isMac()) {
+    ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabAdvanced));
+  }
+
   // set up the language combo
   I18N::reDetectLanguages();
   ui->comboLanguage->addItems(I18N::detectedLanguages());

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -84,6 +84,7 @@ void SettingsDialog::initConnections() const
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(ui->buttonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &SettingsDialog::loadFromConfig);
 
   connect(ui->groupSecurity, &QGroupBox::toggled, this, &SettingsDialog::updateTlsControlsEnabled);
   connect(ui->groupService, &QGroupBox::toggled, this, &SettingsDialog::updateControls);
@@ -187,6 +188,9 @@ void SettingsDialog::updateText()
   ui->comboLogLevel->setItemData(5, tr("Debug entries"), Qt::ToolTipRole);
   ui->comboLogLevel->setItemData(6, tr("More debug output"), Qt::ToolTipRole);
   ui->comboLogLevel->setItemData(7, tr("Verbose debug output"), Qt::ToolTipRole);
+  ui->buttonBox->button(QDialogButtonBox::Save)->setToolTip(tr("Close and save changes"));
+  ui->buttonBox->button(QDialogButtonBox::Cancel)->setToolTip(tr("Close and forget changes"));
+  ui->buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset to stored values"));
 }
 
 void SettingsDialog::accept()
@@ -397,6 +401,7 @@ void SettingsDialog::setButtonBoxEnabledButtons() const
 {
   const bool modified = isModified();
   ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(modified);
+  ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(modified);
 }
 
 SettingsDialog::~SettingsDialog() = default;

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -96,7 +96,7 @@ void SettingsDialog::initConnections() const
   connect(ui->comboTlsKeyLength, &QComboBox::currentIndexChanged, this, &SettingsDialog::updateRequestedKeySize);
   connect(ui->btnTlsCertPath, &QPushButton::clicked, this, &SettingsDialog::browseCertificatePath);
   connect(ui->btnBrowseLog, &QPushButton::clicked, this, &SettingsDialog::browseLogPath);
-  connect(ui->cbLogToFile, &QCheckBox::toggled, this, &SettingsDialog::setLogToFile);
+  connect(ui->groupLogToFile, &QGroupBox::toggled, this, &SettingsDialog::setLogToFile);
   connect(ui->comboLogLevel, &QComboBox::currentIndexChanged, this, &SettingsDialog::logLevelChanged);
   connect(ui->comboLanguage, &QComboBox::currentTextChanged, this, [](const QString &lang) {
     const auto shortName = I18N::nativeTo639Name(lang);
@@ -110,7 +110,6 @@ void SettingsDialog::initConnections() const
   connect(ui->comboInterface, &QComboBox::currentIndexChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->comboTlsKeyLength, &QComboBox::currentIndexChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->comboLanguage, &QComboBox::currentIndexChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
-  connect(ui->cbLogToFile, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbAutoHide, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbPreventSleep, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbCloseToTray, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
@@ -120,6 +119,7 @@ void SettingsDialog::initConnections() const
   connect(ui->cbUseWlClipboard, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbShowVersion, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbRequireClientCert, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
+  connect(ui->groupLogToFile, &QGroupBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->groupService, &QGroupBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->groupSecurity, &QGroupBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->lineLogFilename, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
@@ -203,7 +203,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Core::Port, ui->sbPort->value());
   Settings::setValue(Settings::Core::Interface, ui->comboInterface->currentData());
   Settings::setValue(Settings::Log::Level, ui->comboLogLevel->currentIndex());
-  Settings::setValue(Settings::Log::ToFile, ui->cbLogToFile->isChecked());
+  Settings::setValue(Settings::Log::ToFile, ui->groupLogToFile->isChecked());
   Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
   Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
   Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
@@ -234,7 +234,7 @@ void SettingsDialog::loadFromConfig()
 {
   ui->sbPort->setValue(Settings::value(Settings::Core::Port).toInt());
   ui->comboLogLevel->setCurrentIndex(Settings::value(Settings::Log::Level).toInt());
-  ui->cbLogToFile->setChecked(Settings::value(Settings::Log::ToFile).toBool());
+  ui->groupLogToFile->setChecked(Settings::value(Settings::Log::ToFile).toBool());
   ui->lineLogFilename->setText(Settings::value(Settings::Log::File).toString());
   ui->cbAutoHide->setChecked(Settings::value(Settings::Gui::Autohide).toBool());
   ui->cbPreventSleep->setChecked(Settings::value(Settings::Core::PreventSleep).toBool());
@@ -324,14 +324,14 @@ void SettingsDialog::updateControls()
 {
   const bool writable = Settings::isWritable();
   const bool serviceChecked = ui->groupService->isChecked();
-  const bool logToFile = ui->cbLogToFile->isChecked();
+  const bool logToFile = ui->groupLogToFile->isChecked();
 
   ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(writable);
 
   ui->sbPort->setEnabled(writable);
   ui->comboInterface->setEnabled(writable);
   ui->comboLogLevel->setEnabled(writable);
-  ui->cbLogToFile->setEnabled(writable);
+  ui->groupLogToFile->setEnabled(writable);
   ui->cbAutoHide->setEnabled(writable);
   ui->cbAutoUpdate->setEnabled(writable);
   ui->cbPreventSleep->setEnabled(writable);
@@ -381,7 +381,7 @@ bool SettingsDialog::isModified() const
   return (
       (ui->sbPort->value() != Settings::value(Settings::Core::Port).toInt()) ||
       (ui->comboLogLevel->currentIndex() != Settings::value(Settings::Log::Level).toInt()) ||
-      (ui->cbLogToFile->isChecked() != Settings::value(Settings::Log::ToFile).toBool()) ||
+      (ui->groupLogToFile->isChecked() != Settings::value(Settings::Log::ToFile).toBool()) ||
       (ui->lineLogFilename->text() != Settings::value(Settings::Log::File).toString()) ||
       (ui->cbAutoHide->isChecked() != Settings::value(Settings::Gui::Autohide).toBool()) ||
       (ui->cbPreventSleep->isChecked() != Settings::value(Settings::Core::PreventSleep).toBool()) ||
@@ -409,7 +409,7 @@ bool SettingsDialog::isDefault() const
   return (
       (ui->sbPort->value() == Settings::defaultValue(Settings::Core::Port).toInt()) &&
       (ui->comboLogLevel->currentIndex() == Settings::defaultValue(Settings::Log::Level).toInt()) &&
-      (ui->cbLogToFile->isChecked() == Settings::defaultValue(Settings::Log::ToFile).toBool()) &&
+      (ui->groupLogToFile->isChecked() == Settings::defaultValue(Settings::Log::ToFile).toBool()) &&
       (ui->lineLogFilename->text() == Settings::defaultValue(Settings::Log::File).toString()) &&
       (ui->cbAutoHide->isChecked() == Settings::defaultValue(Settings::Gui::Autohide).toBool()) &&
       (ui->cbPreventSleep->isChecked() == Settings::defaultValue(Settings::Core::PreventSleep).toBool()) &&
@@ -434,7 +434,7 @@ void SettingsDialog::resetToDefault()
 {
   ui->sbPort->setValue(Settings::defaultValue(Settings::Core::Port).toInt());
   ui->comboLogLevel->setCurrentIndex(Settings::defaultValue(Settings::Log::Level).toInt());
-  ui->cbLogToFile->setChecked(Settings::defaultValue(Settings::Log::ToFile).toBool());
+  ui->groupLogToFile->setChecked(Settings::defaultValue(Settings::Log::ToFile).toBool());
   ui->lineLogFilename->setText(Settings::defaultValue(Settings::Log::File).toString());
   ui->cbAutoHide->setChecked(Settings::defaultValue(Settings::Gui::Autohide).toBool());
   ui->cbPreventSleep->setChecked(Settings::defaultValue(Settings::Core::PreventSleep).toBool());

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -23,11 +23,10 @@
 
 using namespace deskflow::gui;
 
-SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfig, const CoreProcess &coreProcess)
+SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfig)
     : QDialog(parent),
       ui{std::make_unique<Ui::SettingsDialog>()},
-      m_serverConfig(serverConfig),
-      m_coreProcess(coreProcess)
+      m_serverConfig(serverConfig)
 {
 
   ui->setupUi(this);
@@ -269,7 +268,7 @@ void SettingsDialog::updateTlsControlsEnabled()
 
 bool SettingsDialog::isClientMode() const
 {
-  return m_coreProcess.mode() == Settings::CoreMode::Client;
+  return Settings::value(Settings::Core::CoreMode) == Settings::CoreMode::Client;
 }
 
 void SettingsDialog::updateKeyLengthOnFile(const QString &path)

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -61,6 +61,18 @@ private:
   /// @brief update if the log level warning is shown
   void logLevelChanged();
 
+  /**
+   * @brief isModified
+   * @return true when any client settings in the gui do not match the stored settings values.
+   */
+  bool isModified() const;
+
+  /**
+   * @brief setButtonBoxEnabledButtons
+   * Enable / Disable the button box buttons based on the state of the gui
+   */
+  void setButtonBoxEnabledButtons() const;
+
   std::unique_ptr<Ui::SettingsDialog> ui;
   const IServerConfig &m_serverConfig;
 };

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -68,6 +68,17 @@ private:
   bool isModified() const;
 
   /**
+   * @brief isDefault
+   * @return true if all client settings match the default values
+   */
+  bool isDefault() const;
+
+  /**
+   * @brief Set the gui values to the defalut values for all client settings
+   */
+  void resetToDefault();
+
+  /**
    * @brief setButtonBoxEnabledButtons
    * Enable / Disable the button box buttons based on the state of the gui
    */

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -10,7 +10,6 @@
 #include <QDialog>
 
 #include "gui/config/IServerConfig.h"
-#include "gui/core/CoreProcess.h"
 
 namespace Ui {
 class SettingsDialog;
@@ -19,13 +18,12 @@ class SettingsDialog;
 class SettingsDialog : public QDialog
 {
   using IServerConfig = deskflow::gui::IServerConfig;
-  using CoreProcess = deskflow::gui::CoreProcess;
 
   Q_OBJECT
 
 public:
   void extracted();
-  SettingsDialog(QWidget *parent, const IServerConfig &serverConfig, const CoreProcess &coreProcess);
+  SettingsDialog(QWidget *parent, const IServerConfig &serverConfig);
   ~SettingsDialog() override;
 
 Q_SIGNALS:
@@ -65,5 +63,4 @@ private:
 
   std::unique_ptr<Ui::SettingsDialog> ui;
   const IServerConfig &m_serverConfig;
-  const CoreProcess &m_coreProcess;
 };

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>549</width>
-    <height>755</height>
+    <height>529</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -278,7 +278,214 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabLog">
+      <attribute name="title">
+       <string>&amp;Logs</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>25</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="lblLogLevel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Level</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboLogLevel">
+           <item>
+            <property name="text">
+             <string>Fatal</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Error</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Warning</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Note</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Info</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Debug</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Debug1</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Debug2</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupLogToFile">
+         <property name="title">
+          <string>Log to file</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QWidget" name="widgetLogFilename" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QHBoxLayout" name="_4">
+             <property name="spacing">
+              <number>3</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="labelLogPath">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Log path</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_7">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Policy::Minimum</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>17</width>
+                 <height>25</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineLogFilename">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnBrowseLog">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset theme="QIcon::ThemeIcon::DocumentOpen"/>
+               </property>
+               <property name="flat">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbGuiDebug">
+         <property name="text">
+          <string>Enable GUI debug messages</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblDebugWarning">
+         <property name="text">
+          <string>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -396,206 +603,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupLogs">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Logs</string>
-         </property>
-         <layout class="QGridLayout" name="_3">
-          <property name="verticalSpacing">
-           <number>9</number>
-          </property>
-          <item row="3" column="2">
-           <widget class="QLabel" name="lblLogLevel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Level</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QComboBox" name="comboLogLevel">
-            <item>
-             <property name="text">
-              <string>Fatal</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Error</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Warning</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Note</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Info</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Debug</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Debug1</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Debug2</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="8" column="0" colspan="4">
-           <widget class="QWidget" name="widgetLogFilename" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QHBoxLayout" name="_4">
-             <property name="spacing">
-              <number>3</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="labelLogPath">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Log path</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_7">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::Minimum</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="lineLogFilename">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnBrowseLog">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset theme="QIcon::ThemeIcon::DocumentOpen"/>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="cbLogToFile">
-            <property name="text">
-             <string>Log to file</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="9" column="0" colspan="4">
-           <widget class="QLabel" name="lblDebugWarning">
-            <property name="text">
-             <string>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="4">
-           <widget class="QCheckBox" name="cbGuiDebug">
-            <property name="text">
-             <string>Enable GUI debug messages</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>549</width>
-    <height>529</height>
+    <width>554</width>
+    <height>447</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,6 +33,9 @@
        <string>&amp;General</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>9</number>
+       </property>
        <property name="leftMargin">
         <number>12</number>
        </property>
@@ -43,241 +46,64 @@
         <number>12</number>
        </property>
        <item>
-        <widget class="QGroupBox" name="groupApp">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="QCheckBox" name="cbAutoUpdate">
+         <property name="text">
+          <string>Check for updates on startup</string>
          </property>
-         <property name="title">
-          <string>App</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QCheckBox" name="cbAutoUpdate">
-            <property name="text">
-             <string>Check for updates on startup</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbShowVersion">
-            <property name="text">
-             <string>Include version in the window title</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbAutoHide">
-            <property name="text">
-             <string>Hide the window when the app starts</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbPreventSleep">
-            <property name="text">
-             <string>Prevent this computer from going to sleep</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbCloseToTray">
-            <property name="text">
-             <string>Leave app running in notification area when the window is closed</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <item>
-             <widget class="QLabel" name="lblTrayIconStyle">
-              <property name="text">
-               <string>Tray icon style</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="rbIconColorful">
-              <property name="text">
-               <string>Colorful</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="rbIconMono">
-              <property name="text">
-               <string>Monocolor</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupSecurity">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="QCheckBox" name="cbShowVersion">
+         <property name="text">
+          <string>Include version in the window title</string>
          </property>
-         <property name="title">
-          <string>Enable TLS Encryption</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QVBoxLayout" name="_11">
-          <item>
-           <widget class="QWidget" name="widgetTlsCert" native="true">
-            <layout class="QHBoxLayout" name="_12">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="lblTlsCertInfo">
-               <property name="text">
-                <string notr="true"/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="lblTlsCert">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Certificate</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="lineTlsCertPath">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnTlsCertPath">
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset theme="QIcon::ThemeIcon::DocumentOpen"/>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="lblTlsKeyLength">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Key length</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboTlsKeyLength">
-              <item>
-               <property name="text">
-                <string notr="true">2048</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">4096</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="btnTlsRegenCert">
-              <property name="text">
-               <string>Regenerate certificate</string>
-              </property>
-              <property name="icon">
-               <iconset theme="QIcon::ThemeIcon::ViewRefresh"/>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbRequireClientCert">
-            <property name="text">
-             <string>Require client certificates</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
         </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbAutoHide">
+         <property name="text">
+          <string>Hide the window when the app starts</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbPreventSleep">
+         <property name="text">
+          <string>Prevent this computer from going to sleep</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbCloseToTray">
+         <property name="text">
+          <string>Leave app running in notification area when the window is closed</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QLabel" name="lblTrayIconStyle">
+           <property name="text">
+            <string>Tray icon style</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbIconColorful">
+           <property name="text">
+            <string>Colorful</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbIconMono">
+           <property name="text">
+            <string>Monocolor</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_3">
@@ -501,6 +327,294 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabNetwork">
+      <attribute name="title">
+       <string>&amp;Network</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>25</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="lblNetworkIp">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Network IP</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboInterface">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>Automatic</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>25</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="lblPort">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Port</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="sbPort">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximum">
+            <number>65535</number>
+           </property>
+           <property name="value">
+            <number>24800</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupSecurity">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Enable TLS Encryption</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="_11">
+          <item>
+           <widget class="QWidget" name="widgetTlsCert" native="true">
+            <layout class="QHBoxLayout" name="_12">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblTlsCertInfo">
+               <property name="text">
+                <string notr="true"/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblTlsCert">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Certificate</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="lineTlsCertPath">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnTlsCertPath">
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset theme="QIcon::ThemeIcon::DocumentOpen"/>
+               </property>
+               <property name="flat">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="lblTlsKeyLength">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Key length</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboTlsKeyLength">
+              <item>
+               <property name="text">
+                <string notr="true">2048</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">4096</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnTlsRegenCert">
+              <property name="text">
+               <string>Regenerate certificate</string>
+              </property>
+              <property name="icon">
+               <iconset theme="QIcon::ThemeIcon::ViewRefresh"/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbRequireClientCert">
+            <property name="text">
+             <string>Require client certificates</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>79</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabAdvanced">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -512,110 +626,6 @@
        <string>&amp;Advanced</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QGroupBox" name="groupNetworking">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Networking</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="lblNetworkIp">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Network IP</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboInterface">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <item>
-             <property name="text">
-              <string>Automatic</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Policy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>25</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="lblPort">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Port</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sbPort">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximum">
-             <number>65535</number>
-            </property>
-            <property name="value">
-             <number>24800</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item>
         <widget class="QGroupBox" name="groupService">
          <property name="enabled">

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -46,6 +46,31 @@
         <number>12</number>
        </property>
        <item>
+        <widget class="QWidget" name="widgetLanguage" native="true">
+         <property name="toolTip">
+          <string>Force a language to be used for the GUI.</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QLabel" name="lblLanguage">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboLanguage"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="cbAutoUpdate">
          <property name="text">
           <string>Check for updates on startup</string>
@@ -125,6 +150,9 @@
        <string>&amp;Logs</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>9</number>
+       </property>
        <property name="leftMargin">
         <number>12</number>
        </property>
@@ -332,6 +360,9 @@
        <string>&amp;Network</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_7">
+       <property name="spacing">
+        <number>9</number>
+       </property>
        <property name="leftMargin">
         <number>12</number>
        </property>
@@ -608,7 +639,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>79</height>
+           <height>32</height>
           </size>
          </property>
         </spacer>
@@ -626,6 +657,18 @@
        <string>&amp;Advanced</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>9</number>
+       </property>
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>25</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
        <item>
         <widget class="QGroupBox" name="groupService">
          <property name="enabled">
@@ -656,31 +699,6 @@
              <bool>false</bool>
             </property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="widgetLanguage" native="true">
-         <property name="toolTip">
-          <string>Force a language to be used for the GUI.</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="lblLanguage">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Language</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboLanguage"/>
           </item>
          </layout>
         </widget>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -711,7 +711,7 @@
       <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::Save</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -22,7 +22,7 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <widget class="QWidget" name="tabRegular">
+     <widget class="QWidget" name="tabGeneral">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
         <horstretch>0</horstretch>
@@ -30,9 +30,18 @@
        </sizepolicy>
       </property>
       <attribute name="title">
-       <string>&amp;Regular</string>
+       <string>&amp;General</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>25</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
        <item>
         <widget class="QGroupBox" name="groupApp">
          <property name="sizePolicy">

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -711,7 +711,7 @@
       <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Save</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1224,16 +1224,8 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">IP de red</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation type="unfinished">Registros</translation>
-    </message>
-    <message>
         <source>Log path</source>
         <translation type="unfinished">Ruta de registro</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation type="unfinished">Registrar en archivo</translation>
     </message>
     <message>
         <source>Fatal</source>
@@ -1374,6 +1366,14 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>Include version in the window title</source>
         <translation type="unfinished">Incluir la versión en el título de la ventana</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>Registrar en archivo</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation>&amp;Registro</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1328,6 +1328,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Restablecer los valores almacenados</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Restablecer valores predeterminados</translation>
+    </message>
+    <message>
         <source>TLS Certificate Regenerated</source>
         <translation type="unfinished">Certificado TLS regenerado</translation>
     </message>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1152,10 +1152,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Preferencias</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation type="unfinished">Aplicación</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation type="unfinished">Buscar actualizaciones al iniciar</translation>
     </message>
@@ -1206,10 +1202,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>&amp;Advanced</source>
         <translation type="unfinished">&amp;Avanzado</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation type="unfinished">Redes</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1374,6 +1366,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>&amp;General</source>
         <translation type="unfinished">&amp;General</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>R&amp;ed</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1152,10 +1152,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Preferencias</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation type="unfinished">&amp;Regular</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation type="unfinished">Aplicación</translation>
     </message>
@@ -1374,6 +1370,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>&amp;Logs</source>
         <translation>&amp;Registro</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation type="unfinished">&amp;General</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1316,6 +1316,18 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Salida de depuración detallada</translation>
     </message>
     <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Cerrar y guardar los cambios</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Cerrar y olvidar los cambios</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Restablecer los valores almacenados</translation>
+    </message>
+    <message>
         <source>TLS Certificate Regenerated</source>
         <translation type="unfinished">Certificado TLS regenerado</translation>
     </message>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1328,6 +1328,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation type="unfinished">Ripristina i valori memorizzati</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Ripristina i valori predefiniti</translation>
+    </message>
+    <message>
         <source>TLS Certificate Regenerated</source>
         <translation>Certificato TLS rigenerato</translation>
     </message>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1152,10 +1152,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>Preferenze</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation>App</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>Controlla aggiornamenti all&apos;avvio</translation>
     </message>
@@ -1206,10 +1202,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>&amp;Advanced</source>
         <translation>&amp;Avanzate</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation>Rete</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1374,6 +1366,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>&amp;General</source>
         <translation type="unfinished">&amp;Generale</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>&amp;Rete</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1224,16 +1224,8 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>IP di rete</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation>Log</translation>
-    </message>
-    <message>
         <source>Log path</source>
         <translation>Percorso log</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation>Salva log su file</translation>
     </message>
     <message>
         <source>Fatal</source>
@@ -1374,6 +1366,14 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>Include version in the window title</source>
         <translation type="unfinished">Includi la versione nel titolo della finestra</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>Salva log su file</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation>&amp;Logs</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1152,10 +1152,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>Preferenze</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation>&amp;Regolare</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation>App</translation>
     </message>
@@ -1374,6 +1370,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>&amp;Logs</source>
         <translation>&amp;Logs</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation type="unfinished">&amp;Generale</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1316,6 +1316,18 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>Output di debug dettagliato</translation>
     </message>
     <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Chiudi e salva le modifiche</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Chiudi e dimentica le modifiche</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Ripristina i valori memorizzati</translation>
+    </message>
+    <message>
         <source>TLS Certificate Regenerated</source>
         <translation>Certificato TLS rigenerato</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1357,6 +1357,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>変更前の値にリセットする</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation>デフォルト値にリセットする</translation>
+    </message>
+    <message>
         <source>Enable wl-clipboard support</source>
         <translation>wl-clipboard によるクリップボード対応を有効にする</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1225,10 +1225,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>IPアドレス</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation>ログ</translation>
-    </message>
-    <message>
         <source>Level</source>
         <translation>レベル</translation>
     </message>
@@ -1267,10 +1263,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Log path</source>
         <translation>ログファイルのパス</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation>ファイルにログを保存する</translation>
     </message>
     <message>
         <source>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</source>
@@ -1375,6 +1367,14 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Include version in the window title</source>
         <translation>ウィンドウタイトルにバージョン情報を含める</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>ファイルにログを保存する</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation>ログ(&amp;L)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1153,10 +1153,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>設定</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation>アプリケーション</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>起動時にソフトウェア更新を確認する</translation>
     </message>
@@ -1207,10 +1203,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Advanced</source>
         <translation>詳細(&amp;A)</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation>ネットワーク</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1375,6 +1367,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;General</source>
         <translation>一般(&amp;G)</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>ネットワーク(&amp;N)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1345,6 +1345,18 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>詳細なデバッグ出力</translation>
     </message>
     <message>
+        <source>Close and save changes</source>
+        <translation>変更を保存して閉じる</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>変更を破棄して閉じる</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation>変更前の値にリセットする</translation>
+    </message>
+    <message>
         <source>Enable wl-clipboard support</source>
         <translation>wl-clipboard によるクリップボード対応を有効にする</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1153,10 +1153,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>設定</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation>基本(&amp;R)</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation>アプリケーション</translation>
     </message>
@@ -1375,6 +1371,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Logs</source>
         <translation>ログ(&amp;L)</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation>一般(&amp;G)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1223,10 +1223,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>네트워크 IP</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation>로그</translation>
-    </message>
-    <message>
         <source>Level</source>
         <translation>레벨</translation>
     </message>
@@ -1265,10 +1261,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Log path</source>
         <translation>로그 경로</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation>파일로 로그 저장</translation>
     </message>
     <message>
         <source>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</source>
@@ -1373,6 +1365,14 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Include version in the window title</source>
         <translation type="unfinished">창 제목에 버전 정보 포함</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>파일로 로그 저장</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation>로그 (&amp;L)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1151,10 +1151,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>환경설정</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation>앱</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>시작 시 업데이트 확인</translation>
     </message>
@@ -1205,10 +1201,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Advanced</source>
         <translation>고급(&amp;A)</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation>네트워크</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1373,6 +1365,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;General</source>
         <translation type="unfinished">일반적인 (&amp;G)</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>네트워크(&amp;N)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1355,6 +1355,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished">저장된 값으로 재설정</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">기본값으로 재설정</translation>
+    </message>
+    <message>
         <source>Enable wl-clipboard support</source>
         <translation>wl-clipboard 지원 사용</translation>
     </message>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1151,10 +1151,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>환경설정</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation>일반(&amp;R)</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation>앱</translation>
     </message>
@@ -1373,6 +1369,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Logs</source>
         <translation>로그 (&amp;L)</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation type="unfinished">일반적인 (&amp;G)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1343,6 +1343,18 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>상세 디버그 출력</translation>
     </message>
     <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">닫기 및 변경 사항 저장</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">설정을 저장하고 나면 변경 사항은 더 이상 신경 쓸 필요가 없습니다</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">저장된 값으로 재설정</translation>
+    </message>
+    <message>
         <source>Enable wl-clipboard support</source>
         <translation>wl-clipboard 지원 사용</translation>
     </message>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1347,6 +1347,18 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Подробный вывод отладки</translation>
     </message>
     <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Закрыть и сохранить изменения</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Закройте изменения и забудьте о них</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Сбросить до сохраненных значений</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Requires the wl-clipboard package&lt;/p&gt;&lt;p&gt;When using wl-clipboard v2.2.1, there is a focus stealing bug that may make Deskflow harder to use. This has been fixed when using the wl-clipboard master branch, unless your Compositor lacks wlroots-data-control protocol support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Требуется пакет wl-clipboard. В версии 2.2.1 есть ошибка перехвата фокуса.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1151,10 +1151,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation>&amp;Основные</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation>Приложение</translation>
     </message>
@@ -1373,6 +1369,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Logs</source>
         <translation>&amp;Журнал</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation type="unfinished">&amp;Общий</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1151,10 +1151,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation>Приложение</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>Проверять обновления при запуске</translation>
     </message>
@@ -1205,10 +1201,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Advanced</source>
         <translation>&amp;Расширенные</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation>Сеть</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1373,6 +1365,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;General</source>
         <translation type="unfinished">&amp;Общий</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>&amp;Сеть</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1223,10 +1223,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Сетевой IP-адрес</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation>Журналы</translation>
-    </message>
-    <message>
         <source>Level</source>
         <translation>Уровень</translation>
     </message>
@@ -1265,10 +1261,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Log path</source>
         <translation>Путь к журналам</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation>Записывать в файл</translation>
     </message>
     <message>
         <source>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</source>
@@ -1373,6 +1365,14 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Include version in the window title</source>
         <translation type="unfinished">Включить номер версии в заголовок окна</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>Записывать в файл</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation>&amp;Журнал</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1359,6 +1359,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished">Сбросить до сохраненных значений</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Сбросить до значений по умолчанию</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Requires the wl-clipboard package&lt;/p&gt;&lt;p&gt;When using wl-clipboard v2.2.1, there is a focus stealing bug that may make Deskflow harder to use. This has been fixed when using the wl-clipboard master branch, unless your Compositor lacks wlroots-data-control protocol support.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Требуется пакет wl-clipboard. В версии 2.2.1 есть ошибка перехвата фокуса.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1357,6 +1357,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished">重置为存储值</translation>
     </message>
     <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">重置为默认值</translation>
+    </message>
+    <message>
         <source>Enable wl-clipboard support</source>
         <translation>启用 wl-clipboard 支持</translation>
     </message>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1153,10 +1153,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>首选项</translation>
     </message>
     <message>
-        <source>App</source>
-        <translation>应用程序</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>启动时检查更新</translation>
     </message>
@@ -1207,10 +1203,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Advanced</source>
         <translation>高级(&amp;A)</translation>
-    </message>
-    <message>
-        <source>Networking</source>
-        <translation>网络</translation>
     </message>
     <message>
         <source>Port</source>
@@ -1375,6 +1367,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;General</source>
         <translation>常规(&amp;G)</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>网络(&amp;N)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1153,10 +1153,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>首选项</translation>
     </message>
     <message>
-        <source>&amp;Regular</source>
-        <translation>常规(&amp;R)</translation>
-    </message>
-    <message>
         <source>App</source>
         <translation>应用程序</translation>
     </message>
@@ -1375,6 +1371,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&amp;Logs</source>
         <translation type="unfinished">日志(&amp;L)</translation>
+    </message>
+    <message>
+        <source>&amp;General</source>
+        <translation>常规(&amp;G)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1225,10 +1225,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>网络 IP</translation>
     </message>
     <message>
-        <source>Logs</source>
-        <translation>日志</translation>
-    </message>
-    <message>
         <source>Level</source>
         <translation>级别</translation>
     </message>
@@ -1267,10 +1263,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Log path</source>
         <translation>日志路径</translation>
-    </message>
-    <message>
-        <source>Log to file</source>
-        <translation>记录日志到文件</translation>
     </message>
     <message>
         <source>Using a Debug log level may affect performance. Only use a Debug level if you are attempting to debug an issue or are gathering logs to submit with a bug report.</source>
@@ -1375,6 +1367,14 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Include version in the window title</source>
         <translation type="unfinished">在窗口标题中包含版本信息</translation>
+    </message>
+    <message>
+        <source>Log to file</source>
+        <translation>记录日志到文件</translation>
+    </message>
+    <message>
+        <source>&amp;Logs</source>
+        <translation type="unfinished">日志(&amp;L)</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -175,7 +175,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Close and forget changes</source>
-        <translation type="unfinished">关闭并忘记更改</translation>
+        <translation>关闭并放弃修改</translation>
     </message>
     <message>
         <source>Reset to stored values</source>
@@ -1343,6 +1343,18 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Verbose debug output</source>
         <translation>详细调试输出</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>关闭并放弃修改</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">重置为存储值</translation>
     </message>
     <message>
         <source>Enable wl-clipboard support</source>


### PR DESCRIPTION
## Description
<!--- Describe your what your changes do -->
 - Adjust Layout for `SettingsDialog`
 - Add `reset` and `RestoreDefault` to `SettingsDialog`
 
<img width=50% alt="Screenshot_20260216_172545" src="https://github.com/user-attachments/assets/61471f08-4893-4f5b-acba-43ee14e73e54" />

<img width=50% alt="Screenshot_20260216_172642" src="https://github.com/user-attachments/assets/c96c6f21-10f2-415b-8c59-02b82d1e7a46" />

<img width=50% alt="Screenshot_20260216_172727" src="https://github.com/user-attachments/assets/e132d4cb-186c-451a-bbca-948dd20f493c" />

<img width=50% alt="Screenshot_20260216_172743" src="https://github.com/user-attachments/assets/0f535903-36e4-4ce5-aa30-9ef57915ba3b" />

**On windows `Advanced` shows the Daemon Options.**
**On macOS the `Advanced` tab is not visible**

## Disclosure of AI use
<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None, Google translate used to update translations

## Attn Translators, new strings please check 
  @sinuku, @levpr1c, @sailordiary, @albanobattistella
  - i18n(ja) strings updated by @ykasap 
## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

 - Run.