### PR TITLE
fix: Settings dialog blocking return to Automatic

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -31,8 +31,8 @@ SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfi
 
   ui->setupUi(this);
 
-  // no advanced options on macOS
-  if (deskflow::platform::isMac()) {
+  // hide advanced options on macOS and portable windows
+  if (deskflow::platform::isMac() || (deskflow::platform::isWindows() && Settings::isPortableMode())) {
     ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabAdvanced));
   }
 

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -84,6 +84,7 @@ private:
    */
   void setButtonBoxEnabledButtons() const;
 
+  bool m_interfaceSetOnLoad = false;
   std::unique_ptr<Ui::SettingsDialog> ui;
   const IServerConfig &m_serverConfig;
 };


### PR DESCRIPTION
## Description
<!--- Describe your what your changes do -->
ignore the interface changes being check as part of isModified when the settings was opened w/ the interface not set and its has not changed. 
 - Hide the Advanced tab on when portable windows 
## Disclosure of AI use
<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None
## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #9501
## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

Run play w/ interface settings.