### PR TITLE
fix(macos): recognize brightness media keys

### DIFF
--- a/src/lib/platform/OSXMediaKeySupport.m
+++ b/src/lib/platform/OSXMediaKeySupport.m
@@ -62,6 +62,12 @@ static KeyID convertNXKeyTypeToKeyID(uint32_t const type)
   case NX_KEYTYPE_SOUND_DOWN:
     id = kKeyAudioDown;
     break;
+  case NX_KEYTYPE_BRIGHTNESS_UP:
+    id = kKeyBrightnessUp;
+    break;
+  case NX_KEYTYPE_BRIGHTNESS_DOWN:
+    id = kKeyBrightnessDown;
+    break;
   case NX_KEYTYPE_MUTE:
     id = kKeyAudioMute;
     break;


### PR DESCRIPTION
Map macOS brightness media key events back to Deskflow key IDs so they can be captured and forwarded from macOS servers.

## Description
<!--- Describe what your changes do -->
Map macOS brightness media key events back to Deskflow key IDs
so they can be captured and forwarded from macOS servers

## AI tools used for this PR
Copilot
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->


## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes:
#7133
fixes: #9709 

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
