### PR TITLE
fix(tls): prevent DoS by removing blocking sleep

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -423,13 +423,12 @@ int SecureSocket::secureAccept(int socket)
   checkResult(r, retry);
 
   if (isFatal()) {
-    // tell user and sleep so the socket isn't hammered.
+    // Never block here; this thread services every connected socket.
+    // Historically a 1s sleep let any failed handshake DoS all clients.
     LOG_ERR("failed to accept secure socket");
-    LOG_WARN("client connection may not be secure");
     m_secureReady = false;
-    Arch::sleep(1);
     retry = 0;
-    return -1; // Failed, error out
+    return -1; // Fail
   }
 
   // If not fatal and no retry, state is good
@@ -455,7 +454,7 @@ int SecureSocket::secureAccept(int socket)
 
   // no good state exists here
   LOG_ERR("unexpected state attempting to accept connection");
-  return -1;
+  return -1; // Fail
 }
 
 int SecureSocket::secureConnect(int socket)


### PR DESCRIPTION
## Description

Fixes a TLS DoS (clients become unusable) by removing an unnecessary sleep that blocks the server TLS multiplexer thread handling connected clients.

## AI tools used for this PR

Claude Opus 4.7 to find the sleep causing the vuln.

## Related Issue

Fixes: 
- [GHSA-3mxm-cgh2-6448](https://github.com/deskflow/deskflow/security/advisories/GHSA-3mxm-cgh2-6448)
- #8214

## How Has This Been Tested?

Run the PoC: https://github.com/deskflow/scripts/pull/9

```
$ scripts/security/poc/cve_XXXX_XXXXX_tls_dos.py

CVE-XXXX-XXXXX — TLS multiplexer stall on failed SSL_accept
target: 127.0.0.1:24800  stalls: 5

[*] collecting baseline hello rtt (no attack)
  baseline hello rtt: 8 ms
  baseline hello rtt: 5 ms
  baseline hello rtt: 5 ms
  baseline median: 5 ms

[*] firing 5 plaintext garbage connections
[*] measuring hello rtt during attack
  attack hello rtt: 4957 ms

  attack median: 4957 ms
  overhead:      4951 ms (threshold 2500 ms)
[FAIL] multiplexer stalled by 4951 ms — VULNERABLE (CVE-XXXX-XXXXX)
```