### PR TITLE
fix: adjust command line size to allow expanding

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -870,6 +870,9 @@
        </item>
        <item>
         <layout class="QFormLayout" name="formLayout_3">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+         </property>
          <property name="rowWrapPolicy">
           <enum>QFormLayout::RowWrapPolicy::DontWrapRows</enum>
          </property>


### PR DESCRIPTION
## Description
<!--- Describe your what your changes do -->
Fixes the command entry in settings advanced to span the area on mac os (the style does not change ) 
 Before
<img width=50% height="371" alt="Screenshot%202026-03-18%20at%208 17 42%E2%80%AFAM" src="https://github.com/user-attachments/assets/edd24165-db7d-4323-97b3-cec1bd579e46" />

After: 

<img width=50% height="366" alt="Screenshot 2026-03-18 at 8 35 53 AM" src="https://github.com/user-attachments/assets/8f2ea13b-9be3-41a6-a274-8b2044f7ba26" />


## Disclosure of AI use

<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None
## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
command lines are way to short to use and not expanding 
## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Ran on macOS
Ran on Kde 
