### PR TITLE
build: ensuring macOS codesign is triggered for changes in core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,10 @@ endif()
 include(cmake/Libraries.cmake)
 configure_libs()
 
+if(BUILD_OSX_BUNDLE AND APPLE_CODESIGN_DEV)
+  include(cmake/MacCodesign.cmake)
+endif()
+
 # setup install paths
 include(GNUInstallDirs)
 if (WIN32)

--- a/cmake/MacCodesign.cmake
+++ b/cmake/MacCodesign.cmake
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2025-2026 Deskflow Contributors
+# SPDX-License-Identifier: MIT
+
+# Warning: Do not use for CI/production, as the `entitlements-dev.plist` file adds special
+# entitlements that are only appropriate for local development.
+#
+# macOS made TCC stricter so that if you don't sign your local dev builds properly, macOS will
+# nag you to remove and re-approve the app every time you make a change to the binary which is
+# extremely annoying during development.
+#
+# If you were to use ad-hoc signing (i.e. not specify a certificate), TCC would still nag you
+# because the binary identity is anchored not on the app ID, but on the CD hash (which changes
+# based on the binary contents).
+#
+# To use, simply generate a personal certificate for free with Xcode and pass the ID to CMake.
+# Full instructions are in the docs.
+
+function(configure_mac_codesign target)
+  set_property(GLOBAL APPEND PROPERTY _MAC_CODESIGN_DEPENDS $<TARGET_FILE:${target}>)
+
+  if(NOT _MAC_CODESIGN_DEFERRED)
+    set(_MAC_CODESIGN_DEFERRED TRUE CACHE INTERNAL "")
+    message(STATUS "Apple codesign ID for development only: ${APPLE_CODESIGN_DEV}")
+    cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL _finalize_mac_codesign)
+  endif()
+endfunction()
+
+function(_finalize_mac_codesign)
+  get_property(depends GLOBAL PROPERTY _MAC_CODESIGN_DEPENDS)
+
+  set(stamp_file "${CMAKE_BINARY_DIR}/CMakeFiles/codesign-dev.stamp")
+
+  # Use a stamp file because codesign modifies the binaries it signs.
+  add_custom_command(
+    OUTPUT ${stamp_file}
+    COMMAND /usr/bin/codesign
+            --force
+            --options runtime
+            --entitlements "${CMAKE_SOURCE_DIR}/src/apps/res/entitlements-dev.plist"
+            --sign "${APPLE_CODESIGN_DEV}"
+            "$<TARGET_BUNDLE_DIR:${CMAKE_PROJECT_PROPER_NAME}>"
+    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
+    DEPENDS ${depends}
+    COMMENT "Codesigning ${CMAKE_PROJECT_PROPER_NAME}"
+    VERBATIM
+  )
+
+  add_custom_target(codesign-dev ALL DEPENDS ${stamp_file})
+endfunction()

--- a/src/apps/deskflow-core/CMakeLists.txt
+++ b/src/apps/deskflow-core/CMakeLists.txt
@@ -50,6 +50,9 @@ if(BUILD_OSX_BUNDLE)
     INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks"
     RUNTIME_OUTPUT_DIRECTORY $<TARGET_BUNDLE_CONTENT_DIR:${CMAKE_PROJECT_PROPER_NAME}>/MacOS
   )
+  if (APPLE_CODESIGN_DEV)
+    configure_mac_codesign(${target})
+  endif()
 elseif (WIN32)
   install(RUNTIME_DEPENDENCY_SET coreDeps
     PRE_EXCLUDE_REGEXES ${WIN32_PRE_EXCLUDE_REGEXES}

--- a/src/apps/deskflow-gui/CMakeLists.txt
+++ b/src/apps/deskflow-gui/CMakeLists.txt
@@ -95,32 +95,8 @@ elseif(APPLE)
       INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks"
       MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/deskflow.plist"
     )
-
-    # Warning: Do not use for CI/production, as the `entitlements-dev.plist` file adds special
-    # entitlements that are only appropriate for local development.
-    #
-    # macOS made TCC stricter so that if you don't sign your local dev builds properly, macOS will
-    # nag you to remove and re-approve the app every time you make a change to the binary which is
-    # extremely annoying during development.
-    #
-    # If you were to use ad-hoc signing (i.e. not specify a certificate), TCC would still nag you
-    # because the binary identity is anchored not on the app ID, but on the CD hash (which changes
-    # based on the binary contents).
-    #
-    # To use, simply generate a personal certificate for free with Xcode and pass the ID to CMake.
-    # Full instructions are in the docs.
-    if (NOT "${APPLE_CODESIGN_DEV}" STREQUAL "")
-      message(STATUS "Apple codesign ID for development only: ${APPLE_CODESIGN_DEV}")
-      add_custom_command(
-        TARGET ${target} POST_BUILD
-        COMMAND /usr/bin/codesign
-                --force
-                --options runtime
-                --entitlements "$<SHELL_PATH:${CMAKE_SOURCE_DIR}/src/apps/res/entitlements-dev.plist>"
-                --sign "${APPLE_CODESIGN_DEV}"
-                "$<TARGET_BUNDLE_DIR:${target}>"
-        VERBATIM
-      )
+    if (APPLE_CODESIGN_DEV)
+      configure_mac_codesign(${target})
     endif()
   else()
     set_target_properties(${target} PROPERTIES MACOSX_BUNDLE FALSE)


### PR DESCRIPTION
## Description
This ensures that changes on deskflow-core binary also trigger resigning in macOS.

Please note that it creates a stamp file to keep track of the last time the signature happen. 
Using the binary itself was not possible given that codesign itself touches the binary files.
POST_BUILD scripting triggered resigning every time, which is not intended.

## Disclosure of AI use
Claude Code guidance on how to properly create a stamp file

## Related Issue
N/A

## How Has This Been Tested?
Tested building with codesign and without codesign.
When it should, changes on the gui or in core triggered `codesign`
