### PR TITLE
fix: properly handling infinite timeout for macOS on EventQueue

### DIFF
--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -31,9 +31,10 @@ void OSXEventQueueBuffer::waitForEvent(double timeout)
 {
   std::unique_lock lock(m_mutex);
   if (m_dataQueue.empty()) {
-    auto duration = std::chrono::duration<double>(timeout);
     LOG_DEBUG2("waiting for event, timeout: %f seconds", timeout);
-    m_cond.wait_for(lock, duration, [this] { return !m_dataQueue.empty(); });
+    auto end = timeout < 0 ? std::chrono::steady_clock::time_point::max()
+                           : std::chrono::steady_clock::now() + std::chrono::duration<double>(timeout);
+    m_cond.wait_until(lock, end, [this] { return !m_dataQueue.empty(); });
   } else {
     LOG_DEBUG2("found events in the queue");
   }


### PR DESCRIPTION
## Description
Fixes an unhandled situation of a negative timeout for the `OSXEventQueueBuffer` variant of the Event Queue.

-1 should be handled as an infinite timeout, but it was leading to a busy loop on macOS.

Taking a closer look on libc++ implementation of condition_variable::wait_for:
```cpp
template <class _Rep, class _Period, class _Predicate>
inline bool
condition_variable::wait_for(unique_lock<mutex>& __lk, const chrono::duration<_Rep, _Period>& __d, _Predicate __pred) {
  return wait_until(__lk, chrono::steady_clock::now() + __d, std::move(__pred));
}
```
The implementation already uses `wait_until` + `now`, hence using it one level up will bring no real harm.

## Disclosure of AI use
No AI Used for this PR

## Related Issue
fixes: #9529

## How Has This Been Tested?
Tested on macOS Tahoe 26.3, closed the lid on the client and observed the CPU usage over ssh.
