### PR TITLE
fix(win): handle dead-key overlap correctly and add integration regre…

### DIFF
--- a/src/lib/platform/MSWindowsDeadKeyUtils.h
+++ b/src/lib/platform/MSWindowsDeadKeyUtils.h
@@ -1,0 +1,183 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <Windows.h>
+
+namespace deskflow {
+namespace win32 {
+
+struct DeadKeyState
+{
+  WPARAM m_deadVirtKey = 0;
+  LPARAM m_deadLParam = 0;
+  WCHAR m_deadChar = 0;
+  BYTE m_deadKeyState[256] = {0};
+};
+
+enum class DeadKeyEventType
+{
+  KeyDown,
+  KeyUp
+};
+
+enum class DeadKeyAction
+{
+  StoreDead,
+  KeepPending,
+  ConsumeWithComposedChar,
+  ConsumeWithDeadFallback,
+  ConsumeBeforeNewCandidate,
+  NoDeadInteraction
+};
+
+struct DeadKeyTransitionInput
+{
+  DeadKeyEventType m_eventType = DeadKeyEventType::KeyDown;
+  int m_toUnicodeResult = 0;
+  UINT m_vk = 0;
+  UINT m_button = 0;
+  bool m_isModifierOrToggle = false;
+  bool m_hasPendingDead = false;
+  UINT m_deadOwnerButton = 0;
+};
+
+struct DeadKeyTransition
+{
+  DeadKeyAction m_action = DeadKeyAction::NoDeadInteraction;
+  bool m_setOwner = false;
+  bool m_clearOwner = false;
+  bool m_clearPending = false;
+  bool m_emitDeadFallback = false;
+  bool m_recomputeWithoutDead = false;
+};
+
+inline bool isModifierOrToggleVK(UINT vk)
+{
+  switch (vk) {
+  case VK_SHIFT:
+  case VK_LSHIFT:
+  case VK_RSHIFT:
+  case VK_CONTROL:
+  case VK_LCONTROL:
+  case VK_RCONTROL:
+  case VK_MENU:
+  case VK_LMENU:
+  case VK_RMENU:
+  case VK_LWIN:
+  case VK_RWIN:
+  case VK_CAPITAL:
+  case VK_NUMLOCK:
+  case VK_SCROLL:
+    return true;
+
+  default:
+    return false;
+  }
+}
+
+inline void sanitizeDeadKeyState(BYTE keys[256], UINT deadVK)
+{
+  BYTE sanitized[256] = {0};
+  for (UINT i = 0; i < 256; ++i) {
+    if (i == deadVK || isModifierOrToggleVK(i)) {
+      sanitized[i] = keys[i];
+    }
+  }
+
+  for (size_t i = 0; i < 256; ++i) {
+    keys[i] = sanitized[i];
+  }
+}
+
+inline bool shouldClearDeadKeyState(int toUnicodeResult, bool isKeyUpEvent)
+{
+  return (toUnicodeResult == 1 || toUnicodeResult == 2) && !isKeyUpEvent;
+}
+
+inline DeadKeyTransition decideDeadKeyTransition(const DeadKeyTransitionInput &input)
+{
+  const bool isKeyDown = (input.m_eventType == DeadKeyEventType::KeyDown);
+  const bool hasPendingDead = input.m_hasPendingDead;
+  const bool isModifierOrToggle = input.m_isModifierOrToggle;
+  const bool isOwnerButton = (input.m_deadOwnerButton != 0 && input.m_button == input.m_deadOwnerButton);
+
+  // Priority 1: a fresh dead key candidate was pressed.
+  // Store it immediately so subsequent key events can consume or fallback it.
+  // NOTE: order matters; this check must run before "no pending dead".
+  if (isKeyDown && input.m_toUnicodeResult < 0) {
+    return {DeadKeyAction::StoreDead, false, true, false, false, false};
+  }
+
+  // Priority 2: no dead key is pending, so this event does not interact with dead-key state.
+  if (!hasPendingDead) {
+    return {DeadKeyAction::NoDeadInteraction, false, false, false, false, false};
+  }
+
+  // Priority 3: key-up handling while a dead key is pending.
+  // If this key-up belongs to the owner button, force fallback and clear;
+  // otherwise keep pending for the next key-down.
+  if (!isKeyDown) {
+    if (isOwnerButton) {
+      return {DeadKeyAction::ConsumeWithDeadFallback, false, true, true, true, false};
+    }
+    return {DeadKeyAction::KeepPending, false, false, false, false, false};
+  }
+
+  // Priority 4: modifiers/toggles do not consume pending dead keys.
+  if (isModifierOrToggle) {
+    return {DeadKeyAction::KeepPending, false, false, false, false, false};
+  }
+
+  // Priority 5: key-down composition outcomes.
+  // result == 1: composed char produced (consume pending dead key).
+  if (input.m_toUnicodeResult == 1) {
+    return {DeadKeyAction::ConsumeWithComposedChar, false, true, true, false, false};
+  }
+
+  // result == 2: pending dead key did not compose with current key.
+  // Emit fallback for dead key and continue with current key.
+  if (input.m_toUnicodeResult == 2) {
+    return {DeadKeyAction::ConsumeWithDeadFallback, false, true, true, true, false};
+  }
+
+  // Priority 6: track ownership for overlap scenarios.
+  if (input.m_deadOwnerButton == 0) {
+    return {DeadKeyAction::KeepPending, true, false, false, false, false};
+  }
+
+  if (isOwnerButton) {
+    return {DeadKeyAction::KeepPending, false, false, false, false, false};
+  }
+
+  // Priority 7: overlap with a different key/button while dead is pending.
+  // Consume pending dead fallback first, clear dead state, then recompute.
+  return {DeadKeyAction::ConsumeBeforeNewCandidate, false, true, true, true, true};
+}
+
+inline void captureDeadKeyState(
+    DeadKeyState &state, WPARAM deadVirtKey, LPARAM deadLParam, const BYTE keys[256], WCHAR deadChar = 0
+)
+{
+  state.m_deadVirtKey = deadVirtKey;
+  state.m_deadLParam = deadLParam;
+  state.m_deadChar = deadChar;
+  for (size_t i = 0; i < 256; ++i) {
+    state.m_deadKeyState[i] = keys[i];
+  }
+  sanitizeDeadKeyState(state.m_deadKeyState, static_cast<UINT>(deadVirtKey));
+}
+
+inline void clearDeadKeyState(DeadKeyState &state)
+{
+  state.m_deadVirtKey = 0;
+  state.m_deadLParam = 0;
+  state.m_deadChar = 0;
+}
+
+} // namespace win32
+} // namespace deskflow

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -9,6 +9,7 @@
 #include "base/DirectionTypes.h"
 #include "base/Log.h"
 #include "deskflow/ScreenException.h"
+#include "platform/MSWindowsDeadKeyUtils.h"
 
 #ifndef WM_MOUSEHWHEEL
 #define WM_MOUSEHWHEEL 0x020E
@@ -35,6 +36,8 @@ struct DeadRuntimeState
   WPARAM m_virtKey = 0;
   WPARAM m_releaseVirtKey = 0;
   LPARAM m_lParam = 0;
+  WCHAR m_char = 0;
+  UINT m_ownerButton = 0;
   BYTE m_keyState[256] = {0};
 
   void reset()
@@ -42,6 +45,8 @@ struct DeadRuntimeState
     m_virtKey = 0;
     m_releaseVirtKey = 0;
     m_lParam = 0;
+    m_char = 0;
+    m_ownerButton = 0;
     for (size_t i = 0; i < 256; ++i) {
       m_keyState[i] = 0;
     }
@@ -222,6 +227,60 @@ static void setDeadKey(WCHAR wc[], int size, UINT flags)
   }
 }
 
+static void clearTrackedDeadKeyState(deskflow::win32::DeadKeyState &deadState, UINT flags)
+{
+  if (g_mode == kHOOK_RELAY_EVENTS) {
+    BYTE emptyState[256] = {0};
+    WCHAR unicode[2] = {0, 0};
+    constexpr UINT kFlushDeadComposeVk = VK_SPACE;
+    const UINT scanCode = MapVirtualKey(kFlushDeadComposeVk, MAPVK_VK_TO_VSC);
+    constexpr int kMaxFlushAttempts = 8;
+
+    // Relay mode owns the translated stream, so we must drain ToUnicode compose
+    // state here to avoid leaking a consumed dead key into the next key event.
+    for (int i = 0; i < kMaxFlushAttempts; ++i) {
+      if (ToUnicode(kFlushDeadComposeVk, scanCode, emptyState, unicode, 2, flags) >= 0) {
+        break;
+      }
+    }
+  }
+
+  deskflow::win32::clearDeadKeyState(deadState);
+  g_dead.reset();
+  g_dead.m_virtKey = deadState.m_deadVirtKey;
+  g_dead.m_lParam = deadState.m_deadLParam;
+  g_dead.m_char = deadState.m_deadChar;
+  for (size_t i = 0; i < 256; ++i) {
+    g_dead.m_keyState[i] = deadState.m_deadKeyState[i];
+  }
+}
+
+static deskflow::win32::DeadKeyState makeTrackedDeadKeyStateSnapshot()
+{
+  deskflow::win32::DeadKeyState deadState;
+  deadState.m_deadVirtKey = g_dead.m_virtKey;
+  deadState.m_deadLParam = g_dead.m_lParam;
+  deadState.m_deadChar = g_dead.m_char;
+  for (size_t i = 0; i < 256; ++i) {
+    deadState.m_deadKeyState[i] = g_dead.m_keyState[i];
+  }
+  return deadState;
+}
+
+static void storeCapturedDeadKeyState(
+    deskflow::win32::DeadKeyState &deadState, WPARAM wParam, LPARAM lParam, const BYTE keys[256], WCHAR deadChar
+)
+{
+  deskflow::win32::captureDeadKeyState(deadState, wParam, lParam, keys, deadChar);
+  g_dead.m_virtKey = deadState.m_deadVirtKey;
+  g_dead.m_lParam = deadState.m_deadLParam;
+  g_dead.m_char = deadState.m_deadChar;
+  g_dead.m_ownerButton = 0;
+  for (size_t i = 0; i < 256; ++i) {
+    g_dead.m_keyState[i] = deadState.m_deadKeyState[i];
+  }
+}
+
 static void normalizeControlAltForTranslation(BYTE keys[256], UINT &control, UINT &menu)
 {
   control = keys[VK_CONTROL] | keys[VK_LCONTROL] | keys[VK_RCONTROL];
@@ -257,47 +316,171 @@ struct TranslationResult
 };
 
 static TranslationResult translateToUnicodeWithAltGrFallback(
-    WPARAM wParam, LPARAM lParam, const BYTE keys[256], UINT flags, UINT control, UINT menu
+    WPARAM wParam, LPARAM lParam, const BYTE keys[256], UINT flags, UINT control, UINT menu, bool restorePendingDead
 )
 {
   TranslationResult result;
+  BYTE activeKeys[256];
+  for (size_t i = 0; i < 256; ++i) {
+    activeKeys[i] = keys[i];
+  }
 
-  // map the key event to a character.  we have to put the dead
-  // key back first and this has the side effect of removing it.
-  setDeadKey(result.m_chars, 2, flags);
+  if (restorePendingDead) {
+    setDeadKey(result.m_chars, 2, flags);
+  }
 
   const UINT scanCode = static_cast<UINT>((lParam & 0x10ff0000u) >> 16);
-  result.m_count = ToUnicode((UINT)wParam, scanCode, keys, result.m_chars, 2, flags);
+  result.m_count = ToUnicode((UINT)wParam, scanCode, activeKeys, result.m_chars, 2, flags);
 
-  // if mapping failed and ctrl and alt are pressed then try again
-  // with both not pressed.  this handles the case where ctrl and
-  // alt are being used as individual modifiers rather than AltGr.
-  // we note that's the case in the message sent back to deskflow
-  // because there's no simple way to deduce it after the fact.
-  // we have to put the dead key back first, if there was one.
   if (result.m_count == 0 && (control & 0x80) != 0 && (menu & 0x80) != 0) {
     result.m_noAltGr = true;
     PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x05000000, lParam);
-    setDeadKey(result.m_chars, 2, flags);
 
-    BYTE keys2[256];
-    for (size_t i = 0; i < sizeof(keys2) / sizeof(keys2[0]); ++i) {
-      keys2[i] = keys[i];
+    if (restorePendingDead) {
+      setDeadKey(result.m_chars, 2, flags);
     }
-    keys2[VK_LCONTROL] = 0;
-    keys2[VK_RCONTROL] = 0;
-    keys2[VK_CONTROL] = 0;
-    keys2[VK_LMENU] = 0;
-    keys2[VK_RMENU] = 0;
-    keys2[VK_MENU] = 0;
-    result.m_count = ToUnicode((UINT)wParam, scanCode, keys2, result.m_chars, 2, flags);
+
+    activeKeys[VK_LCONTROL] = 0;
+    activeKeys[VK_RCONTROL] = 0;
+    activeKeys[VK_CONTROL] = 0;
+    activeKeys[VK_LMENU] = 0;
+    activeKeys[VK_RMENU] = 0;
+    activeKeys[VK_MENU] = 0;
+    result.m_count = ToUnicode((UINT)wParam, scanCode, activeKeys, result.m_chars, 2, flags);
   }
 
   return result;
 }
 
+static bool keyboardHookHandlerLegacy(WPARAM wParam, LPARAM lParam)
+{
+  deskflow::win32::DeadKeyState deadState = makeTrackedDeadKeyStateSnapshot();
+
+  DWORD vkCode = static_cast<DWORD>(wParam);
+  bool kf_up = (lParam & (KF_UP << 16)) != 0;
+
+  if (wParam == DESKFLOW_HOOK_FAKE_INPUT_VIRTUAL_KEY && ((lParam >> 16) & 0xffu) == DESKFLOW_HOOK_FAKE_INPUT_SCANCODE) {
+    g_fakeServerInput = ((lParam & 0x80000000u) == 0);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, 0xff000000u | wParam, lParam);
+    return true;
+  }
+
+  if (g_fakeServerInput) {
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, 0xfe000000u | wParam, lParam);
+    return false;
+  }
+
+  if (wParam == VK_RSHIFT) {
+    lParam &= ~0x01000000u;
+  }
+
+  PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam, lParam);
+
+  if ((g_dead.m_virtKey == wParam || g_dead.m_releaseVirtKey == wParam) && (lParam & 0x80000000u) != 0) {
+    g_dead.m_releaseVirtKey = 0;
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x04000000, lParam);
+    return false;
+  }
+
+  BYTE keys[256];
+  keyboardGetState(keys, vkCode, kf_up);
+
+  UINT control = 0;
+  UINT menu = 0;
+  normalizeControlAltForTranslation(keys, control, menu);
+  UINT flags = getTranslationFlags(menu);
+
+  if (g_mode != kHOOK_RELAY_EVENTS) {
+    UINT sc = (lParam & 0x01ff0000u) >> 16;
+    if (menu && (sc >= 0x47u && sc <= 0x52u && sc != 0x4au && sc != 0x4eu)) {
+      return false;
+    }
+  }
+
+  TranslationResult translation = translateToUnicodeWithAltGrFallback(wParam, lParam, keys, flags, control, menu, true);
+  WCHAR *wc = translation.m_chars;
+  int n = translation.m_count;
+  bool noAltGr = translation.m_noAltGr;
+
+  PostThreadMessage(
+      g_threadID, DESKFLOW_MSG_DEBUG, (wc[0] & 0xffff) | ((wParam & 0xff) << 16) | ((n & 0xf) << 24) | 0x60000000,
+      lParam
+  );
+  WPARAM charAndVirtKey = 0;
+  bool clearDeadKey = false;
+  bool isKeyUpEvent = ((lParam & 0x80000000u) != 0);
+  switch (n) {
+  default:
+    if (isKeyUpEvent) {
+      break;
+    }
+    storeCapturedDeadKeyState(deadState, wParam, lParam, keys, wc[0]);
+    break;
+
+  case 0:
+    if (!isKeyUpEvent && g_dead.m_virtKey != 0 && g_dead.m_virtKey != wParam) {
+      WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_dead.m_virtKey, wc[0], noAltGr);
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam & 0x7fffffffu);
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam | 0x80000000u);
+      clearDeadKey = true;
+    }
+    charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    break;
+
+  case 1:
+    if (isKeyUpEvent) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    } else {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, wc[0], noAltGr);
+      clearDeadKey = deskflow::win32::shouldClearDeadKeyState(1, isKeyUpEvent);
+    }
+    break;
+
+  case 2: {
+    if (isKeyUpEvent) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    } else {
+      WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_dead.m_virtKey, wc[0], noAltGr);
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam & 0x7fffffffu);
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam | 0x80000000u);
+      charAndVirtKey = makeKeyMsg((UINT)wParam, wc[1], noAltGr);
+      clearDeadKey = deskflow::win32::shouldClearDeadKeyState(2, isKeyUpEvent);
+    }
+    break;
+  }
+  }
+
+  const bool keepDeadKeyForLocalApp = (g_mode != kHOOK_RELAY_EVENTS);
+  if (g_dead.m_virtKey != 0 && (!clearDeadKey || keepDeadKeyForLocalApp)) {
+    ToUnicode((UINT)g_dead.m_virtKey, (g_dead.m_lParam & 0x10ff0000u) >> 16, g_dead.m_keyState, wc, 2, flags);
+  }
+
+  if (clearDeadKey) {
+    clearTrackedDeadKeyState(deadState, flags);
+  }
+
+  if (charAndVirtKey != 0) {
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, charAndVirtKey | 0x07000000, lParam);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, charAndVirtKey, lParam);
+  }
+
+  return false;
+}
+
 static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
 {
+  if (g_mode != kHOOK_RELAY_EVENTS) {
+    return keyboardHookHandlerLegacy(wParam, lParam);
+  }
+
+  deskflow::win32::DeadKeyState deadState;
+  deadState.m_deadVirtKey = g_dead.m_virtKey;
+  deadState.m_deadLParam = g_dead.m_lParam;
+  deadState.m_deadChar = g_dead.m_char;
+  for (size_t i = 0; i < 256; ++i) {
+    deadState.m_deadKeyState[i] = g_dead.m_keyState[i];
+  }
+
   DWORD vkCode = static_cast<DWORD>(wParam);
   bool kf_up = (lParam & (KF_UP << 16)) != 0;
 
@@ -356,86 +539,132 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   // FIXME -- figure out some way to check if a menu is active
   UINT flags = getTranslationFlags(menu);
 
-  // if we're on the server screen then just pass numpad keys with alt
-  // key down as-is.  we won't pick up the resulting character but the
-  // local app will.  if on a client screen then grab keys as usual;
-  // if the client is a windows system it'll synthesize the expected
-  // character.  if not then it'll probably just do nothing.
-  if (g_mode != kHOOK_RELAY_EVENTS) {
-    // we don't use virtual keys because we don't know what the
-    // state of the numlock key is.  we'll hard code the scan codes
-    // instead.  hopefully this works across all keyboards.
-    UINT sc = (lParam & 0x01ff0000u) >> 16;
-    if (menu && (sc >= 0x47u && sc <= 0x52u && sc != 0x4au && sc != 0x4eu)) {
-      return false;
-    }
-  }
+  const bool isKeyUpEvent = ((lParam & 0x80000000u) != 0);
+  const UINT button = static_cast<UINT>((lParam & 0x01ff0000u) >> 16);
+  const bool hasPendingDead = (g_dead.m_virtKey != 0);
+  const bool isModifierOrToggle = deskflow::win32::isModifierOrToggleVK(static_cast<UINT>(wParam));
 
-  TranslationResult translation = translateToUnicodeWithAltGrFallback(wParam, lParam, keys, flags, control, menu);
-  WCHAR *wc = translation.m_chars;
-  int n = translation.m_count;
-  bool noAltGr = translation.m_noAltGr;
+  WCHAR wc[] = {0, 0};
+  bool noAltGr = false;
+  int n = 0;
+  bool translatedWithPendingDead = false;
+  if (!isKeyUpEvent) {
+    translatedWithPendingDead = hasPendingDead;
+    TranslationResult translation =
+        translateToUnicodeWithAltGrFallback(wParam, lParam, keys, flags, control, menu, hasPendingDead);
+    wc[0] = translation.m_chars[0];
+    wc[1] = translation.m_chars[1];
+    noAltGr = translation.m_noAltGr;
+    n = translation.m_count;
+  }
 
   PostThreadMessage(
       g_threadID, DESKFLOW_MSG_DEBUG, (wc[0] & 0xffff) | ((wParam & 0xff) << 16) | ((n & 0xf) << 24) | 0x60000000,
       lParam
   );
+
+  deskflow::win32::DeadKeyTransitionInput transitionInput;
+  transitionInput.m_eventType =
+      isKeyUpEvent ? deskflow::win32::DeadKeyEventType::KeyUp : deskflow::win32::DeadKeyEventType::KeyDown;
+  transitionInput.m_toUnicodeResult = n;
+  transitionInput.m_vk = static_cast<UINT>(wParam);
+  transitionInput.m_button = button;
+  transitionInput.m_isModifierOrToggle = isModifierOrToggle;
+  transitionInput.m_hasPendingDead = hasPendingDead;
+  transitionInput.m_deadOwnerButton = g_dead.m_ownerButton;
+  const auto transition = deskflow::win32::decideDeadKeyTransition(transitionInput);
+
+  if (transition.m_setOwner) {
+    g_dead.m_ownerButton = button;
+  }
+  if (transition.m_clearOwner) {
+    g_dead.m_ownerButton = 0;
+  }
+
+  auto emitPendingDeadFallback = [&](bool noAltGrFallback, WCHAR deadChar) {
+    if (g_dead.m_virtKey == 0) {
+      return;
+    }
+
+    const WCHAR effectiveDeadChar = (deadChar != 0) ? deadChar : g_dead.m_char;
+    WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_dead.m_virtKey, effectiveDeadChar, noAltGrFallback);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam & 0x7fffffffu);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam | 0x80000000u);
+  };
+
   WPARAM charAndVirtKey = 0;
-  bool clearDeadKey = false;
-  switch (n) {
-  default:
-    // key is a dead key
-
-    if (lParam & 0x80000000u)
-      // This handles the obscure situation where a key has been
-      // pressed which is both a dead key and a normal character
-      // depending on which modifiers have been pressed. We
-      // break here to prevent it from being considered a dead
-      // key.
-      break;
-
-    g_dead.m_virtKey = wParam;
-    g_dead.m_lParam = lParam;
-    for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
-      g_dead.m_keyState[i] = keys[i];
+  bool clearDeadAfterRestore = transition.m_clearPending;
+  using DeadKeyAction = deskflow::win32::DeadKeyAction;
+  switch (transition.m_action) {
+  case DeadKeyAction::StoreDead:
+    if (!isKeyUpEvent) {
+      storeCapturedDeadKeyState(deadState, wParam, lParam, keys, wc[0]);
     }
     break;
 
-  case 0:
-    // key doesn't map to a character.  this can happen if
-    // non-character keys are pressed after a dead key.
+  case DeadKeyAction::KeepPending:
     charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
     break;
 
-  case 1:
-    // key maps to a character composed with dead key
+  case DeadKeyAction::ConsumeWithComposedChar:
     charAndVirtKey = makeKeyMsg((UINT)wParam, wc[0], noAltGr);
-    clearDeadKey = true;
     break;
 
-  case 2: {
-    // previous dead key not composed.  send a fake key press
-    // and release for the dead key to our window.
-    WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_dead.m_virtKey, wc[0], noAltGr);
-    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam & 0x7fffffffu);
-    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam | 0x80000000u);
+  case DeadKeyAction::ConsumeWithDeadFallback:
+    emitPendingDeadFallback(noAltGr, wc[0]);
+    if (!isKeyUpEvent && n == 2) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, wc[1], noAltGr);
+    } else {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    }
+    break;
 
-    // use uncomposed character
-    charAndVirtKey = makeKeyMsg((UINT)wParam, wc[1], noAltGr);
-    clearDeadKey = true;
+  case DeadKeyAction::ConsumeBeforeNewCandidate: {
+    // A different key-down arrived while a dead key is pending; emit fallback for
+    // the pending dead key, clear compose state, then recompute translation cleanly.
+    emitPendingDeadFallback(noAltGr, g_dead.m_char);
+    clearTrackedDeadKeyState(deadState, flags);
+    translatedWithPendingDead = false;
+    clearDeadAfterRestore = false;
+
+    WCHAR recomputedWc[] = {0, 0};
+    TranslationResult recomputedTranslation =
+        translateToUnicodeWithAltGrFallback(wParam, lParam, keys, flags, control, menu, false);
+    recomputedWc[0] = recomputedTranslation.m_chars[0];
+    recomputedWc[1] = recomputedTranslation.m_chars[1];
+    const bool recomputedNoAltGr = recomputedTranslation.m_noAltGr;
+    const int recomputed = recomputedTranslation.m_count;
+    if (recomputed < 0) {
+      storeCapturedDeadKeyState(deadState, wParam, lParam, keys, recomputedWc[0]);
+    } else if (recomputed == 0) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, recomputedNoAltGr);
+    } else {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, recomputedWc[0], recomputedNoAltGr);
+    }
     break;
   }
+
+  case DeadKeyAction::NoDeadInteraction:
+    if (isKeyUpEvent) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    } else if (n == 0) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+    } else if (n > 0) {
+      charAndVirtKey = makeKeyMsg((UINT)wParam, wc[0], noAltGr);
+    }
+    break;
   }
 
-  // put back the dead key, if any, for the application to use
-  if (g_dead.m_virtKey != 0) {
+  // Local/server mode must preserve Windows' native compose behavior for the
+  // focused app. Relay mode must avoid restoring consumed dead state.
+  const bool keepDeadKeyForLocalApp = (g_mode != kHOOK_RELAY_EVENTS);
+  if (translatedWithPendingDead && g_dead.m_virtKey != 0 && (!clearDeadAfterRestore || keepDeadKeyForLocalApp)) {
     ToUnicode((UINT)g_dead.m_virtKey, (g_dead.m_lParam & 0x10ff0000u) >> 16, g_dead.m_keyState, wc, 2, flags);
   }
 
   // clear out old dead key state
-  if (clearDeadKey) {
-    g_dead.m_virtKey = 0;
-    g_dead.m_lParam = 0;
+  if (clearDeadAfterRestore) {
+    clearTrackedDeadKeyState(deadState, flags);
   }
 
   // forward message to our window.  do this whether or not we're

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -29,10 +29,26 @@ static int32_t g_xScreen = 0;
 static int32_t g_yScreen = 0;
 static int32_t g_wScreen = 0;
 static int32_t g_hScreen = 0;
-static WPARAM g_deadVirtKey = 0;
-static WPARAM g_deadRelease = 0;
-static LPARAM g_deadLParam = 0;
-static BYTE g_deadKeyState[256] = {0};
+
+struct DeadRuntimeState
+{
+  WPARAM m_virtKey = 0;
+  WPARAM m_releaseVirtKey = 0;
+  LPARAM m_lParam = 0;
+  BYTE m_keyState[256] = {0};
+
+  void reset()
+  {
+    m_virtKey = 0;
+    m_releaseVirtKey = 0;
+    m_lParam = 0;
+    for (size_t i = 0; i < 256; ++i) {
+      m_keyState[i] = 0;
+    }
+  }
+};
+
+static DeadRuntimeState g_dead;
 static BYTE g_keyState[256] = {0};
 static DWORD g_hookThread = 0;
 static bool g_fakeServerInput = false;
@@ -188,20 +204,20 @@ static WPARAM makeKeyMsg(UINT virtKey, WCHAR wc, bool noAltGr)
 
 static void setDeadKey(WCHAR wc[], int size, UINT flags)
 {
-  if (g_deadVirtKey != 0) {
-    auto virtualKey = static_cast<UINT>(g_deadVirtKey);
-    auto scanCode = static_cast<UINT>((g_deadLParam & 0x10ff0000u) >> 16);
-    if (ToUnicode(virtualKey, scanCode, g_deadKeyState, wc, size, flags) >= 2) {
+  if (g_dead.m_virtKey != 0) {
+    auto virtualKey = static_cast<UINT>(g_dead.m_virtKey);
+    auto scanCode = static_cast<UINT>((g_dead.m_lParam & 0x10ff0000u) >> 16);
+    if (ToUnicode(virtualKey, scanCode, g_dead.m_keyState, wc, size, flags) >= 2) {
       // If ToUnicode returned >=2, it means that we accidentally removed
       // a double dead key instead of restoring it. Thus, we call
       // ToUnicode again with the same parameters to restore the
       // internal dead key state.
-      ToUnicode(virtualKey, scanCode, g_deadKeyState, wc, size, flags);
+      ToUnicode(virtualKey, scanCode, g_dead.m_keyState, wc, size, flags);
 
-      // We need to keep track of this because g_deadVirtKey will be
+      // We need to keep track of this because g_dead.m_virtKey will be
       // cleared later on; this would cause the dead key release to
       // incorrectly restore the dead key state.
-      g_deadRelease = g_deadVirtKey;
+      g_dead.m_releaseVirtKey = g_dead.m_virtKey;
     }
   }
 }
@@ -241,8 +257,8 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam, lParam);
 
   // ignore dead key release
-  if ((g_deadVirtKey == wParam || g_deadRelease == wParam) && (lParam & 0x80000000u) != 0) {
-    g_deadRelease = 0;
+  if ((g_dead.m_virtKey == wParam || g_dead.m_releaseVirtKey == wParam) && (lParam & 0x80000000u) != 0) {
+    g_dead.m_releaseVirtKey = 0;
     PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x04000000, lParam);
     return false;
   }
@@ -345,10 +361,10 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
       // key.
       break;
 
-    g_deadVirtKey = wParam;
-    g_deadLParam = lParam;
+    g_dead.m_virtKey = wParam;
+    g_dead.m_lParam = lParam;
     for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
-      g_deadKeyState[i] = keys[i];
+      g_dead.m_keyState[i] = keys[i];
     }
     break;
 
@@ -367,9 +383,9 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   case 2: {
     // previous dead key not composed.  send a fake key press
     // and release for the dead key to our window.
-    WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_deadVirtKey, wc[0], noAltGr);
-    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_deadLParam & 0x7fffffffu);
-    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_deadLParam | 0x80000000u);
+    WPARAM deadCharAndVirtKey = makeKeyMsg((UINT)g_dead.m_virtKey, wc[0], noAltGr);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam & 0x7fffffffu);
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, deadCharAndVirtKey, g_dead.m_lParam | 0x80000000u);
 
     // use uncomposed character
     charAndVirtKey = makeKeyMsg((UINT)wParam, wc[1], noAltGr);
@@ -379,14 +395,14 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   }
 
   // put back the dead key, if any, for the application to use
-  if (g_deadVirtKey != 0) {
-    ToUnicode((UINT)g_deadVirtKey, (g_deadLParam & 0x10ff0000u) >> 16, g_deadKeyState, wc, 2, flags);
+  if (g_dead.m_virtKey != 0) {
+    ToUnicode((UINT)g_dead.m_virtKey, (g_dead.m_lParam & 0x10ff0000u) >> 16, g_dead.m_keyState, wc, 2, flags);
   }
 
   // clear out old dead key state
   if (clearDeadKey) {
-    g_deadVirtKey = 0;
-    g_deadLParam = 0;
+    g_dead.m_virtKey = 0;
+    g_dead.m_lParam = 0;
   }
 
   // forward message to our window.  do this whether or not we're
@@ -610,8 +626,7 @@ EHookResult MSWindowsHook::install()
   }
 
   // discard old dead keys
-  g_deadVirtKey = 0;
-  g_deadLParam = 0;
+  g_dead.reset();
 
   // reset fake input flag
   g_fakeServerInput = false;
@@ -654,8 +669,7 @@ EHookResult MSWindowsHook::install()
 int MSWindowsHook::uninstall()
 {
   // discard old dead keys
-  g_deadVirtKey = 0;
-  g_deadLParam = 0;
+  g_dead.reset();
 
   // uninstall hooks
   if (g_keyboardLL != nullptr) {

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -222,6 +222,80 @@ static void setDeadKey(WCHAR wc[], int size, UINT flags)
   }
 }
 
+static void normalizeControlAltForTranslation(BYTE keys[256], UINT &control, UINT &menu)
+{
+  control = keys[VK_CONTROL] | keys[VK_LCONTROL] | keys[VK_RCONTROL];
+  menu = keys[VK_MENU] | keys[VK_LMENU] | keys[VK_RMENU];
+  if ((control & 0x80) == 0 || (menu & 0x80) == 0) {
+    keys[VK_LCONTROL] = 0;
+    keys[VK_RCONTROL] = 0;
+    keys[VK_CONTROL] = 0;
+  } else {
+    keys[VK_LCONTROL] = 0x80;
+    keys[VK_RCONTROL] = 0x80;
+    keys[VK_CONTROL] = 0x80;
+    keys[VK_LMENU] = 0x80;
+    keys[VK_RMENU] = 0x80;
+    keys[VK_MENU] = 0x80;
+  }
+}
+
+static UINT getTranslationFlags(UINT menu)
+{
+  UINT flags = 0;
+  if ((menu & 0x80) != 0) {
+    flags |= 1;
+  }
+  return flags;
+}
+
+struct TranslationResult
+{
+  int m_count = 0;
+  WCHAR m_chars[2] = {0, 0};
+  bool m_noAltGr = false;
+};
+
+static TranslationResult translateToUnicodeWithAltGrFallback(
+    WPARAM wParam, LPARAM lParam, const BYTE keys[256], UINT flags, UINT control, UINT menu
+)
+{
+  TranslationResult result;
+
+  // map the key event to a character.  we have to put the dead
+  // key back first and this has the side effect of removing it.
+  setDeadKey(result.m_chars, 2, flags);
+
+  const UINT scanCode = static_cast<UINT>((lParam & 0x10ff0000u) >> 16);
+  result.m_count = ToUnicode((UINT)wParam, scanCode, keys, result.m_chars, 2, flags);
+
+  // if mapping failed and ctrl and alt are pressed then try again
+  // with both not pressed.  this handles the case where ctrl and
+  // alt are being used as individual modifiers rather than AltGr.
+  // we note that's the case in the message sent back to deskflow
+  // because there's no simple way to deduce it after the fact.
+  // we have to put the dead key back first, if there was one.
+  if (result.m_count == 0 && (control & 0x80) != 0 && (menu & 0x80) != 0) {
+    result.m_noAltGr = true;
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x05000000, lParam);
+    setDeadKey(result.m_chars, 2, flags);
+
+    BYTE keys2[256];
+    for (size_t i = 0; i < sizeof(keys2) / sizeof(keys2[0]); ++i) {
+      keys2[i] = keys[i];
+    }
+    keys2[VK_LCONTROL] = 0;
+    keys2[VK_RCONTROL] = 0;
+    keys2[VK_CONTROL] = 0;
+    keys2[VK_LMENU] = 0;
+    keys2[VK_RMENU] = 0;
+    keys2[VK_MENU] = 0;
+    result.m_count = ToUnicode((UINT)wParam, scanCode, keys2, result.m_chars, 2, flags);
+  }
+
+  return result;
+}
+
 static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
 {
   DWORD vkCode = static_cast<DWORD>(wParam);
@@ -271,29 +345,16 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   // and ctrl+backspace to delete.  we don't want those translations
   // so clear the control modifier state.  however, if we want to
   // simulate AltGr (which is ctrl+alt) then we must not clear it.
-  UINT control = keys[VK_CONTROL] | keys[VK_LCONTROL] | keys[VK_RCONTROL];
-  UINT menu = keys[VK_MENU] | keys[VK_LMENU] | keys[VK_RMENU];
-  if ((control & 0x80) == 0 || (menu & 0x80) == 0) {
-    keys[VK_LCONTROL] = 0;
-    keys[VK_RCONTROL] = 0;
-    keys[VK_CONTROL] = 0;
-  } else {
-    keys[VK_LCONTROL] = 0x80;
-    keys[VK_RCONTROL] = 0x80;
-    keys[VK_CONTROL] = 0x80;
-    keys[VK_LMENU] = 0x80;
-    keys[VK_RMENU] = 0x80;
-    keys[VK_MENU] = 0x80;
-  }
+  UINT control = 0;
+  UINT menu = 0;
+  normalizeControlAltForTranslation(keys, control, menu);
 
   // ToAscii() needs to know if a menu is active for some reason.
   // we don't know and there doesn't appear to be any way to find
   // out.  so we'll just assume a menu is active if the menu key
   // is down.
   // FIXME -- figure out some way to check if a menu is active
-  UINT flags = 0;
-  if ((menu & 0x80) != 0)
-    flags |= 1;
+  UINT flags = getTranslationFlags(menu);
 
   // if we're on the server screen then just pass numpad keys with alt
   // key down as-is.  we won't pick up the resulting character but the
@@ -310,38 +371,10 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
     }
   }
 
-  // map the key event to a character.  we have to put the dead
-  // key back first and this has the side effect of removing it.
-  WCHAR wc[] = {0, 0};
-  setDeadKey(wc, 2, flags);
-
-  UINT scanCode = ((lParam & 0x10ff0000u) >> 16);
-  int n = ToUnicode((UINT)wParam, scanCode, keys, wc, 2, flags);
-
-  // if mapping failed and ctrl and alt are pressed then try again
-  // with both not pressed.  this handles the case where ctrl and
-  // alt are being used as individual modifiers rather than AltGr.
-  // we note that's the case in the message sent back to deskflow
-  // because there's no simple way to deduce it after the fact.
-  // we have to put the dead key back first, if there was one.
-  bool noAltGr = false;
-  if (n == 0 && (control & 0x80) != 0 && (menu & 0x80) != 0) {
-    noAltGr = true;
-    PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x05000000, lParam);
-    setDeadKey(wc, 2, flags);
-
-    BYTE keys2[256];
-    for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
-      keys2[i] = keys[i];
-    }
-    keys2[VK_LCONTROL] = 0;
-    keys2[VK_RCONTROL] = 0;
-    keys2[VK_CONTROL] = 0;
-    keys2[VK_LMENU] = 0;
-    keys2[VK_RMENU] = 0;
-    keys2[VK_MENU] = 0;
-    n = ToUnicode((UINT)wParam, scanCode, keys2, wc, 2, flags);
-  }
+  TranslationResult translation = translateToUnicodeWithAltGrFallback(wParam, lParam, keys, flags, control, menu);
+  WCHAR *wc = translation.m_chars;
+  int n = translation.m_count;
+  bool noAltGr = translation.m_noAltGr;
 
   PostThreadMessage(
       g_threadID, DESKFLOW_MSG_DEBUG, (wc[0] & 0xffff) | ((wParam & 0xff) << 16) | ((n & 0xf) << 24) | 0x60000000,

--- a/src/unittests/platform/CMakeLists.txt
+++ b/src/unittests/platform/CMakeLists.txt
@@ -9,6 +9,13 @@ if (WIN32)
     SOURCE MSWindowsClipboardTests.cpp
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
   )
+  create_test(
+    NAME MSWindowsHookIntegrationTests
+    DEPENDS platform
+    LIBS base arch app
+    SOURCE MSWindowsHookIntegrationTests.cpp
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
+  )
 elseif(APPLE)
   create_test(
     NAME OSXClipboardTests

--- a/src/unittests/platform/MSWindowsHookIntegrationTests.cpp
+++ b/src/unittests/platform/MSWindowsHookIntegrationTests.cpp
@@ -1,0 +1,771 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "MSWindowsHookIntegrationTests.h"
+
+#include "platform/MSWindowsHook.h"
+
+#include <Windows.h>
+
+#include <QElapsedTimer>
+#include <QList>
+#include <QString>
+#include <QTest>
+#include <QVector>
+#include <QtGlobal>
+#include <cwctype>
+#include <initializer_list>
+#include <utility>
+
+namespace {
+
+struct ComposePair
+{
+  UINT deadVK = 0;
+  UINT composeVK = 0;
+  WCHAR composed = 0;
+};
+
+struct DeadKeyAoPair
+{
+  UINT deadVK = 0;
+  WCHAR composedA = 0;
+  WCHAR composedO = 0;
+};
+
+struct AltGrPair
+{
+  UINT vk = 0;
+  WCHAR expectedChar = 0;
+};
+
+struct KeyDownEvent
+{
+  UINT vk = 0;
+  WCHAR wc = 0;
+  bool noAltGr = false;
+};
+
+class ScopedKeyboardLayout
+{
+public:
+  explicit ScopedKeyboardLayout(HKL layout) : m_previous(GetKeyboardLayout(0))
+  {
+    if (layout != nullptr) {
+      const HKL activationResult = ActivateKeyboardLayout(layout, 0);
+      if (activationResult != nullptr) {
+        m_active = GetKeyboardLayout(0);
+      }
+    }
+  }
+
+  ~ScopedKeyboardLayout()
+  {
+    if (m_previous != nullptr) {
+      ActivateKeyboardLayout(m_previous, 0);
+    }
+  }
+
+  HKL activeLayout() const
+  {
+    return m_active;
+  }
+
+private:
+  HKL m_previous = nullptr;
+  HKL m_active = nullptr;
+};
+
+QString formatLayoutRowName(HKL layout)
+{
+  return QStringLiteral("layout_%1").arg(static_cast<qulonglong>(reinterpret_cast<quintptr>(layout)), 0, 16);
+}
+
+void addInstalledLayoutsAsTestRows()
+{
+  QTest::addColumn<quintptr>("layoutValue");
+
+  const int count = GetKeyboardLayoutList(0, nullptr);
+  QVERIFY2(count > 0, "No keyboard layouts are loaded for the current process");
+
+  QVector<HKL> layouts(count);
+  const int loaded = GetKeyboardLayoutList(count, layouts.data());
+  QVERIFY2(loaded > 0, "Failed to enumerate keyboard layouts");
+
+  for (int i = 0; i < loaded; ++i) {
+    const auto rowName = formatLayoutRowName(layouts[i]).toLocal8Bit();
+    QTest::newRow(rowName.constData()) << static_cast<quintptr>(reinterpret_cast<quintptr>(layouts[i]));
+  }
+}
+
+void flushDeadKeyBuffer(HKL layout)
+{
+  BYTE emptyState[256] = {0};
+  WCHAR unicode[4] = {0};
+  while (ToUnicodeEx(VK_SPACE, MapVirtualKeyEx(VK_SPACE, MAPVK_VK_TO_VSC, layout), emptyState, unicode, 4, 0, layout) <
+         0) {
+  }
+}
+
+bool findDeadComposePair(ComposePair &pair)
+{
+  const HKL layout = GetKeyboardLayout(0);
+  if (layout == nullptr) {
+    return false;
+  }
+
+  const UINT deadCandidates[] = {VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7};
+  const UINT composeCandidates[] = {'A', 'E', 'I', 'O', 'U', 'N', 'C'};
+
+  for (const UINT deadVK : deadCandidates) {
+    flushDeadKeyBuffer(layout);
+
+    BYTE deadState[256] = {0};
+    deadState[deadVK] = 0x80;
+    WCHAR unicode[4] = {0};
+    const UINT deadScan = MapVirtualKeyEx(deadVK, MAPVK_VK_TO_VSC, layout);
+    const int deadResult = ToUnicodeEx(deadVK, deadScan, deadState, unicode, 4, 0, layout);
+    if (deadResult >= 0) {
+      continue;
+    }
+
+    for (const UINT composeVK : composeCandidates) {
+      BYTE composeState[256] = {0};
+      composeState[composeVK] = 0x80;
+      WCHAR composedOut[4] = {0};
+      const UINT composeScan = MapVirtualKeyEx(composeVK, MAPVK_VK_TO_VSC, layout);
+      const int composeResult = ToUnicodeEx(composeVK, composeScan, composeState, composedOut, 4, 0, layout);
+
+      flushDeadKeyBuffer(layout);
+
+      if (composeResult == 1 && composedOut[0] != 0) {
+        pair.deadVK = deadVK;
+        pair.composeVK = composeVK;
+        pair.composed = composedOut[0];
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+bool composeWithDeadKey(HKL layout, UINT deadVK, UINT composeVK, WCHAR &resultChar)
+{
+  flushDeadKeyBuffer(layout);
+
+  BYTE deadState[256] = {0};
+  deadState[deadVK] = 0x80;
+  WCHAR temp[4] = {0};
+  const UINT deadScan = MapVirtualKeyEx(deadVK, MAPVK_VK_TO_VSC, layout);
+  const int deadResult = ToUnicodeEx(deadVK, deadScan, deadState, temp, 4, 0, layout);
+  if (deadResult >= 0) {
+    flushDeadKeyBuffer(layout);
+    return false;
+  }
+
+  BYTE composeState[256] = {0};
+  composeState[composeVK] = 0x80;
+  WCHAR composedOut[4] = {0};
+  const UINT composeScan = MapVirtualKeyEx(composeVK, MAPVK_VK_TO_VSC, layout);
+  const int composeResult = ToUnicodeEx(composeVK, composeScan, composeState, composedOut, 4, 0, layout);
+  flushDeadKeyBuffer(layout);
+
+  if (composeResult == 1 && composedOut[0] != 0) {
+    resultChar = composedOut[0];
+    return true;
+  }
+  return false;
+}
+
+bool findDeadKeyForAoComposition(DeadKeyAoPair &pair)
+{
+  const HKL layout = GetKeyboardLayout(0);
+  if (layout == nullptr) {
+    return false;
+  }
+
+  const UINT deadCandidates[] = {VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7};
+  for (const UINT deadVK : deadCandidates) {
+    WCHAR composedA = 0;
+    WCHAR composedO = 0;
+    if (!composeWithDeadKey(layout, deadVK, 'A', composedA)) {
+      continue;
+    }
+    if (!composeWithDeadKey(layout, deadVK, 'O', composedO)) {
+      continue;
+    }
+
+    if (std::towlower(composedA) == L'a' || std::towlower(composedO) == L'o') {
+      continue;
+    }
+
+    pair.deadVK = deadVK;
+    pair.composedA = composedA;
+    pair.composedO = composedO;
+    return true;
+  }
+
+  return false;
+}
+
+bool isPrintableChar(WCHAR wc)
+{
+  return wc >= 0x20 && wc != 0x7f;
+}
+
+int translateVkWithModifiers(HKL layout, UINT vk, bool ctrl, bool alt, WCHAR out[2])
+{
+  BYTE state[256] = {0};
+  if (ctrl) {
+    state[VK_CONTROL] = 0x80;
+    state[VK_LCONTROL] = 0x80;
+  }
+  if (alt) {
+    state[VK_MENU] = 0x80;
+    state[VK_RMENU] = 0x80;
+  }
+
+  const UINT scan = MapVirtualKeyEx(vk, MAPVK_VK_TO_VSC, layout);
+  return ToUnicodeEx(vk, scan, state, out, 2, 0, layout);
+}
+
+bool findAltGrMappedPrintablePair(AltGrPair &pair)
+{
+  const HKL layout = GetKeyboardLayout(0);
+  if (layout == nullptr) {
+    return false;
+  }
+
+  const UINT candidates[] = {
+      '0', '1', '2', '3', '4', '5', '6',      '7',      '8',      '9',      'A',      'B',      'C',      'D',      'E',
+      'F', 'G', 'H', 'I', 'J', 'K', 'L',      'M',      'N',      'O',      'P',      'Q',      'R',      'S',      'T',
+      'U', 'V', 'W', 'X', 'Y', 'Z', VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8,
+  };
+
+  for (const UINT vk : candidates) {
+    flushDeadKeyBuffer(layout);
+
+    WCHAR plain[2] = {0, 0};
+    const int plainCount = translateVkWithModifiers(layout, vk, false, false, plain);
+    if (plainCount < 0) {
+      flushDeadKeyBuffer(layout);
+      continue;
+    }
+
+    WCHAR altGr[2] = {0, 0};
+    const int altGrCount = translateVkWithModifiers(layout, vk, true, true, altGr);
+    flushDeadKeyBuffer(layout);
+
+    if (altGrCount != 1 || !isPrintableChar(altGr[0])) {
+      continue;
+    }
+
+    if (plainCount == 1 && plain[0] == altGr[0]) {
+      continue;
+    }
+
+    pair.vk = vk;
+    pair.expectedChar = altGr[0];
+    return true;
+  }
+
+  return false;
+}
+
+bool findCtrlAltFallbackPair(AltGrPair &pair)
+{
+  const HKL layout = GetKeyboardLayout(0);
+  if (layout == nullptr) {
+    return false;
+  }
+
+  const UINT candidates[] = {
+      '0', '1', '2', '3', '4', '5', '6',      '7',      '8',      '9',      'A',      'B',      'C',      'D',      'E',
+      'F', 'G', 'H', 'I', 'J', 'K', 'L',      'M',      'N',      'O',      'P',      'Q',      'R',      'S',      'T',
+      'U', 'V', 'W', 'X', 'Y', 'Z', VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8,
+  };
+
+  for (const UINT vk : candidates) {
+    flushDeadKeyBuffer(layout);
+
+    WCHAR plain[2] = {0, 0};
+    const int plainCount = translateVkWithModifiers(layout, vk, false, false, plain);
+    if (plainCount != 1 || !isPrintableChar(plain[0])) {
+      flushDeadKeyBuffer(layout);
+      continue;
+    }
+
+    WCHAR altGr[2] = {0, 0};
+    const int altGrCount = translateVkWithModifiers(layout, vk, true, true, altGr);
+    flushDeadKeyBuffer(layout);
+
+    if (altGrCount != 0) {
+      continue;
+    }
+
+    pair.vk = vk;
+    pair.expectedChar = plain[0];
+    return true;
+  }
+
+  return false;
+}
+
+INPUT makeKeyInput(WORD vk, bool keyUp)
+{
+  INPUT in = {};
+  in.type = INPUT_KEYBOARD;
+  in.ki.wVk = vk;
+  in.ki.dwFlags = keyUp ? KEYEVENTF_KEYUP : 0;
+  return in;
+}
+
+void sendKey(WORD vk, bool keyUp)
+{
+  INPUT in = makeKeyInput(vk, keyUp);
+  (void)SendInput(1, &in, sizeof(INPUT));
+}
+
+QList<MSG> collectHookMessages(UINT target, int timeoutMs)
+{
+  QList<MSG> out;
+  QElapsedTimer timer;
+  timer.start();
+
+  while (timer.elapsed() < timeoutMs) {
+    MSG msg;
+    bool gotOne = false;
+    while (PeekMessage(&msg, nullptr, DESKFLOW_MSG_INPUT_FIRST, DESKFLOW_HOOK_LAST_MSG, PM_REMOVE)) {
+      gotOne = true;
+      if (msg.message == target) {
+        out.push_back(msg);
+      }
+    }
+    if (!gotOne) {
+      QTest::qWait(5);
+    }
+  }
+
+  return out;
+}
+
+void clearHookMessageQueue()
+{
+  MSG pending;
+  while (PeekMessage(&pending, nullptr, DESKFLOW_MSG_INPUT_FIRST, DESKFLOW_HOOK_LAST_MSG, PM_REMOVE)) {
+  }
+}
+
+void runSequence(const std::initializer_list<std::pair<WORD, bool>> &sequence)
+{
+  for (const auto &event : sequence) {
+    sendKey(event.first, event.second);
+  }
+}
+
+bool containsComposedCharacter(const QList<MSG> &keyMsgs, WCHAR composed)
+{
+  for (const auto &msg : keyMsgs) {
+    const WCHAR wc = static_cast<WCHAR>(LOWORD(msg.wParam));
+    if (wc == composed) {
+      return true;
+    }
+  }
+  return false;
+}
+
+QList<WCHAR> extractKeyDownChars(const QList<MSG> &keyMsgs)
+{
+  QList<WCHAR> chars;
+  for (const auto &msg : keyMsgs) {
+    const bool isKeyUp = (msg.lParam & 0x80000000u) != 0;
+    if (isKeyUp) {
+      continue;
+    }
+    const WCHAR wc = static_cast<WCHAR>(LOWORD(msg.wParam));
+    if (wc != 0) {
+      chars.push_back(wc);
+    }
+  }
+  return chars;
+}
+
+QString charsToDebugString(const QList<WCHAR> &chars)
+{
+  QString out;
+  for (const auto c : chars) {
+    if (!out.isEmpty()) {
+      out += ' ';
+    }
+    out += QStringLiteral("U+%1").arg(static_cast<unsigned int>(c), 4, 16, QLatin1Char('0')).toUpper();
+    out += QStringLiteral("('");
+    out += QChar(c);
+    out += QStringLiteral("')");
+  }
+  return out;
+}
+
+QList<KeyDownEvent> extractKeyDownEvents(const QList<MSG> &keyMsgs)
+{
+  QList<KeyDownEvent> events;
+  for (const auto &msg : keyMsgs) {
+    const bool isKeyUp = (msg.lParam & 0x80000000u) != 0;
+    if (isKeyUp) {
+      continue;
+    }
+
+    const auto hiWord = static_cast<WORD>(HIWORD(msg.wParam));
+    KeyDownEvent event;
+    event.vk = LOBYTE(hiWord);
+    event.noAltGr = HIBYTE(hiWord) != 0;
+    event.wc = static_cast<WCHAR>(LOWORD(msg.wParam));
+    events.push_back(event);
+  }
+  return events;
+}
+
+void assertSequenceProducesComposed(
+    const ComposePair &pair, const std::initializer_list<std::pair<WORD, bool>> &sequence
+)
+{
+  clearHookMessageQueue();
+
+  MSWindowsHook hook;
+  hook.loadLibrary();
+  hook.setMode(kHOOK_RELAY_EVENTS);
+  const auto installResult = MSWindowsHook::install();
+  QVERIFY2(installResult != kHOOK_FAILED, "Failed to install low-level Windows hook");
+
+  runSequence(sequence);
+
+  const auto keyMsgs = collectHookMessages(DESKFLOW_MSG_KEY, 350);
+  MSWindowsHook::uninstall();
+
+  const bool composedSeen = containsComposedCharacter(keyMsgs, pair.composed);
+  QVERIFY2(composedSeen, "Expected composed character from dead-key sequence was not observed");
+}
+
+} // namespace
+
+void MSWindowsHookIntegrationTests::deadKeyIsPreservedAcrossUnrelatedKeyUpUntilNextComposeKeyDown_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::deadKeyIsPreservedAcrossUnrelatedKeyUpUntilNextComposeKeyDown()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  ComposePair pair;
+  if (!findDeadComposePair(pair)) {
+    QSKIP("No suitable dead-key + compose-key pair found for current keyboard layout");
+  }
+  assertSequenceProducesComposed(
+      pair, {{'N', false},
+             {static_cast<WORD>(pair.deadVK), false},
+             {'N', true},
+             {static_cast<WORD>(pair.composeVK), false},
+             {static_cast<WORD>(pair.composeVK), true},
+             {static_cast<WORD>(pair.deadVK), true}}
+  );
+}
+
+void MSWindowsHookIntegrationTests::deadKeyCompose_whenDeadReleasedBeforeComposeKeyDown_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::deadKeyCompose_whenDeadReleasedBeforeComposeKeyDown()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  ComposePair pair;
+  if (!findDeadComposePair(pair)) {
+    QSKIP("No suitable dead-key + compose-key pair found for current keyboard layout");
+  }
+  assertSequenceProducesComposed(
+      pair, {{'N', false},
+             {static_cast<WORD>(pair.deadVK), false},
+             {'N', true},
+             {static_cast<WORD>(pair.deadVK), true},
+             {static_cast<WORD>(pair.composeVK), false},
+             {static_cast<WORD>(pair.composeVK), true}}
+  );
+}
+
+void MSWindowsHookIntegrationTests::deadKeyCompose_whenDeadReleasedBetweenComposeKeyDownAndUp_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::deadKeyCompose_whenDeadReleasedBetweenComposeKeyDownAndUp()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  ComposePair pair;
+  if (!findDeadComposePair(pair)) {
+    QSKIP("No suitable dead-key + compose-key pair found for current keyboard layout");
+  }
+  assertSequenceProducesComposed(
+      pair, {{'N', false},
+             {static_cast<WORD>(pair.deadVK), false},
+             {'N', true},
+             {static_cast<WORD>(pair.composeVK), false},
+             {static_cast<WORD>(pair.deadVK), true},
+             {static_cast<WORD>(pair.composeVK), true}}
+  );
+}
+
+void MSWindowsHookIntegrationTests::deadKeyDoesNotLeakToNextCharacter_afterCompose_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::deadKeyDoesNotLeakToNextCharacter_afterCompose()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  DeadKeyAoPair pair;
+  if (!findDeadKeyForAoComposition(pair)) {
+    QSKIP("No suitable dead-key that composes with both A and O in current keyboard layout");
+  }
+
+  clearHookMessageQueue();
+
+  MSWindowsHook hook;
+  hook.loadLibrary();
+  hook.setMode(kHOOK_RELAY_EVENTS);
+  const auto installResult = MSWindowsHook::install();
+  QVERIFY2(installResult != kHOOK_FAILED, "Failed to install low-level Windows hook");
+
+  runSequence({
+      {'N', false},
+      {static_cast<WORD>(pair.deadVK), false},
+      {'N', true},
+      {'A', false},
+      {'A', true},
+      {'O', false},
+      {'O', true},
+      {static_cast<WORD>(pair.deadVK), true},
+  });
+
+  const auto keyMsgs = collectHookMessages(DESKFLOW_MSG_KEY, 350);
+  MSWindowsHook::uninstall();
+
+  const auto keyDownChars = extractKeyDownChars(keyMsgs);
+  const WCHAR composedA = static_cast<WCHAR>(std::towlower(pair.composedA));
+  const WCHAR composedO = static_cast<WCHAR>(std::towlower(pair.composedO));
+
+  int indexComposedA = -1;
+  for (int i = 0; i < keyDownChars.size(); ++i) {
+    if (std::towlower(keyDownChars[i]) == composedA) {
+      indexComposedA = i;
+      break;
+    }
+  }
+  QVERIFY2(indexComposedA >= 0, "Expected composed A not observed (relay mode)");
+
+  bool plainOAfterCompose = false;
+  bool composedOAfterCompose = false;
+  for (int i = indexComposedA + 1; i < keyDownChars.size(); ++i) {
+    const WCHAR c = static_cast<WCHAR>(std::towlower(keyDownChars[i]));
+    if (c == L'o') {
+      plainOAfterCompose = true;
+    }
+    if (c == composedO) {
+      composedOAfterCompose = true;
+    }
+  }
+
+  QVERIFY2(plainOAfterCompose, "Expected plain 'o' not observed (relay mode)");
+  QVERIFY2(!composedOAfterCompose, "Dead key leaked to O (relay mode)");
+}
+
+void MSWindowsHookIntegrationTests::deadKeyDoesNotLeak_whenNextKeyDownBeforeComposeKeyUp_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::deadKeyDoesNotLeak_whenNextKeyDownBeforeComposeKeyUp()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  DeadKeyAoPair pair;
+  if (!findDeadKeyForAoComposition(pair)) {
+    QSKIP("No suitable dead-key that composes with both A and O in current keyboard layout");
+  }
+
+  clearHookMessageQueue();
+
+  MSWindowsHook hook;
+  hook.loadLibrary();
+  hook.setMode(kHOOK_RELAY_EVENTS);
+  const auto installResult = MSWindowsHook::install();
+  QVERIFY2(installResult != kHOOK_FAILED, "Failed to install low-level Windows hook");
+
+  runSequence({
+      {'N', false},
+      {static_cast<WORD>(pair.deadVK), false},
+      {'N', true},
+      {'A', false},
+      {static_cast<WORD>(pair.deadVK), true},
+      {'O', false},
+      {'A', true},
+      {'O', true},
+  });
+
+  const auto keyMsgs = collectHookMessages(DESKFLOW_MSG_KEY, 350);
+  MSWindowsHook::uninstall();
+
+  const auto keyDownChars = extractKeyDownChars(keyMsgs);
+  const WCHAR composedA = static_cast<WCHAR>(std::towlower(pair.composedA));
+  const WCHAR composedO = static_cast<WCHAR>(std::towlower(pair.composedO));
+
+  int indexComposedA = -1;
+  for (int i = 0; i < keyDownChars.size(); ++i) {
+    if (std::towlower(keyDownChars[i]) == composedA) {
+      indexComposedA = i;
+      break;
+    }
+  }
+  QVERIFY2(indexComposedA >= 0, "Expected composed A not observed (relay mode)");
+
+  bool plainOAfterCompose = false;
+  bool composedOAfterCompose = false;
+  for (int i = indexComposedA + 1; i < keyDownChars.size(); ++i) {
+    const WCHAR c = static_cast<WCHAR>(std::towlower(keyDownChars[i]));
+    if (c == L'o') {
+      plainOAfterCompose = true;
+    }
+    if (c == composedO) {
+      composedOAfterCompose = true;
+    }
+  }
+
+  const auto debugChars = charsToDebugString(keyDownChars);
+  QVERIFY2(
+      !composedOAfterCompose,
+      qPrintable(QStringLiteral("Dead key leaked in fast-overlap sequence (relay mode). Captured: %1").arg(debugChars))
+  );
+  if (!plainOAfterCompose) {
+    QWARN(qPrintable(
+        QStringLiteral("No plain 'o' observed in overlap sequence (relay mode). Captured: %1").arg(debugChars)
+    ));
+  }
+}
+
+void MSWindowsHookIntegrationTests::altGrMappedCharacter_isPreservedInRelayPath_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::altGrMappedCharacter_isPreservedInRelayPath()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  AltGrPair pair;
+  if (!findAltGrMappedPrintablePair(pair)) {
+    QSKIP("No suitable AltGr-mapped printable key found for current keyboard layout");
+  }
+
+  clearHookMessageQueue();
+
+  MSWindowsHook hook;
+  hook.loadLibrary();
+  hook.setMode(kHOOK_RELAY_EVENTS);
+  const auto installResult = MSWindowsHook::install();
+  QVERIFY2(installResult != kHOOK_FAILED, "Failed to install low-level Windows hook");
+
+  runSequence({
+      {VK_CONTROL, false},
+      {VK_RMENU, false},
+      {static_cast<WORD>(pair.vk), false},
+      {static_cast<WORD>(pair.vk), true},
+      {VK_RMENU, true},
+      {VK_CONTROL, true},
+  });
+
+  const auto keyMsgs = collectHookMessages(DESKFLOW_MSG_KEY, 350);
+  MSWindowsHook::uninstall();
+
+  const auto events = extractKeyDownEvents(keyMsgs);
+  int index = -1;
+  for (int i = 0; i < events.size(); ++i) {
+    if (events[i].vk == pair.vk) {
+      index = i;
+      break;
+    }
+  }
+
+  QVERIFY2(index >= 0, "AltGr key event not observed in relay path");
+  QCOMPARE(events[index].wc, pair.expectedChar);
+  QVERIFY2(!events[index].noAltGr, "AltGr-mapped key was incorrectly tagged as noAltGr fallback");
+}
+
+void MSWindowsHookIntegrationTests::ctrlAltFallback_setsNoAltGrFlagForPlainCharacter_data()
+{
+  addInstalledLayoutsAsTestRows();
+}
+
+void MSWindowsHookIntegrationTests::ctrlAltFallback_setsNoAltGrFlagForPlainCharacter()
+{
+  QFETCH(quintptr, layoutValue);
+  ScopedKeyboardLayout layoutScope(reinterpret_cast<HKL>(layoutValue));
+  QVERIFY2(layoutScope.activeLayout() != nullptr, "Failed to activate requested keyboard layout");
+
+  AltGrPair pair;
+  if (!findCtrlAltFallbackPair(pair)) {
+    QSKIP("No suitable Ctrl+Alt fallback key found for current keyboard layout");
+  }
+
+  clearHookMessageQueue();
+
+  MSWindowsHook hook;
+  hook.loadLibrary();
+  hook.setMode(kHOOK_RELAY_EVENTS);
+  const auto installResult = MSWindowsHook::install();
+  QVERIFY2(installResult != kHOOK_FAILED, "Failed to install low-level Windows hook");
+
+  runSequence({
+      {VK_CONTROL, false},
+      {VK_RMENU, false},
+      {static_cast<WORD>(pair.vk), false},
+      {static_cast<WORD>(pair.vk), true},
+      {VK_RMENU, true},
+      {VK_CONTROL, true},
+  });
+
+  const auto keyMsgs = collectHookMessages(DESKFLOW_MSG_KEY, 350);
+  MSWindowsHook::uninstall();
+
+  const auto events = extractKeyDownEvents(keyMsgs);
+  int index = -1;
+  for (int i = 0; i < events.size(); ++i) {
+    if (events[i].vk == pair.vk) {
+      index = i;
+      break;
+    }
+  }
+
+  QVERIFY2(index >= 0, "Ctrl+Alt key event not observed in relay path");
+  QCOMPARE(events[index].wc, pair.expectedChar);
+  QVERIFY2(events[index].noAltGr, "Ctrl+Alt fallback key should be tagged as noAltGr");
+}
+
+QTEST_MAIN(MSWindowsHookIntegrationTests)

--- a/src/unittests/platform/MSWindowsHookIntegrationTests.h
+++ b/src/unittests/platform/MSWindowsHookIntegrationTests.h
@@ -1,0 +1,30 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QObject>
+
+class MSWindowsHookIntegrationTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void deadKeyIsPreservedAcrossUnrelatedKeyUpUntilNextComposeKeyDown_data();
+  void deadKeyIsPreservedAcrossUnrelatedKeyUpUntilNextComposeKeyDown();
+  void deadKeyCompose_whenDeadReleasedBeforeComposeKeyDown_data();
+  void deadKeyCompose_whenDeadReleasedBeforeComposeKeyDown();
+  void deadKeyCompose_whenDeadReleasedBetweenComposeKeyDownAndUp_data();
+  void deadKeyCompose_whenDeadReleasedBetweenComposeKeyDownAndUp();
+  void deadKeyDoesNotLeakToNextCharacter_afterCompose_data();
+  void deadKeyDoesNotLeakToNextCharacter_afterCompose();
+  void deadKeyDoesNotLeak_whenNextKeyDownBeforeComposeKeyUp_data();
+  void deadKeyDoesNotLeak_whenNextKeyDownBeforeComposeKeyUp();
+  void altGrMappedCharacter_isPreservedInRelayPath_data();
+  void altGrMappedCharacter_isPreservedInRelayPath();
+  void ctrlAltFallback_setsNoAltGrFlagForPlainCharacter_data();
+  void ctrlAltFallback_setsNoAltGrFlagForPlainCharacter();
+};


### PR DESCRIPTION
## Description
This change rewrites the Windows dead-key handling in `MSWindowsHook` so relay mode and local/server mode no longer share the same dead-key flow. 

The fix added explicit tracking for the pending dead key and its transition state, and changed the relay path to decide when that dead key should be preserved, composed, emitted as a standalone character, or cleared before processing the next key. 

This was needed because the two paths do not interact with Windows keyboard composition in the same way, and using one shared flow caused dead keys to be applied to the wrong character, applied twice, or lost during fast overlapping input.

## Disclosure of AI use
This PR was AI-assisted for code and test authoring (implementation and test-writing support).  
Final behavior was validated through local build/test execution and manual verification by the author.

## Related Issue
fixes: [#9254](https://github.com/deskflow/deskflow/issues/9254)

## How Has This Been Tested?

**Regression verification strategy**

1. Add integration tests that reproduce the dead-key overlap sequences that were causing the bug.
2. Check out `master`.
3. Cherry-pick the commit that adds the new tests, without applying the fix.
4. Run the new integration tests against the pre-fix implementation.
5. Confirm that the tests fail on `master`, showing that they reproduce the original bug.
6. Check out `fix/windows-deadkey`.
7. Run the same integration tests again.
8. Confirm that the tests pass on `fix/windows-deadkey`, showing that the fix resolves the reproduced cases.

**Manual validation in real keyboard/layout conditions**

Keyboard Layout: `Portuguese (Brazil ABNT)`

- Client: `~ down, ~ up (dead key pending), a down, o down, a up, o up` -> expected: `não`; before the fix: `nãõ` (the dead key leaked into the next character and was consumed twice).
- Client: `´ down, ´ up (dead key pending), a down, e down, a up, e up` -> expected: `áe`; before the fix: `áé` (the dead key was consumed twice instead of only composing with `a`).
- Server: `t down, ´ down (dead key pending), t up, ´ up, a down, a up` -> expected: `tá`; before the fix: `ta` (the dead key was lost and never applied).
- Client, same sequence as the server scenario above: `t down, ´ down, t up, ´ up, a down, a up` -> expected: `tá`; before the fix: `t´a` (the same overlap produced a different failure on the client side, where the dead key was emitted as a standalone character instead of composing with `a`).

`down` means the key was pressed, and `up` means the key was released. 

When two `down` events appear in the sequence, that explicitly shows an overlap: the second key was pressed before the first key was fully released, which is what happens during fast typing.