### PR TITLE
fix: do not reset network if old interface is missing

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -63,6 +63,11 @@ SettingsDialog::SettingsDialog(QWidget *parent, const IServerConfig &serverConfi
     }
   }
 
+  if (const auto interface = Settings::value(Settings::Core::Interface).toString();
+      !interface.isEmpty() && (ui->comboInterface->findData(interface) == -1)) {
+    ui->comboInterface->addItem(interface, interface);
+  }
+
   loadFromConfig();
 
   adjustSize();


### PR DESCRIPTION

## Description
<!--- Describe your what your changes do -->
Add the current interface to the selection combo it its not added. This prevents reset when the interface is not longer valid. 

## Disclosure of AI use
<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None
## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Server side fix for: #9552

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
set a bogus 10.0.9.1 address for interface in config, run check the set interface that is used and set in the settings and shows in the combo of interfaces.