### PR TITLE
Settings adjust

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -40,10 +40,13 @@
         <number>12</number>
        </property>
        <property name="topMargin">
-        <number>25</number>
+        <number>20</number>
        </property>
        <property name="rightMargin">
         <number>12</number>
+       </property>
+       <property name="bottomMargin">
+        <number>20</number>
        </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -152,10 +155,13 @@
         <number>12</number>
        </property>
        <property name="topMargin">
-        <number>25</number>
+        <number>20</number>
        </property>
        <property name="rightMargin">
         <number>12</number>
+       </property>
+       <property name="bottomMargin">
+        <number>20</number>
        </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -362,10 +368,13 @@
         <number>12</number>
        </property>
        <property name="topMargin">
-        <number>25</number>
+        <number>20</number>
        </property>
        <property name="rightMargin">
         <number>12</number>
+       </property>
+       <property name="bottomMargin">
+        <number>20</number>
        </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
@@ -659,10 +668,13 @@
         <number>12</number>
        </property>
        <property name="topMargin">
-        <number>25</number>
+        <number>20</number>
        </property>
        <property name="rightMargin">
         <number>12</number>
+       </property>
+       <property name="bottomMargin">
+        <number>20</number>
        </property>
        <item>
         <widget class="QGroupBox" name="groupService">

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -101,25 +101,25 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="QLabel" name="lblTrayIconStyle">
-           <property name="text">
-            <string>Tray icon style</string>
-           </property>
-          </widget>
-         </item>
-         <item>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="1" column="1">
           <widget class="QRadioButton" name="rbIconColorful">
            <property name="text">
             <string>Colorful</string>
            </property>
           </widget>
          </item>
-         <item>
+         <item row="0" column="1">
           <widget class="QRadioButton" name="rbIconMono">
            <property name="text">
             <string>Monocolor</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblTrayIconStyle">
+           <property name="text">
+            <string>Tray icon style</string>
            </property>
           </widget>
          </item>

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -46,29 +46,24 @@
         <number>12</number>
        </property>
        <item>
-        <widget class="QWidget" name="widgetLanguage" native="true">
-         <property name="toolTip">
-          <string>Force a language to be used for the GUI.</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="lblLanguage">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Language</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboLanguage"/>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="lblLanguage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Language</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboLanguage"/>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QCheckBox" name="cbAutoUpdate">

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1258,10 +1258,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation type="unfinished">Fuerza el uso de un idioma para la interfaz gráfica de usuario.</translation>
-    </message>
-    <message>
         <source>Enable GUI debug messages</source>
         <translation type="unfinished">Habilitar mensajes de depuración de la interfaz gráfica de usuario</translation>
     </message>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1258,10 +1258,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>Lingua</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation>Forza l&apos;utilizzo di una lingua per la GUI.</translation>
-    </message>
-    <message>
         <source>Enable GUI debug messages</source>
         <translation>Abilita i messaggi di debug della GUI</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1196,10 +1196,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>常にsystem権限で実行する(ログイン画面とUACで必要)</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation>GUIの使用言語を設定します。</translation>
-    </message>
-    <message>
         <source>Language</source>
         <translation>言語</translation>
     </message>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1194,10 +1194,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>항상 시스템 권한으로 실행(로그인 화면 및 UAC에서 동작)</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation>GUI에서 사용할 언어를 강제로 지정합니다.</translation>
-    </message>
-    <message>
         <source>Language</source>
         <translation>언어</translation>
     </message>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1192,10 +1192,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Всегда запускать от имени системы (работает на экране входа и UAC)</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation>Принудительно использовать язык для интерфейса.</translation>
-    </message>
-    <message>
         <source>Language</source>
         <translation>Язык</translation>
     </message>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1196,10 +1196,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished">始终以系统身份运行 (在登录屏幕和 UAC 下工作)</translation>
     </message>
     <message>
-        <source>Force a language to be used for the GUI.</source>
-        <translation>强制 GUI 使用特定语言。</translation>
-    </message>
-    <message>
         <source>Language</source>
         <translation>语言</translation>
     </message>


### PR DESCRIPTION
## Description
<!--- Describe your what your changes do -->
 - Adjust settings dialog language Combo to fix spacing in the label padding
 - Adjust layout for the tray icon selection 
 - Adjust layouts for tabs so they have a margin of 20 top and bottom, and 12 for Left/Right

Before
<img width=50% height="674" alt="Screenshot_20260228_142338" src="https://github.com/user-attachments/assets/45cddf61-347e-4ef6-9ee6-1942041472a4" />


After
<img width=50% height="691" alt="Screenshot_20260228_142126" src="https://github.com/user-attachments/assets/05ac1915-f023-4c11-8e25-7ba2793c72b0" />

## Disclosure of AI use
<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None
## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Language box contents pushed hard left w/o padding when in widget 
## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run the app