### PR TITLE
[WIP] Long running Core process with file log tail

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -132,6 +132,9 @@ int main(int argc, char **argv)
   QApplication::setApplicationName(QStringLiteral("%1 Core").arg(kAppName));
 
   const auto ipcServer = new deskflow::core::ipc::CoreIpcServer(&app); // NOSONAR - Qt managed
+  QObject::connect(
+      ipcServer, &deskflow::core::ipc::IpcServer::stopProcessRequested, coreApp, &App::quit, Qt::DirectConnection
+  );
   ipcServer->listen();
 
   QThread coreThread;

--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -11,6 +11,7 @@
 #include "arch/Arch.h"
 #include "base/EventQueue.h"
 #include "base/Log.h"
+#include "base/LogOutputters.h"
 #include "common/Constants.h"
 #include "common/ExitCodes.h"
 #include "deskflow/ClientApp.h"
@@ -22,8 +23,10 @@
 #endif
 
 #include <QApplication>
+#include <QDir>
 #include <QFileInfo>
 #include <QSharedMemory>
+#include <QStandardPaths>
 #include <QTextStream>
 #include <QThread>
 #include <QtGlobal>
@@ -85,6 +88,11 @@ int main(int argc, char **argv)
   Log log;
   qInstallMessageHandler(qtMessageHandler);
 
+  const auto cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+  QDir().mkpath(cacheDir);
+  const auto coreLogFilename = QStringLiteral("%1/%2-core.log").arg(cacheDir, kAppId);
+  CLOG->insert(new FileLogOutputter(coreLogFilename)); // NOSONAR - Adopted by `Log`
+
   QStringList args;
   for (int i = 0; i < argc; i++)
     args.append(argv[i]);
@@ -131,7 +139,7 @@ int main(int argc, char **argv)
   QApplication app(argc, argv);
   QApplication::setApplicationName(QStringLiteral("%1 Core").arg(kAppName));
 
-  const auto ipcServer = new deskflow::core::ipc::CoreIpcServer(&app); // NOSONAR - Qt managed
+  const auto ipcServer = new deskflow::core::ipc::CoreIpcServer(&app, coreLogFilename); // NOSONAR - Qt managed
   QObject::connect(
       ipcServer, &deskflow::core::ipc::IpcServer::stopProcessRequested, coreApp, &App::quit, Qt::DirectConnection
   );

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -168,6 +168,12 @@ void App::handleScreenError() const
   getEvents()->addEvent(Event(EventTypes::Quit));
 }
 
+void App::quit()
+{
+  LOG_INFO("quitting");
+  getEvents()->addEvent(Event(EventTypes::Quit));
+}
+
 void App::runEventsLoop(const void *)
 {
   int exitCode = m_events->loop();

--- a/src/lib/deskflow/App.h
+++ b/src/lib/deskflow/App.h
@@ -77,6 +77,7 @@ public:
   }
 
   void run(QThread &coreThread);
+  void quit();
   void setupFileLogging();
   void loggingFilterWarning() const;
   void initApp() override;

--- a/src/lib/deskflow/ipc/CoreIpcServer.cpp
+++ b/src/lib/deskflow/ipc/CoreIpcServer.cpp
@@ -29,8 +29,14 @@ CoreIpcServer &CoreIpcServer::instance()
 
 void CoreIpcServer::processCommand(QLocalSocket *clientSocket, const QString &command, const QStringList &parts)
 {
-  Q_UNUSED(clientSocket)
   Q_UNUSED(parts)
+  if (command == QStringLiteral("stop")) {
+    LOG_DEBUG("core ipc server got stop message");
+    writeToClientSocket(clientSocket, QStringLiteral("ok"));
+    broadcastCommand(QStringLiteral("bye"));
+    Q_EMIT stopProcessRequested();
+    return;
+  }
   LOG_WARN("core ipc server got unknown command: %s", command.toUtf8().constData());
 }
 

--- a/src/lib/deskflow/ipc/CoreIpcServer.cpp
+++ b/src/lib/deskflow/ipc/CoreIpcServer.cpp
@@ -15,7 +15,9 @@ namespace deskflow::core::ipc {
 
 static CoreIpcServer *s_instance = nullptr;
 
-CoreIpcServer::CoreIpcServer(QObject *parent) : IpcServer(parent, kCoreIpcName, QStringLiteral("core"))
+CoreIpcServer::CoreIpcServer(QObject *parent, const QString &logFilename)
+    : IpcServer(parent, kCoreIpcName, QStringLiteral("core")),
+      m_logFilename(logFilename)
 {
   assert(s_instance == nullptr);
   s_instance = this;
@@ -35,6 +37,11 @@ void CoreIpcServer::processCommand(QLocalSocket *clientSocket, const QString &co
     writeToClientSocket(clientSocket, QStringLiteral("ok"));
     broadcastCommand(QStringLiteral("bye"));
     Q_EMIT stopProcessRequested();
+    return;
+  }
+  if (command == QStringLiteral("logPath")) {
+    LOG_DEBUG("core ipc server got log path request");
+    writeToClientSocket(clientSocket, QStringLiteral("logPath=%1").arg(m_logFilename));
     return;
   }
   LOG_WARN("core ipc server got unknown command: %s", command.toUtf8().constData());

--- a/src/lib/deskflow/ipc/CoreIpcServer.h
+++ b/src/lib/deskflow/ipc/CoreIpcServer.h
@@ -20,12 +20,14 @@ class CoreIpcServer : public IpcServer
   Q_OBJECT
 
 public:
-  explicit CoreIpcServer(QObject *parent);
+  explicit CoreIpcServer(QObject *parent, const QString &logFilename);
 
   static CoreIpcServer &instance();
 
 private:
   void processCommand(QLocalSocket *clientSocket, const QString &command, const QStringList &parts) override;
+
+  const QString m_logFilename;
 };
 
 } // namespace deskflow::core::ipc

--- a/src/lib/deskflow/ipc/IpcServer.cpp
+++ b/src/lib/deskflow/ipc/IpcServer.cpp
@@ -125,13 +125,12 @@ void IpcServer::processMessage(QLocalSocket *clientSocket, const QString &messag
     LOG_DEBUG("%s ipc server got hello message (version: %s)", m_typeName.constData(), versionId.toUtf8().constData());
 
     if (clientVersion != versionId) {
-      LOG_ERR(
+      LOG_WARN(
           "%s ipc client version mismatch (client: %s, server: %s)", m_typeName.constData(),
           clientVersion.toUtf8().constData(), versionId.toUtf8().constData()
       );
-      writeToClientSocket(clientSocket, QStringLiteral("error=version mismatch, expected: %1").arg(versionId));
+      writeToClientSocket(clientSocket, QStringLiteral("versionMismatch=%1").arg(versionId));
       clientSocket->flush();
-      clientSocket->disconnectFromServer();
       return;
     }
 

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -144,6 +144,33 @@ void CoreProcess::daemonIpcClientConnected()
   m_daemonIpcClient->requestLogPath();
 }
 
+void CoreProcess::checkExistingProcess()
+{
+  qInfo("checking existing core");
+
+  auto *client = new ipc::CoreIpcClient(this);
+  connect(client, &ipc::CoreIpcClient::connected, this, [client] {
+    qInfo("existing core has matching version, leaving it running");
+    client->deleteLater();
+  });
+  connect(client, &ipc::CoreIpcClient::versionMismatch, this, [client] {
+    qInfo("existing core has mismatched version, asking it to stop");
+    client->sendStop();
+  });
+  connect(client, &ipc::CoreIpcClient::serverShutdown, this, [this, client] {
+    qInfo("existing core stopped successfully");
+    client->deleteLater();
+    setProcessState(ProcessState::RetryPending);
+    m_retryTimer.setSingleShot(true);
+    m_retryTimer.start(kRetryDelay);
+  });
+  connect(client, &ipc::CoreIpcClient::connectionFailed, this, [client] {
+    qCritical("could not contact existing core");
+    client->deleteLater();
+  });
+  client->connectToServer();
+}
+
 void CoreProcess::onProcessFinished(int exitCode, QProcess::ExitStatus)
 {
   using enum ProcessState;
@@ -155,10 +182,11 @@ void CoreProcess::onProcessFinished(int exitCode, QProcess::ExitStatus)
 
   if (exitCode != s_exitSuccess) {
     setProcessState(Stopped);
-    if (exitCode == s_exitDuplicate)
-      qWarning("desktop process is already running");
-    else
-      qWarning("desktop process exited with code: %d", exitCode);
+    if (exitCode == s_exitDuplicate) {
+      checkExistingProcess();
+      return;
+    }
+    qWarning("desktop process exited with code: %d", exitCode);
     return;
   }
 
@@ -399,9 +427,14 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
 
           m_coreIpcClient = new ipc::CoreIpcClient(this);
           connect(m_coreIpcClient, &ipc::CoreIpcClient::commandReceived, this, &CoreProcess::onCoreIpcMessageReceived);
-          connect(m_coreIpcClient, &ipc::CoreIpcClient::connected, this, [] { qInfo("connected to core ipc server"); });
+          connect(m_coreIpcClient, &ipc::CoreIpcClient::connected, this, [] {
+            qDebug("connected to core ipc server");
+          });
           connect(m_coreIpcClient, &ipc::CoreIpcClient::connectionFailed, this, [] {
             qWarning("failed to establish core ipc connection");
+          });
+          connect(m_coreIpcClient, &ipc::CoreIpcClient::serverShutdown, this, [] {
+            qDebug("core ipc server shut down cleanly");
           });
 
           m_coreIpcClient->connectToServer();

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -144,31 +144,52 @@ void CoreProcess::daemonIpcClientConnected()
   m_daemonIpcClient->requestLogPath();
 }
 
-void CoreProcess::checkExistingProcess()
+void CoreProcess::setupCoreIpcClient()
 {
-  qInfo("checking existing core");
+  if (m_coreIpcClient) {
+    return;
+  }
 
-  auto *client = new ipc::CoreIpcClient(this);
-  connect(client, &ipc::CoreIpcClient::connected, this, [client] {
-    qInfo("existing core has matching version, leaving it running");
-    client->deleteLater();
+  m_coreIpcClient = new ipc::CoreIpcClient(this);
+
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::commandReceived, this, &CoreProcess::onCoreIpcMessageReceived);
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::logPathReceived, this, &CoreProcess::setupCoreLogTail);
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::connected, this, [this] {
+    qDebug("connected to core ipc server");
+    m_coreIpcClient->requestLogPath();
   });
-  connect(client, &ipc::CoreIpcClient::versionMismatch, this, [client] {
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::versionMismatch, this, [this] {
     qInfo("existing core has mismatched version, asking it to stop");
-    client->sendStop();
+    m_coreIpcClient->sendStop();
   });
-  connect(client, &ipc::CoreIpcClient::serverShutdown, this, [this, client] {
-    qInfo("existing core stopped successfully");
-    client->deleteLater();
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::connectionFailed, this, [] {
+    qWarning("failed to establish core ipc connection");
+  });
+  connect(m_coreIpcClient, &ipc::CoreIpcClient::serverShutdown, this, [this] {
+    qDebug("core ipc server shut down cleanly");
+    m_coreIpcClient->deleteLater();
+    m_coreIpcClient = nullptr;
     setProcessState(ProcessState::RetryPending);
     m_retryTimer.setSingleShot(true);
     m_retryTimer.start(kRetryDelay);
   });
-  connect(client, &ipc::CoreIpcClient::connectionFailed, this, [client] {
-    qCritical("could not contact existing core");
-    client->deleteLater();
-  });
-  client->connectToServer();
+}
+
+void CoreProcess::checkExistingProcess()
+{
+  qInfo("checking existing core");
+  setupCoreIpcClient();
+
+  connect(
+      m_coreIpcClient, &ipc::CoreIpcClient::connected, this,
+      [this] {
+        qInfo("existing core has matching version, leaving it running");
+        setProcessState(ProcessState::Started);
+      },
+      static_cast<Qt::ConnectionType>(Qt::SingleShotConnection | Qt::QueuedConnection)
+  );
+
+  m_coreIpcClient->connectToServer();
 }
 
 void CoreProcess::onProcessFinished(int exitCode, QProcess::ExitStatus)
@@ -424,19 +445,7 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
           if (m_processState != ProcessState::Started) {
             return;
           }
-
-          m_coreIpcClient = new ipc::CoreIpcClient(this);
-          connect(m_coreIpcClient, &ipc::CoreIpcClient::commandReceived, this, &CoreProcess::onCoreIpcMessageReceived);
-          connect(m_coreIpcClient, &ipc::CoreIpcClient::connected, this, [] {
-            qDebug("connected to core ipc server");
-          });
-          connect(m_coreIpcClient, &ipc::CoreIpcClient::connectionFailed, this, [] {
-            qWarning("failed to establish core ipc connection");
-          });
-          connect(m_coreIpcClient, &ipc::CoreIpcClient::serverShutdown, this, [] {
-            qDebug("core ipc server shut down cleanly");
-          });
-
+          setupCoreIpcClient();
           m_coreIpcClient->connectToServer();
         });
       },
@@ -642,6 +651,28 @@ void CoreProcess::setupDaemonLogTail(const QString &logPath)
   } else {
     m_daemonFileTail = new FileTail(logPath, this);
     connect(m_daemonFileTail, &FileTail::newLine, this, &CoreProcess::handleLogLines);
+  }
+}
+
+void CoreProcess::setupCoreLogTail(const QString &logPath)
+{
+  const auto processMode = Settings::value(Settings::Core::ProcessMode).value<ProcessMode>();
+  if (processMode != ProcessMode::Desktop) {
+    return;
+  }
+
+  qDebug() << "core log path:" << logPath;
+
+  if (m_coreFileTail) {
+    m_coreFileTail->setWatchedFile(logPath);
+  } else {
+    m_coreFileTail = new FileTail(logPath, this);
+    connect(m_coreFileTail, &FileTail::newLine, this, &CoreProcess::handleLogLines);
+  }
+
+  if (m_process) {
+    disconnect(m_process, &QProcess::readyReadStandardOutput, this, &CoreProcess::onProcessReadyReadStandardOutput);
+    disconnect(m_process, &QProcess::readyReadStandardError, this, &CoreProcess::onProcessReadyReadStandardError);
   }
 }
 

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -114,6 +114,7 @@ private:
   void handleLogLines(const QString &text);
   QString correctedAddress(const QString &address) const;
   void setupDaemonLogTail(const QString &logPath);
+  void checkExistingProcess();
   static QString makeQuotedArgs(const QString &app, const QStringList &args);
   static QString processModeToString(const Settings::ProcessMode mode);
   static QString processStateToString(const CoreProcess::ProcessState state);

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -114,6 +114,8 @@ private:
   void handleLogLines(const QString &text);
   QString correctedAddress(const QString &address) const;
   void setupDaemonLogTail(const QString &logPath);
+  void setupCoreLogTail(const QString &logPath);
+  void setupCoreIpcClient();
   void checkExistingProcess();
   static QString makeQuotedArgs(const QString &app, const QStringList &args);
   static QString processModeToString(const Settings::ProcessMode mode);
@@ -132,6 +134,7 @@ private:
   deskflow::gui::ipc::CoreIpcClient *m_coreIpcClient = nullptr;
   deskflow::gui::ipc::DaemonIpcClient *m_daemonIpcClient = nullptr;
   FileTail *m_daemonFileTail = nullptr;
+  FileTail *m_coreFileTail = nullptr;
   QProcess *m_process = nullptr;
   QString m_appPath;
 };

--- a/src/lib/gui/ipc/CoreIpcClient.cpp
+++ b/src/lib/gui/ipc/CoreIpcClient.cpp
@@ -20,6 +20,11 @@ CoreIpcClient::CoreIpcClient(QObject *parent) : IpcClient(parent, kCoreIpcName, 
   // do nothing
 }
 
+void CoreIpcClient::sendStop()
+{
+  sendMessage(QStringLiteral("stop"));
+}
+
 void CoreIpcClient::processCommand(const QString &command, const QStringList &parts)
 {
   const auto args = parts.size() >= 2 ? parts.at(1) : QString();

--- a/src/lib/gui/ipc/CoreIpcClient.cpp
+++ b/src/lib/gui/ipc/CoreIpcClient.cpp
@@ -25,8 +25,18 @@ void CoreIpcClient::sendStop()
   sendMessage(QStringLiteral("stop"));
 }
 
+void CoreIpcClient::requestLogPath()
+{
+  sendMessage(QStringLiteral("logPath"));
+}
+
 void CoreIpcClient::processCommand(const QString &command, const QStringList &parts)
 {
+  if (command == QStringLiteral("logPath") && parts.size() == 2) {
+    Q_EMIT logPathReceived(parts.at(1));
+    return;
+  }
+
   const auto args = parts.size() >= 2 ? parts.at(1) : QString();
   Q_EMIT commandReceived(command, args);
 }

--- a/src/lib/gui/ipc/CoreIpcClient.h
+++ b/src/lib/gui/ipc/CoreIpcClient.h
@@ -19,6 +19,8 @@ class CoreIpcClient : public IpcClient
 public:
   explicit CoreIpcClient(QObject *parent = nullptr);
 
+  void sendStop();
+
 Q_SIGNALS:
   void commandReceived(const QString &command, const QString &args);
 

--- a/src/lib/gui/ipc/CoreIpcClient.h
+++ b/src/lib/gui/ipc/CoreIpcClient.h
@@ -20,9 +20,11 @@ public:
   explicit CoreIpcClient(QObject *parent = nullptr);
 
   void sendStop();
+  void requestLogPath();
 
 Q_SIGNALS:
   void commandReceived(const QString &command, const QString &args);
+  void logPathReceived(const QString &logPath);
 
 protected:
   void processCommand(const QString &command, const QStringList &parts) override;

--- a/src/lib/gui/ipc/IpcClient.cpp
+++ b/src/lib/gui/ipc/IpcClient.cpp
@@ -151,6 +151,13 @@ void IpcClient::handleReadyRead()
       continue;
     }
 
+    if (parts.at(0) == QStringLiteral("bye")) {
+      qDebug().noquote() << QStringLiteral("%1 ipc server is shutting down").arg(m_typeName);
+      disconnectFromServer();
+      Q_EMIT serverShutdown();
+      return;
+    }
+
     processCommand(parts.at(0), parts);
   }
 
@@ -169,21 +176,23 @@ void IpcClient::handleHandshakeMessage(const QStringList &parts)
     return;
   }
 
+  const auto versionId = QStringLiteral("%1+%2").arg(kVersion, kVersionGitSha);
+
+  if (parts.at(0) == QStringLiteral("versionMismatch")) {
+    const auto serverVersion = parts.size() >= 2 ? parts.at(1) : QStringLiteral("unknown");
+    qWarning().noquote(
+    ) << QStringLiteral("%1 ipc version mismatch (client: %2, server: %3)").arg(m_typeName, versionId, serverVersion);
+    m_state = State::Connected;
+    Q_EMIT versionMismatch();
+    return;
+  }
+
   if (parts.at(0) != QStringLiteral("hello")) {
     return;
   }
 
   if (parts.size() < 2) {
     qCritical().noquote() << QStringLiteral("%1 ipc server hello missing version").arg(m_typeName);
-    disconnectFromServer();
-    Q_EMIT connectionFailed();
-    return;
-  }
-
-  const auto versionId = QStringLiteral("%1+%2").arg(kVersion, kVersionGitSha);
-  if (const auto serverVersion = parts.at(1); serverVersion != versionId) {
-    qCritical().noquote(
-    ) << QStringLiteral("%1 ipc version mismatch (client: %2 , server: %3)").arg(m_typeName, versionId, serverVersion);
     disconnectFromServer();
     Q_EMIT connectionFailed();
     return;

--- a/src/lib/gui/ipc/IpcClient.h
+++ b/src/lib/gui/ipc/IpcClient.h
@@ -38,6 +38,8 @@ public:
 Q_SIGNALS:
   void connected();
   void connectionFailed();
+  void serverShutdown();
+  void versionMismatch();
 
 private Q_SLOTS:
   void handleDisconnected();


### PR DESCRIPTION
:warning:  WIP: Unfinished, commits missing, not ready for review.

## Description

When there is an existing Core process (e.g. GUI crashes and restarts), we do not handle this in the GUI.

This PR changes the GUI to reuse an existing Core process. It depends on #9645 which kills bad version Core processes for when GUI crashes and user attempts to fix it by updating to a newer version (we can't take over an existing process if it has a bad version).

## Disclosure of AI use

`claude-opus-4-7` to draft specific changes that I proposed, which I edited.

## Related Issue

Depends on #9645
Fixes #8879

## How Has This Been Tested?

1. Start Core from CLI
2. Run GUI

## To do

- [x] Get handover working when we see existing
- [ ] Fix merge conflicts
- [ ] Send current state back to Core IPC client
- [ ] Wire up Core process stop/start controls
- [ ] Apply config without restarting Core