### PR TITLE
Sonar cleanup 26

### DIFF
--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -357,34 +357,35 @@ uint32_t Unicode::fromUTF8(const uint8_t *&data, uint32_t &n)
       truncated = true;
       size = 5;
     }
-    // fall through
+    [[fallthrough]];
 
   case 5:
     if ((data[4] & 0xc0) != 0x80) {
       truncated = true;
       size = 4;
     }
-    // fall through
+    [[fallthrough]];
 
   case 4:
     if ((data[3] & 0xc0) != 0x80) {
       truncated = true;
       size = 3;
     }
-    // fall through
+    [[fallthrough]];
 
   case 3:
     if ((data[2] & 0xc0) != 0x80) {
       truncated = true;
       size = 2;
     }
-    // fall through
+    [[fallthrough]];
 
   case 2:
     if ((data[1] & 0xc0) != 0x80) {
       truncated = true;
       size = 1;
     }
+    [[fallthrough]];
 
   default:
     break;

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -31,28 +31,6 @@ inline static uint16_t decode16(const uint8_t *n, bool byteSwapped)
   return c.n16;
 }
 
-inline static uint32_t decode32(const uint8_t *n, bool byteSwapped)
-{
-  union x32
-  {
-    uint8_t n8[4];
-    uint32_t n32;
-  };
-  x32 c;
-  if (byteSwapped) {
-    c.n8[0] = n[3];
-    c.n8[1] = n[2];
-    c.n8[2] = n[1];
-    c.n8[3] = n[0];
-  } else {
-    c.n8[0] = n[0];
-    c.n8[1] = n[1];
-    c.n8[2] = n[2];
-    c.n8[3] = n[3];
-  }
-  return c.n32;
-}
-
 inline static void resetError(bool *errors)
 {
   if (errors != nullptr) {

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -46,12 +46,12 @@ protected:
   void addHotkey();
   void editHotkey();
   void removeHotkey();
-  void listHotkeysSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected [[maybe_unused]]);
+  void listHotkeysSelectionChanged(const QItemSelection &selected, [[maybe_unused]] const QItemSelection &deselected);
 
   void addAction();
   void editAction();
   void removeAction();
-  void listActionsSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected [[maybe_unused]]);
+  void listActionsSelectionChanged(const QItemSelection &selected, [[maybe_unused]] const QItemSelection &deselected);
 
   void toggleSwitchDoubleTap(bool enable);
   void setSwitchDoubleTap(int within);

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -30,7 +30,7 @@ public:
     std::string m_what;
   };
 
-  explicit IDataSocket(const IEventQueue *events [[maybe_unused]])
+  explicit IDataSocket([[maybe_unused]] const IEventQueue *events)
   {
     // do nothing
   }

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -297,7 +297,7 @@ bool SecureSocket::loadCertificate(const QString &filename)
   if (!QFile::exists(filename)) {
     std::string errorMsg("tls certificate doesn't exist: ");
     errorMsg.append(filename.toStdString());
-    SslLogger::logError(errorMsg.c_str());
+    SslLogger::logError(errorMsg);
     return false;
   }
 

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -246,5 +246,5 @@ private:
   // pointer to (singleton) screen.  this is only needed by
   // ioErrorHandler().
   static XWindowsScreen *s_screen;
-  XDGPowerManager m_powerManager;
+  [[no_unique_address]] XDGPowerManager m_powerManager;
 };


### PR DESCRIPTION
## Description
<!--- Describe your what your changes do -->
Few clean ups from sonar 

 - refactor: add explicit fallthrough for fall through cases in unicode
 - chore: remove unused Unicode::decode32 method
 - refactor: remove redundant c_str when setting logError
 - refactor: correctly use [[maybe_unused]]
 - refactor: add [[no_unique_address]] hint for XWindowsScreen::m_powerManager
 - 
## Disclosure of AI use
<!--- Disclouse your use of AI Tools used to make this pr -->
<!--- If any AI tools were used to crate the code let us know -->
None
## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None
## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Test run