### PR TITLE
fix: plus key as hotkey support

### DIFF
--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -1152,6 +1152,12 @@ bool KeyMap::parseModifiers(std::string &x, KeyModifierMask &mask)
     }
     std::string c = x.substr(tb, te - tb);
     if (c.empty()) {
+      // allow '+' to be parsed as the key after modifiers (e.g. Control+Shift++)
+      if (x[tb] == '+') {
+        x.erase(0, tb);
+        return true;
+      }
+
       // missing component
       return false;
     }

--- a/src/lib/gui/KeySequence.cpp
+++ b/src/lib/gui/KeySequence.cpp
@@ -62,6 +62,7 @@ static const struct
     {Qt::Key_Launch0, "AppUser1"},
     {Qt::Key_Launch1, "AppUser2"},
     {Qt::Key_Select, "Select"},
+    {Qt::Key_Plus, "Plus"},
     {Qt::Key_Comma, "Comma"},
     {Qt::Key_Semicolon, "Semicolon"},
 

--- a/src/unittests/deskflow/KeyMapTests.cpp
+++ b/src/unittests/deskflow/KeyMapTests.cpp
@@ -183,4 +183,22 @@ void KeyMapTests::mapkey()
   QVERIFY(result == nullptr);
 }
 
+void KeyMapTests::parseModifiers_plusKey_keepsPlusAsKey()
+{
+  std::string keystroke = "Control+Shift++";
+  KeyModifierMask mask = 0;
+
+  QVERIFY(KeyMap::parseModifiers(keystroke, mask));
+  QCOMPARE(mask, static_cast<KeyModifierMask>(KeyModifierControl | KeyModifierShift));
+  QCOMPARE(keystroke, std::string("+"));
+}
+
+void KeyMapTests::parseKey_plusSymbol_parsesAsAsciiKey()
+{
+  KeyID key = kKeyNone;
+
+  QVERIFY(KeyMap::parseKey("+", key));
+  QCOMPARE(key, static_cast<KeyID>('+'));
+}
+
 QTEST_MAIN(KeyMapTests)

--- a/src/unittests/deskflow/KeyMapTests.h
+++ b/src/unittests/deskflow/KeyMapTests.h
@@ -21,6 +21,8 @@ private Q_SLOTS:
   void findBestKey_noRequiredDown_cannotMatch();
   void isCommand();
   void mapkey();
+  void parseModifiers_plusKey_keepsPlusAsKey();
+  void parseKey_plusSymbol_parsesAsAsciiKey();
 
 private:
   Log m_log;

--- a/src/unittests/gui/CMakeLists.txt
+++ b/src/unittests/gui/CMakeLists.txt
@@ -10,3 +10,10 @@ create_test(
   SOURCE LoggerTests.cpp
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
 )
+
+create_test(
+  NAME KeySequenceTests
+  DEPENDS gui
+  SOURCE KeySequenceTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
+)

--- a/src/unittests/gui/KeySequenceTests.cpp
+++ b/src/unittests/gui/KeySequenceTests.cpp
@@ -1,0 +1,22 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "KeySequenceTests.h"
+
+#include "gui/KeySequence.h"
+
+void KeySequenceTests::toString_controlShiftPlus_usesNamedPlus()
+{
+  KeySequence sequence;
+
+  sequence.appendKey(Qt::Key_Control, Qt::ControlModifier);
+  sequence.appendKey(Qt::Key_Shift, Qt::ControlModifier | Qt::ShiftModifier);
+  QVERIFY(sequence.appendKey(Qt::Key_Plus, Qt::ControlModifier | Qt::ShiftModifier));
+
+  QCOMPARE(sequence.toString(), QStringLiteral("Control+Shift+Plus"));
+}
+
+QTEST_MAIN(KeySequenceTests)

--- a/src/unittests/gui/KeySequenceTests.h
+++ b/src/unittests/gui/KeySequenceTests.h
@@ -1,0 +1,14 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include <QTest>
+
+class KeySequenceTests : public QObject
+{
+  Q_OBJECT
+private Q_SLOTS:
+  void toString_controlShiftPlus_usesNamedPlus();
+};


### PR DESCRIPTION
## Description
Hotkey parsing failed for `Ctrl+Shift++` because `+` is used as both the modifier separator and the plus key itself.

The UI would allow the hotkey combination involving `+` to be saved i.e., `Ctrl+Shift++` but the server failed to start due to config parse error  `ERROR: cannot read configuration "~/.config/Deskflow/deskflow-server.conf": read error: line 38: unable to parse key modifiers`

### Fixes

**Parser compatibility**: updated key-modifier parsing to accept legacy plus symbol format i.e., `Control+Shift++`

**Canonical output enhancement**: updated GUI hot key serialization to write plus key as `Plus` (e.g. `Control+Shift+Plus`) to avoid ambiguity in newly saved configs.

## Disclosure of AI use
GPT-5.3 codex + opencode (required as I haven't written c++ in 20 years)

## Related Issue
I searched for existing issues before working on a fix, didn't come across any to link.

## How Has This Been Tested?
* Tests were written and executed
* Manually validated the fix corrected the initial parsing issue (`Ctrl+Shift++` saved as hotkey scenario) no longer blocked server from initializing and hotkey functioned
* Manually validated the new serialization format for `Plus` when saving hotkeys involving the plus key
