### PR TITLE
fix: high-resolution scrolling on macOS clients

### DIFF
--- a/src/lib/deskflow/ISecondaryScreen.h
+++ b/src/lib/deskflow/ISecondaryScreen.h
@@ -70,6 +70,26 @@ public:
     return delta;
   }
 
+  double getYScrollScale() const
+  {
+    return m_yScrollScale;
+  }
+
+  double getXScrollScale() const
+  {
+    return m_xScrollScale;
+  }
+
+  bool getInvertYScroll() const
+  {
+    return m_invertYScroll;
+  }
+
+  bool getInvertXScroll() const
+  {
+    return m_invertXScroll;
+  }
+
 private:
   /**
    * @brief this member is used to modify the verical scroll direction.

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -240,6 +240,8 @@ private:
      Evil, and this should be moved to a place where it need not
      be mutable as soon as possible. */
   mutable MouseButtonState m_buttonState;
+  mutable double m_scrollRemainderX = 0.0;
+  mutable double m_scrollRemainderY = 0.0;
   using MouseButtonEventMapType = std::map<uint16_t, CGEventType>;
   std::vector<MouseButtonEventMapType> MouseButtonEventMap;
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -588,21 +588,55 @@ void OSXScreen::fakeMouseRelativeMove(int32_t dx, int32_t dy) const
 void OSXScreen::fakeMouseWheel(ScrollDelta delta) const
 {
   if (delta.x != 0 || delta.y != 0) {
-    // use server's acceleration with a little boost since other platforms
-    // take one wheel step as a larger step than the mac does.
-    delta = applyScrollModifier(
-        {static_cast<int32_t>(3.0 * delta.x / s_scrollDelta), static_cast<int32_t>(3.0 * delta.y / s_scrollDelta)}
-    );
-    // create a scroll event, post it and release it.  not sure if kCGScrollEventUnitLine
-    // is the right choice here over kCGScrollEventUnitPixel
-    CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitLine, 2, delta.y, delta.x);
+    // Multiplier for lines per scroll tick (3.0 is a legacy boost).
+    const double linesPerTick = 3.0;
+    // Multiplier for pixels per line (common on macOS).
+    const double pixelsPerLine = 15.0;
 
-    // Fix for sticky keys
-    CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
-    CGEventSetFlags(scrollEvent, modifiers);
+    // Use doubles for intermediate calculations to preserve high-resolution scroll data.
+    double dx = linesPerTick * pixelsPerLine * delta.x / s_scrollDelta;
+    double dy = linesPerTick * pixelsPerLine * delta.y / s_scrollDelta;
 
-    CGEventPost(kCGHIDEventTap, scrollEvent);
-    CFRelease(scrollEvent);
+    // Scale and invert based on client settings.
+    dx = getInvertXScroll() ? -dx * getXScrollScale() : dx * getXScrollScale();
+    dy = getInvertYScroll() ? -dy * getYScrollScale() : dy * getYScrollScale();
+
+    // Accumulate the fractional pixels.
+    m_scrollRemainderX += dx;
+    m_scrollRemainderY += dy;
+
+    int32_t finalX = static_cast<int32_t>(m_scrollRemainderX);
+    int32_t finalY = static_cast<int32_t>(m_scrollRemainderY);
+
+    // If there was motion but it was too small to result in an integer pixel,
+    // we round up (or down) to at least 1 pixel to satisfy "round up on micro updates".
+    // This ensures that high-resolution scrolling (like Logitech mice) always results
+    // in movement on the client.
+    if (finalX == 0 && delta.x != 0) {
+      finalX = (delta.x > 0) ? (getInvertXScroll() ? -1 : 1) : (getInvertXScroll() ? 1 : -1);
+      m_scrollRemainderX = 0;
+    } else {
+      m_scrollRemainderX -= finalX;
+    }
+
+    if (finalY == 0 && delta.y != 0) {
+      finalY = (delta.y > 0) ? (getInvertYScroll() ? -1 : 1) : (getInvertYScroll() ? 1 : -1);
+      m_scrollRemainderY = 0;
+    } else {
+      m_scrollRemainderY -= finalY;
+    }
+
+    if (finalX != 0 || finalY != 0) {
+      // Post a pixel-unit scroll event for smoother high-resolution scrolling.
+      CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitPixel, 2, finalY, finalX);
+
+      // Fix for sticky keys
+      CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
+      CGEventSetFlags(scrollEvent, modifiers);
+
+      CGEventPost(kCGHIDEventTap, scrollEvent);
+      CFRelease(scrollEvent);
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This change addresses an issue where micro-updates from high-resolution mice (like the Logitech G502 X) were being truncated to zero on macOS clients, causing the scroll wheel to appear non-functional. 

The fix implements scroll accumulation and switches the event unit to pixels (). This ensures that fractional scroll deltas are preserved and eventually result in smooth on-screen movement.

## Disclosure of AI use
I used Gemini to help navigate the codebase, identify the truncation point in , and help draft the accumulation logic to ensure it correctly handled the client's scaling and inversion settings.

## Related Issue
<!--- No existing issue found, but this is a known behavior for high-res mice on Barrier/Synergy forks -->

## How Has This Been Tested?
- **Server**: Arch Linux KDE Wayland
- **Client**: macOS (OSX 26.3.1)
- **Hardware**: Logitech G502 X
- **Results**: Verified that 'micro-ticks' now result in smooth scrolling on the Mac client, and the scroll speed can be further tuned using the client-side ratio settings.