### PR TITLE
feat: support link-local connections in Preferences dialog

### DIFF
--- a/src/lib/gui/core/NetworkMonitor.cpp
+++ b/src/lib/gui/core/NetworkMonitor.cpp
@@ -71,11 +71,15 @@ QStringList NetworkMonitor::validAddresses()
     const bool isVirtualType = interface.type() == QNetworkInterface::Virtual;
     const bool isVirtual = isVirtualInterface(interface.humanReadableName()) || isP2P || isVirtualType;
     const auto addressEntries = interface.addressEntries();
+    // exclude link-local IP addresses on interfaces with better options
+    const bool hasNonLinkLocal = std::ranges::any_of(addressEntries, [](const QNetworkAddressEntry &entry) {
+      return !entry.ip().isLoopback() && !entry.ip().isLinkLocal();
+    });
 
     for (const auto &entry : addressEntries) {
       const QHostAddress address = entry.ip();
 
-      if (address.isLinkLocal() || address.isLoopback() || uniqueAddresses.contains(address)) {
+      if (address.isLoopback() || (hasNonLinkLocal && address.isLinkLocal()) || uniqueAddresses.contains(address)) {
         continue;
       }
 
@@ -98,6 +102,8 @@ QStringList NetworkMonitor::validAddresses()
   std::ranges::sort(physicalIP4, [](const QHostAddress &a, const QHostAddress &b) {
     if (a.isPrivateUse() != b.isPrivateUse())
       return a.isPrivateUse();
+    if (a.isLinkLocal() != b.isLinkLocal())
+      return a.isLinkLocal();
     return a.toIPv4Address() < b.toIPv4Address();
   });
 
@@ -108,6 +114,8 @@ QStringList NetworkMonitor::validAddresses()
   std::ranges::sort(physicalIP6, [](const QHostAddress &a, const QHostAddress &b) {
     if (a.isPrivateUse() != b.isPrivateUse())
       return a.isPrivateUse();
+    if (a.isLinkLocal() != b.isLinkLocal())
+      return a.isLinkLocal();
     return a.toString() < b.toString();
   });
 

--- a/src/lib/gui/core/NetworkMonitor.cpp
+++ b/src/lib/gui/core/NetworkMonitor.cpp
@@ -71,11 +71,16 @@ QStringList NetworkMonitor::validAddresses()
     const bool isVirtualType = interface.type() == QNetworkInterface::Virtual;
     const bool isVirtual = isVirtualInterface(interface.humanReadableName()) || isP2P || isVirtualType;
     const auto addressEntries = interface.addressEntries();
+    // link-local is only worth offering when it's a physical interface's only address, e.g. a direct ethernet cable
+    const bool hasNonLinkLocal = std::ranges::any_of(addressEntries, [](const QNetworkAddressEntry &entry) {
+      return !entry.ip().isLoopback() && !entry.ip().isLinkLocal();
+    });
+    const bool skipLinkLocal = isVirtual || hasNonLinkLocal;
 
     for (const auto &entry : addressEntries) {
       const QHostAddress address = entry.ip();
 
-      if (address.isLinkLocal() || address.isLoopback() || uniqueAddresses.contains(address)) {
+      if (address.isLoopback() || (skipLinkLocal && address.isLinkLocal()) || uniqueAddresses.contains(address)) {
         continue;
       }
 
@@ -98,6 +103,8 @@ QStringList NetworkMonitor::validAddresses()
   std::ranges::sort(physicalIP4, [](const QHostAddress &a, const QHostAddress &b) {
     if (a.isPrivateUse() != b.isPrivateUse())
       return a.isPrivateUse();
+    if (a.isLinkLocal() != b.isLinkLocal())
+      return a.isLinkLocal();
     return a.toIPv4Address() < b.toIPv4Address();
   });
 
@@ -108,6 +115,8 @@ QStringList NetworkMonitor::validAddresses()
   std::ranges::sort(physicalIP6, [](const QHostAddress &a, const QHostAddress &b) {
     if (a.isPrivateUse() != b.isPrivateUse())
       return a.isPrivateUse();
+    if (a.isLinkLocal() != b.isLinkLocal())
+      return a.isLinkLocal();
     return a.toString() < b.toString();
   });
 

--- a/src/lib/gui/core/NetworkMonitor.h
+++ b/src/lib/gui/core/NetworkMonitor.h
@@ -47,7 +47,7 @@ public:
   void stopMonitoring();
 
   /**
-   * @brief Get list of all available IP addresses (excluding local and link-local addresses)
+   * @brief Get list of all available IP addresses (excluding loopback addresses)
    * @return IP address list
    */
   static QStringList validAddresses();


### PR DESCRIPTION
most link-local IPs are just noise, but if an entire interface is link-local only, maybe someone is hooking up their computers directly by ethernet cable

## Description
Currently all link-local addresses are filtered out of the preferences dialog. This makes sense, given that ~every interface has a fe80 address. But I do actually use Deskflow with link-local address for two laptops on (otherwise) different networks connected by Ethernet, so I added logic to allow link-local addresses from interfaces that don't have other IPs.

## Disclosure of AI use
Used Gemini to double check the std::ranges::any_of api usage

## How Has This Been Tested?
Built, and tested the dialog on Linux. I'm sure this code works fine on other platforms but I do wonder if Windows is more aggressive at handing out link-local IP addresses to disconnected interfaces.