### PR TITLE
Windows uninstall cleanup

### DIFF
--- a/deploy/windows/wix-custom.cpp
+++ b/deploy/windows/wix-custom.cpp
@@ -11,9 +11,14 @@
 
 // Include after Windows.h
 #include <MsiQuery.h>
+#include <TlHelp32.h>
 
+#include <chrono>
+#include <filesystem>
 #include <stdio.h>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace {
 // Warning: DLL will crash with error code 1603 if we exceed this.
@@ -24,6 +29,229 @@ const std::string kLogPrefix = std::string(kAppId) + " installer: ";
 
 // Note: Resized to log line max when used.
 static std::string s_logMessageBuffer; // NOSONAR - Must be mutable.
+
+const auto kServiceStopTimeout = std::chrono::seconds(30);
+const auto kFileDeleteRetries = 10;
+const auto kDeleteRetryDelay = std::chrono::milliseconds(250);
+
+std::string getMsiPropertyA(const MSIHANDLE hInstall, const char *name)
+{
+  DWORD size = 0;
+  char empty[1] = {'\0'};
+  auto result = MsiGetPropertyA(hInstall, name, empty, &size);
+  if (result != ERROR_SUCCESS && result != ERROR_MORE_DATA) {
+    return {};
+  }
+
+  std::string value(size + 1, '\0');
+  result = MsiGetPropertyA(hInstall, name, value.data(), &size);
+  if (result != ERROR_SUCCESS) {
+    return {};
+  }
+
+  value.resize(size);
+  return value;
+}
+
+std::vector<std::pair<std::string, std::string>> parseCustomActionData(const std::string &data)
+{
+  std::vector<std::pair<std::string, std::string>> kvPairs;
+  size_t start = 0;
+  while (start < data.size()) {
+    const auto end = data.find(';', start);
+    const auto pairText = data.substr(start, (end == std::string::npos) ? std::string::npos : (end - start));
+
+    const auto separator = pairText.find('=');
+    if (separator != std::string::npos && separator > 0) {
+      kvPairs.emplace_back(pairText.substr(0, separator), pairText.substr(separator + 1));
+    }
+
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+
+  return kvPairs;
+}
+
+std::string findValue(const std::vector<std::pair<std::string, std::string>> &kvPairs, const std::string &key)
+{
+  for (const auto &[k, v] : kvPairs) {
+    if (k == key) {
+      return v;
+    }
+  }
+  return {};
+}
+
+std::wstring toWide(const std::string &text)
+{
+  if (text.empty()) {
+    return {};
+  }
+
+  const auto size = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+  if (size <= 0) {
+    return {};
+  }
+
+  std::wstring wide(size, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wide.data(), size);
+  if (!wide.empty() && wide.back() == L'\0') {
+    wide.pop_back();
+  }
+  return wide;
+}
+
+std::wstring joinPath(std::wstring base, const std::wstring &leaf)
+{
+  if (base.empty()) {
+    return {};
+  }
+
+  while (!base.empty() && (base.back() == L'\\' || base.back() == L'/')) {
+    base.pop_back();
+  }
+
+  if (base.empty()) {
+    return {};
+  }
+
+  return base + L"\\" + leaf;
+}
+
+bool killProcessByName(const wchar_t *processName)
+{
+  bool terminatedAny = false;
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  PROCESSENTRY32W entry{};
+  entry.dwSize = sizeof(entry);
+  if (!Process32FirstW(snapshot, &entry)) {
+    CloseHandle(snapshot);
+    return false;
+  }
+
+  do {
+    if (_wcsicmp(entry.szExeFile, processName) != 0) {
+      continue;
+    }
+
+    const auto currentPid = GetCurrentProcessId();
+    if (entry.th32ProcessID == 0 || entry.th32ProcessID == currentPid) {
+      continue;
+    }
+
+    HANDLE process =
+        OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, FALSE, entry.th32ProcessID);
+    if (process == nullptr) {
+      continue;
+    }
+
+    if (TerminateProcess(process, 0)) {
+      WaitForSingleObject(process, 3000);
+      terminatedAny = true;
+    }
+    CloseHandle(process);
+  } while (Process32NextW(snapshot, &entry));
+
+  CloseHandle(snapshot);
+  return terminatedAny;
+}
+
+bool stopAndDeleteService(const wchar_t *serviceName)
+{
+  SC_HANDLE scm = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
+  if (scm == nullptr) {
+    return false;
+  }
+
+  SC_HANDLE service = OpenServiceW(scm, serviceName, SERVICE_STOP | SERVICE_QUERY_STATUS | DELETE);
+  if (service == nullptr) {
+    CloseServiceHandle(scm);
+    return false;
+  }
+
+  SERVICE_STATUS_PROCESS status{};
+  DWORD bytesNeeded = 0;
+  const auto queryOk = QueryServiceStatusEx(
+      service, SC_STATUS_PROCESS_INFO, reinterpret_cast<LPBYTE>(&status), sizeof(status), &bytesNeeded
+  );
+
+  if (queryOk && status.dwCurrentState != SERVICE_STOPPED && status.dwCurrentState != SERVICE_STOP_PENDING) {
+    SERVICE_STATUS unused{};
+    ControlService(service, SERVICE_CONTROL_STOP, &unused);
+  }
+
+  const auto deadline = std::chrono::steady_clock::now() + kServiceStopTimeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    bytesNeeded = 0;
+    if (!QueryServiceStatusEx(
+            service, SC_STATUS_PROCESS_INFO, reinterpret_cast<LPBYTE>(&status), sizeof(status), &bytesNeeded
+        )) {
+      break;
+    }
+
+    if (status.dwCurrentState == SERVICE_STOPPED) {
+      break;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  }
+
+  const auto deleted = (DeleteService(service) == TRUE);
+  CloseServiceHandle(service);
+  CloseServiceHandle(scm);
+  return deleted;
+}
+
+void deletePathWithRetries(const std::wstring &path)
+{
+  if (path.empty()) {
+    return;
+  }
+
+  std::error_code ec;
+  for (int i = 0; i < kFileDeleteRetries; ++i) {
+    if (!std::filesystem::exists(path, ec)) {
+      return;
+    }
+
+    ec.clear();
+    std::filesystem::remove_all(path, ec);
+    if (!ec) {
+      return;
+    }
+
+    std::this_thread::sleep_for(kDeleteRetryDelay);
+  }
+}
+
+void deleteFileWithRetries(const std::wstring &path)
+{
+  if (path.empty()) {
+    return;
+  }
+
+  std::error_code ec;
+  for (int i = 0; i < kFileDeleteRetries; ++i) {
+    if (!std::filesystem::exists(path, ec)) {
+      return;
+    }
+
+    ec.clear();
+    std::filesystem::remove(path, ec);
+    if (!ec) {
+      return;
+    }
+
+    std::this_thread::sleep_for(kDeleteRetryDelay);
+  }
+}
 } // namespace
 
 // This log output can be viewed by using the DebugView program.
@@ -34,14 +262,14 @@ static std::string s_logMessageBuffer; // NOSONAR - Must be mutable.
 
 extern "C" __declspec(dllexport) UINT __stdcall CheckVCRedist(MSIHANDLE hInstall)
 {
-  const auto kKeyName = TEXT(kRegKey);
-  const auto kValueName = TEXT("Minor");
+  const auto kKeyName = kRegKey;
+  const auto kValueName = "Minor";
   const auto kProperty = "VC_REDIST_VERSION_OK";
 
   MS_LOG_DEBUG("checking for msvc redist v%d.%d", kWindowsRuntimeMajor, kWindowsRuntimeMinor);
 
   HKEY hKey;
-  if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, kKeyName, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, kKeyName, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
     MS_LOG_DEBUG("msvc redist registry key not found");
     return ERROR_FUNCTION_FAILED;
   }
@@ -50,7 +278,7 @@ extern "C" __declspec(dllexport) UINT __stdcall CheckVCRedist(MSIHANDLE hInstall
 
   DWORD minorVersion = 0;
   DWORD size = sizeof(DWORD);
-  RegQueryValueEx(hKey, kValueName, nullptr, nullptr, (LPBYTE)&minorVersion, &size);
+  RegQueryValueExA(hKey, kValueName, nullptr, nullptr, reinterpret_cast<LPBYTE>(&minorVersion), &size);
   RegCloseKey(hKey);
 
   MS_LOG_DEBUG("msvc redist minor version: %lu", minorVersion);
@@ -62,11 +290,69 @@ extern "C" __declspec(dllexport) UINT __stdcall CheckVCRedist(MSIHANDLE hInstall
   }
 
   MS_LOG_DEBUG("msvc redist version ok, setting: %s", kProperty);
-  if (MsiSetProperty(hInstall, kProperty, "ok") != ERROR_SUCCESS) {
+  if (MsiSetPropertyA(hInstall, kProperty, "ok") != ERROR_SUCCESS) {
     MS_LOG_DEBUG("failed to set property: %s", kProperty);
     return ERROR_FUNCTION_FAILED;
   }
 
   MS_LOG_DEBUG("msvc redist version check successful");
+  return ERROR_SUCCESS;
+}
+
+extern "C" __declspec(dllexport) UINT __stdcall StopAndRemoveService(MSIHANDLE hInstall)
+{
+  const auto data = getMsiPropertyA(hInstall, "CustomActionData");
+  const auto kv = parseCustomActionData(data);
+  const auto serviceName = toWide(findValue(kv, "SERVICE_NAME"));
+
+  if (serviceName.empty()) {
+    MS_LOG_DEBUG("%s", "service cleanup skipped: missing service name");
+    return ERROR_SUCCESS;
+  }
+
+  MS_LOG_DEBUG("stopping/deleting service: %ls", serviceName.c_str());
+
+  const auto daemonKilled = killProcessByName(L"deskflow-daemon.exe");
+  const auto coreKilled = killProcessByName(L"deskflow-core.exe");
+  const auto guiKilled = killProcessByName(L"deskflow.exe");
+  MS_LOG_DEBUG(
+      "process cleanup done: daemon=%d core=%d gui=%d", daemonKilled ? 1 : 0, coreKilled ? 1 : 0, guiKilled ? 1 : 0
+  );
+
+  const auto deleted = stopAndDeleteService(serviceName.c_str());
+  MS_LOG_DEBUG("service delete result: %d", deleted ? 1 : 0);
+
+  return ERROR_SUCCESS;
+}
+
+extern "C" __declspec(dllexport) UINT __stdcall CleanupInstalledArtifacts(MSIHANDLE hInstall)
+{
+  const auto data = getMsiPropertyA(hInstall, "CustomActionData");
+  const auto kv = parseCustomActionData(data);
+
+  const auto installRoot = toWide(findValue(kv, "INSTALL_ROOT"));
+  const auto commonAppData = toWide(findValue(kv, "COMMON_APPDATA"));
+  const auto localAppData = toWide(findValue(kv, "LOCAL_APPDATA"));
+  const auto roamingAppData = toWide(findValue(kv, "APPDATA"));
+
+  const std::wstring appName = L"Deskflow";
+  const std::wstring appId = toWide(std::string(kAppId));
+
+  if (!installRoot.empty()) {
+    MS_LOG_DEBUG("cleanup uninstall path: %ls", installRoot.c_str());
+    deletePathWithRetries(installRoot);
+  }
+
+  for (const auto &base : {commonAppData, localAppData, roamingAppData}) {
+    if (base.empty()) {
+      continue;
+    }
+
+    deletePathWithRetries(joinPath(base, appName));
+    deletePathWithRetries(joinPath(base, appId));
+    deleteFileWithRetries(joinPath(base, appName + L".state"));
+    deleteFileWithRetries(joinPath(base, appId + L".state"));
+  }
+
   return ERROR_SUCCESS;
 }

--- a/deploy/windows/wix-custom.h.in
+++ b/deploy/windows/wix-custom.h.in
@@ -7,6 +7,7 @@
 #pragma once
 
 const auto kAppId = "@CMAKE_PROJECT_NAME@";
+const auto kAppName = "@CMAKE_PROJECT_PROPER_NAME@";
 const auto kRegKey = "SOFTWARE\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\@BUILD_ARCHITECTURE@";
 
 // clang-format off

--- a/deploy/windows/wix-patch.xml.in
+++ b/deploy/windows/wix-patch.xml.in
@@ -46,11 +46,50 @@
        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Run Deskflow when finished" />
     </UI>
+
+    <UI>
+       <Publish Dialog="MaintenanceTypeDlg"
+           Control="Finish"
+           Event="DoAction"
+           Value="RunDeskflow"
+           Condition= "WIXUI_RMUSERDATAOPTIONALCHECKBOX = 1 and NOT Installed" />
+       <Property Id="WIXUI_RMUSERDATAOPTIONALCHECKBOX" Value="0" />
+       <Property Id="WIXUI_RMUSERDATAOPTIONALCHECKBOXTEXT" Value="Remove user data when uninstalling" />
+    </UI>
+
     <CustomAction
       Id="CheckVCRedist"
       BinaryRef="CustomDLL"
       DllEntry="CheckVCRedist"
       Execute="immediate" />
+
+    <CustomAction
+      Id="SetStopAndRemoveServiceData"
+      Property="StopAndRemoveService"
+      Value="SERVICE_NAME=@CMAKE_PROJECT_PROPER_NAME@"
+      Execute="immediate" />
+
+    <CustomAction
+      Id="StopAndRemoveService"
+      BinaryRef="CustomDLL"
+      DllEntry="StopAndRemoveService"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check" />
+
+    <CustomAction
+      Id="SetCleanupInstalledArtifactsData"
+      Property="CleanupInstalledArtifacts"
+      Value="INSTALL_ROOT=[INSTALL_ROOT];COMMON_APPDATA=[CommonAppDataFolder];LOCAL_APPDATA=[LocalAppDataFolder];APPDATA=[AppDataFolder]"
+      Execute="immediate" />
+
+    <CustomAction
+      Id="CleanupInstalledArtifacts"
+      BinaryRef="CustomDLL"
+      DllEntry="CleanupInstalledArtifacts"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check" />
 
     <CustomAction
       Id="ShowVCRedistError"
@@ -65,6 +104,22 @@
       Return="asyncNoWait" />
 
     <InstallExecuteSequence>
+      <Custom
+        Action="SetStopAndRemoveServiceData"
+        Before="StopAndRemoveService"
+        Condition="REMOVE=&quot;ALL&quot;" />
+      <Custom
+        Action="StopAndRemoveService"
+        Before="StopServices"
+        Condition="REMOVE=&quot;ALL&quot;" />
+      <Custom
+        Action="SetCleanupInstalledArtifactsData"
+        Before="CleanupInstalledArtifacts"
+        Condition="REMOVE=&quot;ALL&quot;" />
+      <Custom
+        Action="CleanupInstalledArtifacts"
+        After="RemoveFiles"
+        Condition="REMOVE=&quot;ALL&quot;" />
       <Custom
         Action="CheckVCRedist"
         Before="InstallInitialize"


### PR DESCRIPTION
Parts were split into #9777 

## Description

This PR improves Windows build, packaging, and installer reliability.

It includes:
- Proper uninstall cleanup (service removal and residual files)

## Disclosure of AI use

AI tools were used to assist with explanations and structuring the PR description.  
All code changes were implemented, tested, and validated manually.

## Related Issue

N/A

## How Has This Been Tested?

- Built using MSVC2022 and Qt 6.11
- Verified portable build runs correctly
- Verified MSI installer installs and uninstalls cleanly
- Confirmed no leftover services or files after uninstall:
  - `C:\Program Files\Deskflow`
  - `C:\ProgramData\Deskflow`
  - `%APPDATA%\Deskflow`
  - `%LOCALAPPDATA%\Deskflow`