### PR TITLE
fix: prevent daemon ipc client from sending multiple messages at the same time

### DIFF
--- a/src/lib/gui/ipc/DaemonIpcClient.cpp
+++ b/src/lib/gui/ipc/DaemonIpcClient.cpp
@@ -10,6 +10,7 @@
 
 #include <QDebug>
 #include <QLocalSocket>
+#include <QMutexLocker>
 #include <QObject>
 #include <QString>
 
@@ -79,6 +80,7 @@ bool DaemonIpcClient::connectToServer()
 
 void DaemonIpcClient::disconnectFromServer()
 {
+  QMutexLocker locker(&m_mutex);
   m_state = State::Disconnecting;
   qDebug() << "daemon ipc client disconnecting from server";
   m_socket->disconnectFromServer();
@@ -116,6 +118,7 @@ void DaemonIpcClient::handleErrorOccurred()
 
 bool DaemonIpcClient::sendMessage(const QString &message, const QString &expectAck, const bool expectConnected)
 {
+  QMutexLocker locker(&m_mutex);
   if (expectConnected && !isConnected()) {
     qWarning() << "cannot send command, ipc client not connected";
     return false;

--- a/src/lib/gui/ipc/DaemonIpcClient.h
+++ b/src/lib/gui/ipc/DaemonIpcClient.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <QMutex>
 #include <QObject>
 
 class QLocalSocket;
@@ -54,6 +55,7 @@ private:
 
 private:
   QLocalSocket *m_socket;
+  QMutex m_mutex;
   State m_state{State::Unconnected};
 };
 


### PR DESCRIPTION
## Description
Implements a mutex in Daemon IPC's client message sending.
This prevents multiple messages to be sent at the same time and/or while disconnecting. It prevents weird statuses, broken ack messages, and/or timeouts.

While investigating #8808 I tried to implement a splitter on "\n" but it ended up not working all the time and I confirmed the impression from @nbolton that a mutex could prevent this from happening.

## Disclosure of AI use
Github Copilot inline suggestions

## Related Issue
fixes: #8808 

## How Has This Been Tested?
Tested on windows as client and as a server (in service mode, in order to use daemon). 
I was unable to see issues with the signature reported on the linked issue.
