### PR TITLE
Fix client network bind

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -641,17 +641,14 @@ void Client::handleResume()
 
 void Client::bindNetworkInterface(IDataSocket *socket) const
 {
-  try {
-    if (const auto address = Settings::value(Settings::Core::Interface).toString(); !address.isEmpty()) {
-      LOG_VERBOSE("bind to network interface: %s", qPrintable(address));
+  const auto address = Settings::value(Settings::Core::Interface).toString();
+  if (address.isEmpty())
+    return;
 
-      NetworkAddress bindAddress(address.toStdString());
-      bindAddress.resolve();
+  LOG_DEBUG("bind to network interface: %s", qPrintable(address));
 
-      socket->bind(bindAddress);
-    }
-  } catch (BaseException &e) {
-    LOG_WARN("%s", e.what());
-    LOG_WARN("operating system will select network interface automatically");
-  }
+  NetworkAddress bindAddress(address.toStdString());
+  bindAddress.resolve();
+
+  socket->bind(bindAddress);
 }

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -524,14 +524,20 @@ void MainWindow::updateModeControls()
   const auto mode = m_coreProcess.mode();
   const bool isServer = mode == Settings::CoreMode::Server;
   const bool isClient = mode == Settings::CoreMode::Client;
+
   ui->serverOptions->setVisible(isServer);
-  ui->lblIpAddresses->setVisible(isServer);
   ui->clientOptions->setVisible(isClient);
   ui->lblNoMode->setVisible(!isServer && !isClient);
   toggleCanRunCore(canRunCore());
 
-  if (isServer) {
+  ui->lblIpAddresses->setVisible(
+      (isClient && !Settings::value(Settings::Core::Interface).toString().isEmpty()) || isServer
+  );
+
+  if (ui->lblIpAddresses->isVisible())
     updateNetworkInfo();
+
+  if (isServer) {
     m_networkMonitor->startMonitoring();
   } else {
     m_networkMonitor->stopMonitoring();
@@ -587,7 +593,15 @@ void MainWindow::updateSecurityIcon(bool visible)
 
 void MainWindow::updateNetworkInfo()
 {
-  updateIpLabel(NetworkMonitor::validAddresses());
+  const auto mode = m_coreProcess.mode();
+  if (mode == CoreMode::None) {
+    return;
+  }
+
+  if (mode == CoreMode::Server)
+    updateIpLabel(NetworkMonitor::validAddresses());
+  else
+    updateIpLabel({Settings::value(Settings::Core::Interface).toString()});
 }
 
 void MainWindow::serverConnectionConfigureClient(const QString &clientName)
@@ -1215,7 +1229,8 @@ void MainWindow::remoteHostChanged(const QString &newRemoteHost)
 
 void MainWindow::updateIpLabel(const QStringList &addresses)
 {
-  if (m_coreProcess.mode() != CoreMode::Server) {
+  const auto mode = m_coreProcess.mode();
+  if (mode == CoreMode::None) {
     return;
   }
 
@@ -1232,7 +1247,6 @@ void MainWindow::updateIpLabel(const QStringList &addresses)
   QString labelText = fixedIP ? tr("Using IP: ") : tr("Suggested IP: ");
   QString toolTipText = tr("<p>If connecting via the hostname fails, try %1</p>");
 
-  // Get all available IPs for tooltip
   const bool filterIpList = (serverStarted || fixedIP);
   const QRegularExpression ipListFilter(filterIpList ? QStringLiteral("(%1)").arg(m_serverStartIPs.join("|")) : "");
   const QStringList ipList = addresses.filter(ipListFilter);
@@ -1257,7 +1271,7 @@ void MainWindow::updateIpLabel(const QStringList &addresses)
   }
 
   ui->lblIpAddresses->setText(labelText);
-  ui->lblIpAddresses->setToolTip(toolTipText);
+  ui->lblIpAddresses->setToolTip(mode == CoreMode::Server ? toolTipText : QString());
 }
 
 void MainWindow::updateTimeoutDelay(int newDelay)


### PR DESCRIPTION


## Description
When a client is configured to bind to a strict network interface (e.g., a specific Ethernet IP), and that interface drops or becomes unavailable, socket->bind() throws a BaseException.

Previously, this exception was caught and swallowed in Client::bindNetworkInterface, allowing the client to silently fall back to 0.0.0.0 (or INADDR_ANY) and connect over unintended interfaces like WiFi.

This PR re-throws the exception to abort the connection attempt, preventing the automatic OS fallback and respecting the user's strict IP configuration.

## Disclosure of AI use
I used an AI assistant (Google Gemini) to help map the codebase and trace the socket binding fallback logic in Client.cpp. The final C++ exception handling fix was manually written, reviewed, and compiled locally.

## Related Issue
fixes: #9552

## How Has This Been Tested?
Tested locally on Windows 11 using MSVC 2022 and Qt 6.8.3.

Verification Steps:

Configured the Deskflow client to bind to a specific, active network interface IP in the settings.

Disconnected/disabled that specific network interface to simulate an environment change.

Started the client connection.

Verified that the connection cleanly aborts and throws the bind exception, rather than printing the "operating system will select network interface automatically" warning and silently connecting via an alternative active adapter.