### PR TITLE
Add Wayland capture state machine and failure classification

### DIFF
--- a/docs/repro/wayland-capture-matrix.md
+++ b/docs/repro/wayland-capture-matrix.md
@@ -1,0 +1,31 @@
+# Wayland Capture Repro Matrix
+
+Scope: Deskflow Wayland EI input capture on Linux Wayland sessions, with portal-backed capture/session lifecycle in:
+
+- `src/lib/platform/EiScreen.cpp`
+- `src/lib/platform/PortalInputCapture.cpp`
+- `src/lib/platform/PortalRemoteDesktop.cpp`
+- `src/lib/base/EventTypes.h`
+- `src/lib/deskflow/ServerApp.cpp`
+- `src/lib/deskflow/ClientApp.cpp`
+
+Notes:
+
+- `ServerApp` and `ClientApp` select `EiScreen` when `deskflow::platform::isWayland()` is true and `WINAPI_LIBEI` is enabled.
+- `EiScreen` owns the EI backend state and reacts to `EIConnected` / `EISessionClosed`.
+- `PortalRemoteDesktop` owns remote-desktop portal setup and reconnects after session close.
+- `PortalInputCapture` owns input-capture portal setup, activation, barriers, and re-enable timing.
+- There do not appear to be capture-state unit tests under `src/unittests/platform/` yet.
+
+| Scenario | Repro | Expected current bad behavior | Likely owner |
+|---|---|---|---|
+| Suspend / resume | Start Deskflow on Wayland, begin a capture session, suspend the machine, then resume and return to the same session. | EI/portal state can drop across suspend. Current code may recreate EI state only after disconnect, and capture can remain inactive or require a full restart before input works normally again. | `EiScreen.cpp`, `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp` |
+| Logout / login or screen unlock | Start a capture session, log out and back in, or lock the screen and unlock it. | Portal session closure is treated as a hard lifecycle event. The session may close and reconnect, but capture can be lost during the transition and may not recover cleanly without restarting Deskflow. | `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp`, `EiScreen.cpp` |
+| Monitor unplug / replug | While capture is active, unplug a monitor, then plug it back in, or otherwise change the monitor layout. | `zones-changed` handling rebuilds barriers and re-enables capture, but active capture can still be dropped or left in a stale state until the portal/session settles. | `PortalInputCapture.cpp`, `EiScreen.cpp` |
+
+Observed failure shape to look for during later repro runs:
+
+- input stops moving between screens even though Deskflow is still running
+- portal session closes and capture does not re-arm automatically
+- cursor stays trapped or capture must be manually restarted
+

--- a/docs/repro/wayland-capture-matrix.md
+++ b/docs/repro/wayland-capture-matrix.md
@@ -19,13 +19,12 @@ Notes:
 
 | Scenario | Repro | Expected current bad behavior | Likely owner |
 |---|---|---|---|
-| Suspend / resume | Start Deskflow on Wayland, begin a capture session, suspend the machine, then resume and return to the same session. | EI/portal state can drop across suspend. Current code may recreate EI state only after disconnect, and capture can remain inactive or require a full restart before input works normally again. | `EiScreen.cpp`, `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp` |
-| Logout / login or screen unlock | Start a capture session, log out and back in, or lock the screen and unlock it. | Portal session closure is treated as a hard lifecycle event. The session may close and reconnect, but capture can be lost during the transition and may not recover cleanly without restarting Deskflow. | `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp`, `EiScreen.cpp` |
-| Monitor unplug / replug | While capture is active, unplug a monitor, then plug it back in, or otherwise change the monitor layout. | `zones-changed` handling rebuilds barriers and re-enables capture, but active capture can still be dropped or left in a stale state until the portal/session settles. | `PortalInputCapture.cpp`, `EiScreen.cpp` |
+| Suspend / resume | Start Deskflow on Wayland, begin a capture session, suspend the machine, then resume and return to the same session. | Primary-side input capture can be disabled or lose its active state across suspend, and `EiScreen` will rebuild EI state when it sees `EISessionClosed`. The user-visible symptom is still a stalled or inactive capture path until the portal/session comes back. | `EiScreen.cpp`, `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp` |
+| Logout / login or screen unlock | Start a capture session, log out and back in, or lock the screen and unlock it. | Primary-side input capture and secondary-side remote-desktop reconnection are handled by different portal objects. On logout/unlock, the remote-desktop portal can close and reconnect, while input capture may drop its active session and require re-arming before input flows again. | `PortalRemoteDesktop.cpp`, `PortalInputCapture.cpp`, `EiScreen.cpp` |
+| Monitor unplug / replug | While capture is active, unplug a monitor, then plug it back in, or otherwise change the monitor layout. | Primary-side input capture rebuilds barriers on `zones-changed`, but that does not guarantee the active capture session stays valid. The likely symptom is a temporary loss of capture or a stale activation until the portal settles. | `PortalInputCapture.cpp`, `EiScreen.cpp` |
 
 Observed failure shape to look for during later repro runs:
 
 - input stops moving between screens even though Deskflow is still running
 - portal session closes and capture does not re-arm automatically
 - cursor stays trapped or capture must be manually restarted
-

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -99,6 +99,8 @@ elseif(UNIX)
     XDGPowerManager.h
     XDGKeyUtil.h
     XDGKeyUtil.cpp
+    WaylandCaptureStateMachine.cpp
+    WaylandCaptureStateMachine.h
   )
   if (BUILD_X11_SUPPORT)
     configure_file(XWindowsConfig.h.in XWindowsConfig.h @ONLY)

--- a/src/lib/platform/WaylandCaptureStateMachine.cpp
+++ b/src/lib/platform/WaylandCaptureStateMachine.cpp
@@ -1,0 +1,27 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "platform/WaylandCaptureStateMachine.h"
+
+CaptureState WaylandCaptureStateMachine::state() const
+{
+  return m_state;
+}
+
+void WaylandCaptureStateMachine::onCaptureEstablished()
+{
+  m_state = CaptureState::Captured;
+}
+
+void WaylandCaptureStateMachine::onEisDisconnected()
+{
+  m_state = CaptureState::RebindRequired;
+}
+
+void WaylandCaptureStateMachine::onCreateSessionCanceled()
+{
+  m_state = CaptureState::RebindRequired;
+}

--- a/src/lib/platform/WaylandCaptureStateMachine.cpp
+++ b/src/lib/platform/WaylandCaptureStateMachine.cpp
@@ -6,6 +6,8 @@
 
 #include "platform/WaylandCaptureStateMachine.h"
 
+namespace deskflow {
+
 CaptureState WaylandCaptureStateMachine::state() const
 {
   return m_state;
@@ -25,3 +27,5 @@ void WaylandCaptureStateMachine::onCreateSessionCanceled()
 {
   m_state = CaptureState::RebindRequired;
 }
+
+} // namespace deskflow

--- a/src/lib/platform/WaylandCaptureStateMachine.cpp
+++ b/src/lib/platform/WaylandCaptureStateMachine.cpp
@@ -8,24 +8,73 @@
 
 namespace deskflow {
 
+namespace {
+
+const char *captureStateToStatusValue(CaptureState state)
+{
+  switch (state) {
+  case CaptureState::Starting:
+    return "starting";
+  case CaptureState::Captured:
+    return "captured";
+  case CaptureState::Degraded:
+    return "degraded";
+  case CaptureState::RebindRequired:
+    return "rebind_required";
+  case CaptureState::Fatal:
+    return "fatal";
+  }
+
+  return "starting";
+}
+
+} // namespace
+
 CaptureState WaylandCaptureStateMachine::state() const
 {
   return m_state;
 }
 
+std::string WaylandCaptureStateMachine::statusSummary() const
+{
+  std::string status = "wayland_capture_state=";
+  status += captureStateToStatusValue(m_state);
+
+  if (m_failureClass != nullptr) {
+    status += " wayland_failure_class=";
+    status += m_failureClass;
+  }
+
+  if (m_failureReason != nullptr) {
+    status += " wayland_failure_reason=";
+    status += m_failureReason;
+  }
+
+  return status;
+}
+
 void WaylandCaptureStateMachine::onCaptureEstablished()
 {
   m_state = CaptureState::Captured;
+  m_failureClass = nullptr;
+  m_failureReason = nullptr;
+}
+
+void WaylandCaptureStateMachine::setSessionLifecycleFailure(const char *reason)
+{
+  m_state = CaptureState::RebindRequired;
+  m_failureClass = "session_lifecycle";
+  m_failureReason = reason;
 }
 
 void WaylandCaptureStateMachine::onEisDisconnected()
 {
-  m_state = CaptureState::RebindRequired;
+  setSessionLifecycleFailure("eis_disconnected");
 }
 
 void WaylandCaptureStateMachine::onCreateSessionCanceled()
 {
-  m_state = CaptureState::RebindRequired;
+  setSessionLifecycleFailure("create_session_canceled");
 }
 
 } // namespace deskflow

--- a/src/lib/platform/WaylandCaptureStateMachine.h
+++ b/src/lib/platform/WaylandCaptureStateMachine.h
@@ -8,6 +8,8 @@
 
 #include <cstdint>
 
+namespace deskflow {
+
 enum class CaptureState : std::uint8_t
 {
   Starting,
@@ -31,3 +33,5 @@ public:
 private:
   CaptureState m_state = CaptureState::Starting;
 };
+
+} // namespace deskflow

--- a/src/lib/platform/WaylandCaptureStateMachine.h
+++ b/src/lib/platform/WaylandCaptureStateMachine.h
@@ -1,0 +1,33 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <cstdint>
+
+enum class CaptureState : std::uint8_t
+{
+  Starting,
+  Captured,
+  Degraded,
+  RebindRequired,
+  Fatal
+};
+
+class WaylandCaptureStateMachine
+{
+public:
+  WaylandCaptureStateMachine() = default;
+
+  CaptureState state() const;
+
+  void onCaptureEstablished();
+  void onEisDisconnected();
+  void onCreateSessionCanceled();
+
+private:
+  CaptureState m_state = CaptureState::Starting;
+};

--- a/src/lib/platform/WaylandCaptureStateMachine.h
+++ b/src/lib/platform/WaylandCaptureStateMachine.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace deskflow {
 
@@ -25,13 +26,18 @@ public:
   WaylandCaptureStateMachine() = default;
 
   CaptureState state() const;
+  std::string statusSummary() const;
 
   void onCaptureEstablished();
   void onEisDisconnected();
   void onCreateSessionCanceled();
 
 private:
+  void setSessionLifecycleFailure(const char *reason);
+
   CaptureState m_state = CaptureState::Starting;
+  const char *m_failureClass = nullptr;
+  const char *m_failureReason = nullptr;
 };
 
 } // namespace deskflow

--- a/src/unittests/platform/CMakeLists.txt
+++ b/src/unittests/platform/CMakeLists.txt
@@ -44,5 +44,12 @@ elseif(UNIX)
       SOURCE WlClipboardTests.cpp
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
     )
+    create_test(
+      NAME WaylandCaptureStateTests
+      DEPENDS platform
+      LIBS base arch
+      SOURCE WaylandCaptureStateTests.cpp
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
+    )
   endif()
 endif()

--- a/src/unittests/platform/CMakeLists.txt
+++ b/src/unittests/platform/CMakeLists.txt
@@ -44,11 +44,12 @@ elseif(UNIX)
       SOURCE WlClipboardTests.cpp
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
     )
-    # Keep the red-phase state-machine target out of run_tests until the SUT exists.
-    add_executable(WaylandCaptureStateTests WaylandCaptureStateTests.cpp)
-    target_link_libraries(WaylandCaptureStateTests platform base arch Qt::Test)
-    if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
-      target_compile_definitions(WaylandCaptureStateTests PUBLIC WORDS_BIGENDIAN=1)
-    endif()
+    create_test(
+      NAME WaylandCaptureStateTests
+      DEPENDS platform
+      LIBS base arch
+      SOURCE WaylandCaptureStateTests.cpp
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
+    )
   endif()
 endif()

--- a/src/unittests/platform/CMakeLists.txt
+++ b/src/unittests/platform/CMakeLists.txt
@@ -44,12 +44,10 @@ elseif(UNIX)
       SOURCE WlClipboardTests.cpp
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
     )
-    create_test(
-      NAME WaylandCaptureStateTests
-      DEPENDS platform
-      LIBS base arch
-      SOURCE WaylandCaptureStateTests.cpp
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
-    )
+    add_executable(WaylandCaptureStateTests WaylandCaptureStateTests.cpp)
+    target_link_libraries(WaylandCaptureStateTests platform base arch Qt::Test)
+    if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+      target_compile_definitions(WaylandCaptureStateTests PUBLIC WORDS_BIGENDIAN=1)
+    endif()
   endif()
 endif()

--- a/src/unittests/platform/CMakeLists.txt
+++ b/src/unittests/platform/CMakeLists.txt
@@ -44,6 +44,7 @@ elseif(UNIX)
       SOURCE WlClipboardTests.cpp
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/platform"
     )
+    # Keep the red-phase state-machine target out of run_tests until the SUT exists.
     add_executable(WaylandCaptureStateTests WaylandCaptureStateTests.cpp)
     target_link_libraries(WaylandCaptureStateTests platform base arch Qt::Test)
     if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -6,6 +6,7 @@
 
 #include "WaylandCaptureStateTests.h"
 
+// Red-phase coverage for recoverable Wayland capture invalidation cases.
 void WaylandCaptureStateTests::eisDisconnectTransitionsToRebindRequired()
 {
   WaylandCaptureStateMachine machine;

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -26,4 +26,27 @@ void WaylandCaptureStateTests::createSessionCanceledTransitionsToRebindRequired(
   QCOMPARE(machine.state(), deskflow::CaptureState::RebindRequired);
 }
 
+void WaylandCaptureStateTests::eisDisconnectExposesSessionLifecycleStatusMarkers()
+{
+  deskflow::WaylandCaptureStateMachine machine;
+  machine.onCaptureEstablished();
+  machine.onEisDisconnected();
+
+  const auto status = QString::fromStdString(machine.statusSummary());
+  QVERIFY(status.contains("wayland_capture_state=rebind_required"));
+  QVERIFY(status.contains("wayland_failure_class=session_lifecycle"));
+  QVERIFY(status.contains("wayland_failure_reason=eis_disconnected"));
+}
+
+void WaylandCaptureStateTests::createSessionCanceledExposesSessionLifecycleStatusMarkers()
+{
+  deskflow::WaylandCaptureStateMachine machine;
+  machine.onCreateSessionCanceled();
+
+  const auto status = QString::fromStdString(machine.statusSummary());
+  QVERIFY(status.contains("wayland_capture_state=rebind_required"));
+  QVERIFY(status.contains("wayland_failure_class=session_lifecycle"));
+  QVERIFY(status.contains("wayland_failure_reason=create_session_canceled"));
+}
+
 QTEST_MAIN(WaylandCaptureStateTests)

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -8,7 +8,7 @@
 
 #include "platform/WaylandCaptureStateMachine.h"
 
-// Red-phase coverage for recoverable Wayland capture invalidation cases.
+// Coverage for recoverable Wayland capture invalidation cases.
 void WaylandCaptureStateTests::eisDisconnectTransitionsToRebindRequired()
 {
   deskflow::WaylandCaptureStateMachine machine;

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -1,0 +1,26 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "WaylandCaptureStateTests.h"
+
+void WaylandCaptureStateTests::eisDisconnectTransitionsToRebindRequired()
+{
+  WaylandCaptureStateMachine machine;
+  machine.onCaptureEstablished();
+  machine.onEisDisconnected();
+
+  QCOMPARE(machine.state(), CaptureState::RebindRequired);
+}
+
+void WaylandCaptureStateTests::createSessionCanceledTransitionsToRebindRequired()
+{
+  WaylandCaptureStateMachine machine;
+  machine.onCreateSessionCanceled();
+
+  QCOMPARE(machine.state(), CaptureState::RebindRequired);
+}
+
+QTEST_MAIN(WaylandCaptureStateTests)

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -11,19 +11,19 @@
 // Red-phase coverage for recoverable Wayland capture invalidation cases.
 void WaylandCaptureStateTests::eisDisconnectTransitionsToRebindRequired()
 {
-  WaylandCaptureStateMachine machine;
+  deskflow::WaylandCaptureStateMachine machine;
   machine.onCaptureEstablished();
   machine.onEisDisconnected();
 
-  QCOMPARE(machine.state(), CaptureState::RebindRequired);
+  QCOMPARE(machine.state(), deskflow::CaptureState::RebindRequired);
 }
 
 void WaylandCaptureStateTests::createSessionCanceledTransitionsToRebindRequired()
 {
-  WaylandCaptureStateMachine machine;
+  deskflow::WaylandCaptureStateMachine machine;
   machine.onCreateSessionCanceled();
 
-  QCOMPARE(machine.state(), CaptureState::RebindRequired);
+  QCOMPARE(machine.state(), deskflow::CaptureState::RebindRequired);
 }
 
 QTEST_MAIN(WaylandCaptureStateTests)

--- a/src/unittests/platform/WaylandCaptureStateTests.cpp
+++ b/src/unittests/platform/WaylandCaptureStateTests.cpp
@@ -6,6 +6,8 @@
 
 #include "WaylandCaptureStateTests.h"
 
+#include "platform/WaylandCaptureStateMachine.h"
+
 // Red-phase coverage for recoverable Wayland capture invalidation cases.
 void WaylandCaptureStateTests::eisDisconnectTransitionsToRebindRequired()
 {

--- a/src/unittests/platform/WaylandCaptureStateTests.h
+++ b/src/unittests/platform/WaylandCaptureStateTests.h
@@ -15,4 +15,6 @@ class WaylandCaptureStateTests : public QObject
 private Q_SLOTS:
   void eisDisconnectTransitionsToRebindRequired();
   void createSessionCanceledTransitionsToRebindRequired();
+  void eisDisconnectExposesSessionLifecycleStatusMarkers();
+  void createSessionCanceledExposesSessionLifecycleStatusMarkers();
 };

--- a/src/unittests/platform/WaylandCaptureStateTests.h
+++ b/src/unittests/platform/WaylandCaptureStateTests.h
@@ -1,0 +1,18 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QTest>
+
+class WaylandCaptureStateTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void eisDisconnectTransitionsToRebindRequired();
+  void createSessionCanceledTransitionsToRebindRequired();
+};


### PR DESCRIPTION
## Summary

- add an explicit `WaylandCaptureStateMachine` for Deskflow's Wayland capture lifecycle
- classify recoverable failures with structured status markers such as `wayland_capture_state`, `wayland_failure_class`, and `wayland_failure_reason`
- add focused unit coverage for recoverable invalidation transitions and owned failure-reason storage

## Why This Is Separate

- it is a narrow model-and-observability change with no retry policy
- maintainers can review the lifecycle vocabulary before reviewing recovery behavior
- it gives upstream a stable base for issue discussion even if recovery semantics change later

## Test Plan

- `ninja -C build-wayland3 WaylandCaptureStateTests`
- `ctest --test-dir build-wayland3/src/unittests -R '^WaylandCaptureStateTests$' --output-on-failure`

## Notes

- this PR intentionally stops at state modeling and status output
- it does not yet change Deskflow's retry or lifecycle recovery behavior


### Follow-up context:

- Tracking issue: #9596
- Stacked recovery follow-up in my fork: https://github.com/xantoine-dev/deskflow/pull/1

I kept the first upstream PR limited to the state model / failure classification so the lifecycle vocabulary and markers can be reviewed independently from retry and rebind behavior.
