### PR TITLE
fix: kill core orphan on gui death (linux)

### DIFF
--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -14,6 +14,11 @@
 #include "OSXHelpers.h"
 #endif
 
+#ifdef Q_OS_LINUX
+#include <signal.h>
+#include <sys/prctl.h>
+#endif
+
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -202,6 +207,14 @@ void CoreProcess::startForegroundProcess(const QStringList &args)
   // core command can be easily copy/pasted to the terminal for testing.
   const auto quoted = makeQuotedArgs(m_appPath, args);
   qInfo("running command: %s", qPrintable(quoted));
+
+#ifdef Q_OS_LINUX
+  m_process->setChildProcessModifier([] {
+    // the core process becomes orphaned when the gui process exits abruptly (e.g. with kill -9),
+    // so ensure the os also kills the core when that happens to the gui.
+    prctl(PR_SET_PDEATHSIG, SIGTERM);
+  });
+#endif
 
   m_process->start(m_appPath, args);
 


### PR DESCRIPTION
## Description

On Linux, child processes are not automatically killed when the parent unexpectedly dies.

> The prctl() system call provides a rather useful PR_SET_PDEATHSIG option to allow a signal to be sent to child processes when the parent unexpectedly dies. 
> [Source](https://smackerelofopinion.blogspot.com/2015/11/using-prsetpdeathsig-to-reap-child.html)

## Disclosure of AI use

Used Claude to find these links:
https://doc.qt.io/qt-6/qprocess.html#setChildProcessModifier
https://man7.org/linux/man-pages/man2/pr_set_pdeathsig.2const.html

## Related Issue

Fixes #9581

## How Has This Been Tested?

Run: `killall deskflow`
Expect: `ps ax | grep deskflow-core` has no results