### PR TITLE
# feat(macos): add native MDM support via NSUserDefaults

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -283,6 +283,32 @@ screens\size=15
 ```
 
 
+## Administrator managed settings
+
+On macOS an administrator can enforce settings with a configuration profile delivered
+through MDM, such as Jamf Pro, Mosyle, Kandji or Intune. Deskflow reads managed
+preferences for its own bundle identifier, `org.deskflow.deskflow`. Platforms without a
+policy backend never report a setting as managed.
+
+Any key documented above can be enforced. The preference key is the settings key exactly
+as written, for example `security/tlsEnabled`, `core/port` or `server/enableClipboard`.
+
+A managed setting always reports the enforced value, writes to it are rejected, and the
+control that edits it is disabled in the GUI with a note explaining why. Removing the
+policy restores the value the user had before.
+
+To try this without enrolling a device, write the file directly:
+
+```bash
+sudo mkdir -p "/Library/Managed Preferences"
+sudo /usr/libexec/PlistBuddy \
+  -c "Add :security/tlsEnabled bool false" \
+  -c "Add :core/port integer 12345" \
+  "/Library/Managed Preferences/org.deskflow.deskflow.plist"
+```
+
+Delete that file to return to normal behaviour.
+
 # Server Config
 
 The `deskflow-server` command accepts the `-c` or `--config` option, which takes one argument,

--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -9,6 +9,12 @@ endif()
 configure_file(Constants.h.in Constants.h @ONLY)
 configure_file(VersionInfo.h.in VersionInfo.h @ONLY)
 
+if(APPLE)
+  set(managed_sources ManagedSettings.mm)
+else()
+  set(managed_sources ManagedSettings.cpp)
+endif()
+
 add_library(common STATIC
   Coordinate.h
   Enums.h
@@ -16,6 +22,7 @@ add_library(common STATIC
   I18N.h
   I18N.cpp
   LogLevel.h
+  ${managed_sources}
   NetworkProtocol.h
   PlatformInfo.h
   Settings.h
@@ -34,3 +41,7 @@ target_include_directories(common
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/lib>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/lib>
 )
+
+if(APPLE)
+  target_link_libraries(common PRIVATE "-framework Foundation")
+endif()

--- a/src/lib/common/ManagedSettings.cpp
+++ b/src/lib/common/ManagedSettings.cpp
@@ -1,0 +1,19 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "Settings.h"
+
+bool Settings::isManaged(const QString &key)
+{
+  Q_UNUSED(key)
+  return false;
+}
+
+QVariant Settings::managedValue(const QString &key)
+{
+  Q_UNUSED(key)
+  return QVariant();
+}

--- a/src/lib/common/ManagedSettings.mm
+++ b/src/lib/common/ManagedSettings.mm
@@ -1,0 +1,48 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "Settings.h"
+
+#import <Foundation/NSString.h>
+#import <Foundation/NSUserDefaults.h>
+#import <Foundation/NSValue.h>
+
+// Qt headers must come after Foundation to avoid symbol conflicts
+#include <QString>
+#include <QVariant>
+
+#include <cstring>
+
+bool Settings::isManaged(const QString &key)
+{
+  // objectIsForcedForKey: reports only values coming from a forced domain, so a
+  // value the user wrote themselves is never mistaken for an enforced policy
+  return [[NSUserDefaults standardUserDefaults] objectIsForcedForKey:key.toNSString()];
+}
+
+QVariant Settings::managedValue(const QString &key)
+{
+  if (!isManaged(key))
+    return QVariant();
+
+  id value = [[NSUserDefaults standardUserDefaults] objectForKey:key.toNSString()];
+  if (!value)
+    return QVariant();
+
+  if ([value isKindOfClass:[NSNumber class]]) {
+    // NSNumber wraps BOOL as __NSCFBoolean, so the encoded type is the only way
+    // to tell a policy bool from a policy int
+    const char *encodedType = [value objCType];
+    if (strcmp(encodedType, @encode(BOOL)) == 0 || strcmp(encodedType, @encode(bool)) == 0)
+      return QVariant([value boolValue]);
+    return QVariant([value intValue]);
+  }
+
+  if ([value isKindOfClass:[NSString class]])
+    return QVariant(QString::fromNSString(value));
+
+  return QVariant();
+}

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -6,6 +6,8 @@
 
 #include "Settings.h"
 
+#include <QDebug>
+
 #include "LogLevel.h"
 #include "NetworkProtocol.h"
 #include "UrlConstants.h"
@@ -315,13 +317,18 @@ QString Settings::logLevelText()
   return Settings::value(Log::Level).toString();
 }
 
-void Settings::setValue(const QString &key, const QVariant &value)
+bool Settings::setValue(const QString &key, const QVariant &value)
 {
+  if (isManaged(key)) {
+    qWarning() << "not changing" << key << "as it is enforced by an administrator policy";
+    return false;
+  }
+
   const bool useState = Settings::m_stateKeys.contains(key) && !instance()->isPortableMode();
   auto settings = useState ? instance()->m_stateSettings : instance()->m_settings;
 
   if (settings->value(key) == value)
-    return;
+    return true;
 
   if (!value.isValid())
     settings->remove(key);
@@ -334,10 +341,14 @@ void Settings::setValue(const QString &key, const QVariant &value)
 
   settings->sync();
   Q_EMIT instance()->settingsChanged(key);
+  return true;
 }
 
 QVariant Settings::value(const QString &key)
 {
+  if (isManaged(key))
+    return managedValue(key);
+
   const bool useState = Settings::m_stateKeys.contains(key) && !instance()->isPortableMode();
   auto settings = useState ? instance()->m_stateSettings : instance()->m_settings;
   return settings->value(key, defaultValue(key));

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -174,7 +174,7 @@ public:
   static Settings *instance();
   static void setSettingsFile(const QString &settingsFile = QString());
   static void setStateFile(const QString &stateFile = QString());
-  static void setValue(const QString &key = QString(), const QVariant &value = QVariant());
+  static bool setValue(const QString &key = QString(), const QVariant &value = QVariant());
   static QVariant value(const QString &key = QString());
   static void restoreDefaultSettings();
   static QVariant defaultValue(const QString &key);
@@ -192,6 +192,14 @@ public:
   static NetworkProtocol networkProtocol();
   static void save(bool emitSaving = true);
   static QStringList validKeys();
+
+  /**
+   * @brief Checks if a setting is enforced by an administrator policy.
+   * Defined per platform; only platforms with a policy backend can return true.
+   * @param key The settings key to check.
+   * @return true if the setting is enforced and may not be changed.
+   */
+  static bool isManaged(const QString &key);
   static QStringList validGroups();
   static QString portableSettingsFile();
   static void removeUnknownScreens(const QStringList &knownScreens);
@@ -226,6 +234,14 @@ private:
    * @return a valid computerName
    */
   static QString cleanComputerName(const QString &name);
+
+  /**
+   * @brief Gets the value an administrator policy enforces for a setting.
+   * Defined per platform alongside isManaged().
+   * @param key The settings key to look up.
+   * @return The enforced value, or an invalid QVariant if there is none.
+   */
+  static QVariant managedValue(const QString &key);
 
   QSettings *m_settings = nullptr;
   QSettings *m_stateSettings = nullptr;

--- a/src/lib/gui/StyleUtils.h
+++ b/src/lib/gui/StyleUtils.h
@@ -12,8 +12,10 @@
 #include <QIcon>
 #include <QPalette>
 #include <QStyleHints>
+#include <QWidget>
 
 #include "common/Constants.h"
+#include "common/Settings.h"
 
 namespace deskflow::gui {
 
@@ -48,6 +50,28 @@ inline void updateIconTheme()
   else
     QIcon::setFallbackThemeName(themeName);
   QIcon::setFallbackSearchPaths({QStringLiteral(":/icons/%1").arg(themeName)});
+}
+
+/**
+ * @brief Disables any child widget of @p root bound to an administrator managed setting.
+ *
+ * A widget declares which setting it edits through a dynamic property named
+ * "managedSetting" holding the settings key. Widgets whose key returns true from
+ * Settings::isManaged() are disabled and given @p tooltip to explain why.
+ *
+ * @param root The widget whose children should be checked.
+ * @param tooltip Text shown on any widget that gets locked.
+ */
+inline void applyManagedLocks(QWidget *root, const QString &tooltip)
+{
+  const auto widgets = root->findChildren<QWidget *>();
+  for (QWidget *widget : widgets) {
+    const auto key = widget->property("managedSetting").toString();
+    if (!key.isEmpty() && Settings::isManaged(key)) {
+      widget->setEnabled(false);
+      widget->setToolTip(tooltip);
+    }
+  }
 }
 } // namespace deskflow::gui
 

--- a/src/lib/gui/dialogs/ClientConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ClientConfigDialog.cpp
@@ -8,6 +8,7 @@
 #include "ui_ClientConfigDialog.h"
 
 #include "common/Settings.h"
+#include "gui/StyleUtils.h"
 
 #include <QPushButton>
 
@@ -100,6 +101,9 @@ void ClientConfigDialog::load()
   ui->sbYScrollScale->setValue(Settings::value(Settings::Client::YScrollScale).toDouble());
   ui->cbXScrollInvert->setChecked(Settings::value(Settings::Client::InvertXScroll).toBool());
   ui->sbXScrollScale->setValue(Settings::value(Settings::Client::XScrollScale).toDouble());
+
+  // Runs last so a managed control cannot be re-enabled by the code above
+  applyManagedLocks();
 }
 
 void ClientConfigDialog::resetToDefault()
@@ -110,6 +114,19 @@ void ClientConfigDialog::resetToDefault()
   ui->sbYScrollScale->setValue(Settings::defaultValue(Settings::Client::YScrollScale).toDouble());
   ui->cbXScrollInvert->setChecked(Settings::defaultValue(Settings::Client::InvertXScroll).toBool());
   ui->sbXScrollScale->setValue(Settings::defaultValue(Settings::Client::XScrollScale).toDouble());
+}
+
+void ClientConfigDialog::applyManagedLocks()
+{
+  // Each control records the setting it edits so the lock check stays generic.
+  ui->cbDynamicConnectTime->setProperty("managedSetting", Settings::Client::DynamicConnectionRetry);
+  ui->cbLanguageSync->setProperty("managedSetting", Settings::Client::LanguageSync);
+  ui->cbYScrollInvert->setProperty("managedSetting", Settings::Client::InvertYScroll);
+  ui->sbYScrollScale->setProperty("managedSetting", Settings::Client::YScrollScale);
+  ui->cbXScrollInvert->setProperty("managedSetting", Settings::Client::InvertXScroll);
+  ui->sbXScrollScale->setProperty("managedSetting", Settings::Client::XScrollScale);
+
+  deskflow::gui::applyManagedLocks(this, tr("Managed by your organization"));
 }
 
 void ClientConfigDialog::save()

--- a/src/lib/gui/dialogs/ClientConfigDialog.h
+++ b/src/lib/gui/dialogs/ClientConfigDialog.h
@@ -62,6 +62,8 @@ private:
    */
   void load();
 
+  void applyManagedLocks();
+
   /**
    * @brief Set the gui values to the defalut values for all client settings
    */

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/ActionDialog.h"
 #include "dialogs/HotkeyDialog.h"
 #include "dialogs/ScreenSettingsDialog.h"
+#include "gui/StyleUtils.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -433,6 +434,9 @@ void ServerConfigDialog::loadFromConfig()
   m_clipboardSize = Settings::value(Settings::Server::ClipboardSize).toUInt();
   ui->sbClipboardSizeLimit->setValue(m_clipboardSize);
 
+  // Runs last so a managed control cannot be re-enabled by the code above
+  applyManagedLocks();
+
   ui->listHotkeys->clear();
   for (const Hotkey &hotkey : std::as_const(serverConfig().hotkeys()))
     ui->listHotkeys->addItem(hotkey.text());
@@ -451,6 +455,29 @@ void ServerConfigDialog::loadFromConfig()
   } else {
     server->markAsServer();
   }
+}
+
+void ServerConfigDialog::applyManagedLocks()
+{
+  // Each control records the setting it edits so the lock check stays generic.
+  ui->rbProtocolSynergy->setProperty("managedSetting", Settings::Server::Protocol);
+  ui->rbProtocolBarrier->setProperty("managedSetting", Settings::Server::Protocol);
+  ui->cbHeartbeat->setProperty("managedSetting", Settings::Server::EnableHeatbeat);
+  ui->sbHeartbeat->setProperty("managedSetting", Settings::Server::Heartbeat);
+  ui->cbRelativeMouseMoves->setProperty("managedSetting", Settings::Server::RelativeMouseMoves);
+  ui->cbWin32KeepForeground->setProperty("managedSetting", Settings::Server::Win32KeepForeground);
+  ui->cbSwitchDelay->setProperty("managedSetting", Settings::Server::EnableSwitchDelay);
+  ui->sbSwitchDelay->setProperty("managedSetting", Settings::Server::SwitchDelay);
+  ui->cbSwitchDoubleTap->setProperty("managedSetting", Settings::Server::EnableSwitchDoubleTap);
+  ui->sbSwitchDoubleTap->setProperty("managedSetting", Settings::Server::SwitchDoubleTap);
+  ui->groupExternalConfig->setProperty("managedSetting", Settings::Server::ExternalConfig);
+  ui->lineConfigFile->setProperty("managedSetting", Settings::Server::ExternalConfigFile);
+  ui->cbDefaultLockToComputerState->setProperty("managedSetting", Settings::Server::DefaultLockToComputerState);
+  ui->cbDisableLockToComputer->setProperty("managedSetting", Settings::Server::DisableLockToComputer);
+  ui->cbEnableClipboard->setProperty("managedSetting", Settings::Server::EnableClipboard);
+  ui->sbClipboardSizeLimit->setProperty("managedSetting", Settings::Server::ClipboardSize);
+
+  deskflow::gui::applyManagedLocks(this, tr("Managed by your organization"));
 }
 
 void ServerConfigDialog::initConnections() const

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -91,6 +91,7 @@ protected:
 
 private:
   void loadFromConfig();
+  void applyManagedLocks();
   void initConnections() const;
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -14,6 +14,7 @@
 #include "common/I18N.h"
 #include "common/Settings.h"
 #include "gui/Messages.h"
+#include "gui/StyleUtils.h"
 #include "gui/TlsUtility.h"
 #include "gui/core/NetworkMonitor.h"
 
@@ -402,6 +403,41 @@ void SettingsDialog::updateControls()
   ui->widgetLogFilename->setEnabled(writable && logToFile);
 
   updateTlsControls();
+
+  // Runs last so a managed control cannot be re-enabled by the code above
+  applyManagedLocks();
+}
+void SettingsDialog::applyManagedLocks()
+{
+  // Each control records the setting it edits so the lock check stays generic.
+  // Paired radio buttons share a key so both halves lock together.
+  ui->sbPort->setProperty("managedSetting", Settings::Core::Port);
+  ui->comboInterface->setProperty("managedSetting", Settings::Core::Interface);
+  ui->comboLogLevel->setProperty("managedSetting", Settings::Log::Level);
+  ui->groupLogToFile->setProperty("managedSetting", Settings::Log::ToFile);
+  ui->lineLogFilename->setProperty("managedSetting", Settings::Log::File);
+  ui->cbGuiDebug->setProperty("managedSetting", Settings::Log::GuiDebug);
+  ui->cbElevateDaemon->setProperty("managedSetting", Settings::Daemon::Elevate);
+  ui->rbAutoHide->setProperty("managedSetting", Settings::Gui::Autohide);
+  ui->rbShowOnStart->setProperty("managedSetting", Settings::Gui::Autohide);
+  ui->rbCloseToTray->setProperty("managedSetting", Settings::Gui::CloseToTray);
+  ui->rbExitOnClose->setProperty("managedSetting", Settings::Gui::CloseToTray);
+  ui->rbIconMono->setProperty("managedSetting", Settings::Gui::SymbolicTrayIcon);
+  ui->rbIconColorful->setProperty("managedSetting", Settings::Gui::SymbolicTrayIcon);
+  ui->cbAutoUpdate->setProperty("managedSetting", Settings::Gui::AutoUpdateCheck);
+  ui->cbShowVersion->setProperty("managedSetting", Settings::Gui::ShowVersionInTitle);
+  ui->cbPreventSleep->setProperty("managedSetting", Settings::Core::PreventSleep);
+  ui->comboLanguage->setProperty("managedSetting", Settings::Core::Language);
+  ui->cbRunEnterCommand->setProperty("managedSetting", Settings::Core::EnableEnterCommand);
+  ui->cbRunExitCommand->setProperty("managedSetting", Settings::Core::EnableExitCommand);
+  ui->lineCommandEnter->setProperty("managedSetting", Settings::Core::ScreenEnterCommand);
+  ui->lineCommandExit->setProperty("managedSetting", Settings::Core::ScreenExitCommand);
+  ui->groupSecurity->setProperty("managedSetting", Settings::Security::TlsEnabled);
+  ui->lineTlsCertPath->setProperty("managedSetting", Settings::Security::Certificate);
+  ui->comboTlsKeyLength->setProperty("managedSetting", Settings::Security::KeySize);
+  ui->cbRequireClientCert->setProperty("managedSetting", Settings::Security::CheckPeers);
+
+  deskflow::gui::applyManagedLocks(this, tr("Managed by your organization"));
 }
 
 void SettingsDialog::updateRequestedKeySize() const

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -52,6 +52,7 @@ private:
 
   /// @brief Enables controls when they should be.
   void updateControls();
+  void applyManagedLocks();
 
   /// @brief updates the setting vaule for key size.
   void updateRequestedKeySize() const;

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1090,6 +1090,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished">Busque un archivo de configuración</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestionado por su organización</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation type="unfinished">Activar el bloqueo del ordenador al iniciar</translation>
     </message>
@@ -1207,6 +1211,10 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>Reset to default values</source>
         <translation type="unfinished">Restablecer valores predeterminados</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestionado por su organización</translation>
     </message>
     <message>
         <source>TLS Certificate Regenerated</source>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Restablecer valores predeterminados</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestionado por su organización</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Permite que el cliente reduzca la frecuencia con la que intenta reconectarse al servidor cuando los intentos de conexión fallan. El intervalo entre intentos de conexión comenzará en 1 segundo y podrá alcanzar un máximo de 5 minutos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1090,6 +1090,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation>Cerca un file di configurazione</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestito dalla tua organizzazione</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation type="unfinished">Abilita il blocco al computer all&apos;avvio</translation>
     </message>
@@ -1207,6 +1211,10 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>Reset to default values</source>
         <translation type="unfinished">Ripristina i valori predefiniti</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestito dalla tua organizzazione</translation>
     </message>
     <message>
         <source>TLS Certificate Regenerated</source>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Ripristina i valori predefiniti</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Gestito dalla tua organizzazione</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Consente al client di rallentare la frequenza dei tentativi di riconnessione al server quando i tentativi di connessione falliscono. Il ritardo tra i tentativi di connessione inizierà a intervalli di 1 secondo, fino a raggiungere un massimo di 5 minuti tra un tentativo e l&apos;altro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1092,6 +1092,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>設定ファイルを選択</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">組織によって管理されています</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation>起動時にコンピューター間移動のロックを有効にする</translation>
     </message>
@@ -1233,6 +1237,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Reset to default values</source>
         <translation>デフォルト値にリセットする</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">組織によって管理されています</translation>
     </message>
     <message>
         <source>Automatic</source>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation>デフォルト値にリセットする</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">組織によって管理されています</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;接続試行が失敗し続けている場合に、クライアントがサーバーへ再接続を試みる頻度を徐々に下げます。接続試行の間隔は当初1秒から開始され、最大で5分まで延長されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1090,6 +1090,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>설정 파일 찾아보기</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">조직에서 관리함</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation>시작 시 컴퓨터 잠금 사용</translation>
     </message>
@@ -1231,6 +1235,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Reset to default values</source>
         <translation type="unfinished">기본값으로 재설정</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">조직에서 관리함</translation>
     </message>
     <message>
         <source>Automatic</source>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">기본값으로 재설정</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">조직에서 관리함</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;연결 시도가 실패할 경우, 클라이언트가 서버 재연결 시도 주기를 늦추도록 허용합니다. 연결 시도 간 지연 시간은 1초 간격으로 시작되며, 최대 5분까지 늘어날 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1088,6 +1088,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>Выбор файла конфигурации</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Управляется вашей организацией</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation>Включать привязку к компьютеру при запуске</translation>
     </message>
@@ -1229,6 +1233,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Reset to default values</source>
         <translation type="unfinished">Сбросить до значений по умолчанию</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Управляется вашей организацией</translation>
     </message>
     <message>
         <source>Automatic</source>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Сбросить до значений по умолчанию</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">Управляется вашей организацией</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Позволить клиенту замедлять частоту попыток повторного подключения к серверу в случае неудачных попыток соединения. Интервал между попытками подключения будет начинаться с 1 секунды и может достигать максимума в 5 минут.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1092,6 +1092,10 @@ Enabling this setting will disable the server config GUI.</source>
         <translation>浏览配置文件</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">由您的组织管理</translation>
+    </message>
+    <message>
         <source>Enable lock to computer at startup</source>
         <translation type="unfinished">启动时启用锁定到计算机</translation>
     </message>
@@ -1233,6 +1237,10 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Reset to default values</source>
         <translation type="unfinished">重置为默认值</translation>
+    </message>
+    <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">由您的组织管理</translation>
     </message>
     <message>
         <source>Automatic</source>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -182,6 +182,10 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">重置为默认值</translation>
     </message>
     <message>
+        <source>Managed by your organization</source>
+        <translation type="unfinished">由您的组织管理</translation>
+    </message>
+    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;允许客户端在连接尝试失败时，降低其重连服务器的频率。连接尝试之间的间隔将从 1 秒开始，最长可达 5 分钟。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>


### PR DESCRIPTION
## Description

Lets an administrator enforce Deskflow settings on macOS with a configuration profile,
delivered through MDM such as Jamf Pro, Mosyle, Kandji or Intune.

Any setting key can be enforced. The preference key is the settings key exactly as
written, for example `security/tlsEnabled`, `core/port` or `server/enableClipboard`, so
there is no list of manageable settings to maintain.

Enforcement happens in `Settings::value()` and `Settings::setValue()`, so it applies to
the GUI and `deskflow-core` alike and edits to the config file are overridden.
`Settings::setValue()` now returns `false` and warns when it refuses a write rather than
returning silently. `Settings::isManaged()` is declared in `Settings` and defined per
platform: `ManagedSettings.mm` reads forced values through `NSUserDefaults` on macOS,
`ManagedSettings.cpp` reports nothing managed everywhere else.

In the GUI, each control names the setting it edits in a `managedSetting` property and a
shared helper disables the ones that are enforced, showing a note explaining why.

Documented in `docs/user/configuration.md`.

## AI tools used for this PR

<!-- confirm both model versions before posting -->
Claude Opus 4.8 (claude.ai) was used for implementation and for working through review
feedback. 
Claude Sonnet 4.6 (Claude Code) was used for code review. Translations were filled in with Google Translate and left marked unfinished.

## Related Issue

Proposed in #9659

## How Has This Been Tested?

Tested on macOS 15.7.7, 26.5.1 and 26.5.2 on an MDM enrolled Mac as well as on an unenrolled device.

On the enrolled Mac, the settings were delivered as a Jamf Pro configuration profile
using an Application & Custom Settings payload with the preferred domain
`org.deskflow.deskflow` and this plist:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>security/tlsEnabled</key>
    <false/>
    <key>core/port</key>
    <integer>12345</integer>
    <key>server/enableClipboard</key>
    <false/>
</dict>
</plist>
```

On the unenrolled Mac the same payload was written directly to
`/Library/Managed Preferences/org.deskflow.deskflow.plist` with PlistBuddy.

In both cases: enforced controls are disabled and show the enforced value, settings
without a policy stay editable, and edits to the config file are overridden. A value for example
written with `defaults write org.deskflow.deskflow log/level -int 2` is correctly not
treated as enforced, since it is not in a forced domain. Removing the profile makes the affected controls editable again.