### PR TITLE
build: not using cache to store global state for macOS signing

### DIFF
--- a/cmake/MacCodesign.cmake
+++ b/cmake/MacCodesign.cmake
@@ -18,8 +18,10 @@
 function(configure_mac_codesign target)
   set_property(GLOBAL APPEND PROPERTY _MAC_CODESIGN_DEPENDS $<TARGET_FILE:${target}>)
 
-  if(NOT _MAC_CODESIGN_DEFERRED)
-    set(_MAC_CODESIGN_DEFERRED TRUE CACHE INTERNAL "")
+  get_property(deferred GLOBAL PROPERTY _MAC_CODESIGN_DEFERRED)
+
+  if(NOT deferred)
+    set_property(GLOBAL PROPERTY _MAC_CODESIGN_DEFERRED TRUE)
     message(STATUS "Apple codesign ID for development only: ${APPLE_CODESIGN_DEV}")
     cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL _finalize_mac_codesign)
   endif()


### PR DESCRIPTION
## Description
Calling Cmake configure more than once on the same build directory was causing codesign to not be configured correctly for all the targets.
Previous solution was using a cache variable, which is not the correct solution as it needs to not persist. Moved to use property instead.

## Disclosure of AI use
Claude Code, to understand how cmake cache works

## Related Issue
relates: #9547

## How Has This Been Tested?
Tested on macOS Tahoe 26.3.1 on all situations, and multiple times.

To reproduce the issue before my PR, just configure more than once on the same build directory. 
Confirmation about the issue can be seen on the configure output, if the message 
`Apple codesign ID for development only: Apple Development: NAME (TEAMID)` is not printed, then codesign will not be retriggered.