### PR TITLE
fix: ensure correct screen name is set for switchToScreen

### DIFF
--- a/src/lib/gui/dialogs/ActionDialog.cpp
+++ b/src/lib/gui/dialogs/ActionDialog.cpp
@@ -51,7 +51,7 @@ ActionDialog::ActionDialog(QWidget *parent, const ServerConfig &config, Hotkey &
 
     ui->listScreens->addItem(newListItem);
 
-    ui->comboSwitchToScreen->addItem(tr("Switch to %1").arg(screen.name()));
+    ui->comboSwitchToScreen->addItem(tr("Switch to %1").arg(screen.name()), screen.name());
     if (screen.name() == m_action.switchScreenName())
       ui->comboSwitchToScreen->setCurrentIndex(ui->comboSwitchToScreen->count() - 1);
   }
@@ -92,7 +92,7 @@ void ActionDialog::accept()
 
   m_action.setHaveScreens(screenCount);
 
-  m_action.setSwitchScreenName(ui->comboSwitchToScreen->currentText().remove(tr("Switch to ")));
+  m_action.setSwitchScreenName(ui->comboSwitchToScreen->currentData().toString());
   m_action.setSwitchDirection(ui->comboSwitchInDirection->currentIndex());
   m_action.setLockCursorMode(ui->comboLockCursorToScreen->currentIndex());
   m_action.setActiveOnRelease(ui->comboTriggerOn->currentIndex());

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation type="unfinished">Cambiar a %1</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation type="unfinished">Cambiar a </translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation>Passa a %1</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation>Passa a </translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation>%1 に切り替える</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation>に切り替える</translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation>%1(으)로 전환</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation>전환: </translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation>Переключиться на %1</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation>Переключиться на </translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -134,10 +134,6 @@ p, li { white-space: pre-wrap; }
         <source>Switch to %1</source>
         <translation>切换到 %1</translation>
     </message>
-    <message>
-        <source>Switch to </source>
-        <translation>切换到 </translation>
-    </message>
 </context>
 <context>
     <name>ClientConfigDialog</name>


### PR DESCRIPTION
## Description
Fixes a bug where incorrect screen name could be set for switchToScreen in ActionDialog

Korean:
<img width="980" height="620" alt="deskflow_bug" src="https://github.com/user-attachments/assets/28bd62be-48f9-4100-88d3-3736ab716b7c" />

Japanese:
<img width="402" height="142" alt="deskflow_bug_2" src="https://github.com/user-attachments/assets/1b639a78-dacc-4a48-8730-570fb63db326" />

previous implementation got the screen name by removing translated "Switch to " string from the combo box text:
```
m_action.setSwitchScreenName(ui->comboSwitchToScreen->currentText().remove(tr("Switch to ")));
```
if the translation is not as expected, it behaves weirdly as seen above.

this change stores the original screen name in user data (`Qt::UserRole`) for each combo box item and reads it back directly:
```
ui->comboSwitchToScreen->addItem(tr("Switch to %1").arg(screen.name()), screen.name());
...
m_action.setSwitchScreenName(ui->comboSwitchToScreen->currentData().toString());
```
https://doc.qt.io/qt-6/qcombobox.html#addItem

## AI tools used for this PR
none

## Related Issue
I could not find any related issue.

## How Has This Been Tested?
built using github workflow after fork
and tested on Windows 11 x64
