### PR TITLE
Use QStrings for exceptions whats

### DIFF
--- a/src/lib/base/BaseException.cpp
+++ b/src/lib/base/BaseException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -20,7 +20,7 @@ BaseException::BaseException() : std::runtime_error("")
   // do nothing
 }
 
-BaseException::BaseException(const std::string &msg) : std::runtime_error(msg)
+BaseException::BaseException(const QString &msg) : std::runtime_error(msg.toStdString())
 {
   // do nothing
 }
@@ -32,20 +32,20 @@ const char *BaseException::what() const throw()
   }
 
   m_what = getWhat();
-  return m_what.c_str();
+  return qPrintable(m_what);
 }
 
-std::string BaseException::format(const char * /*id*/, const char *fmt, ...) const noexcept
+QString BaseException::format(const char * /*id*/, const char *fmt, ...) const noexcept
 {
   // FIXME -- lookup message string using id as an index.  set
   // fmt to that string if it exists.
 
   // format
-  std::string result;
+  QString result;
   va_list args;
   va_start(args, fmt);
   try {
-    result = deskflow::string::vformat(fmt, args);
+    result = QString::fromStdString(deskflow::string::vformat(fmt, args));
   } catch (...) {
     // ignore
     result.clear();

--- a/src/lib/base/BaseException.h
+++ b/src/lib/base/BaseException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -10,6 +10,8 @@
 
 #include <stdexcept>
 #include <string>
+
+#include <QString>
 
 //! Exception base class
 /*!
@@ -21,7 +23,7 @@ public:
   //! Use getWhat() as the result of what()
   BaseException();
   //! Use \c msg as the result of what()
-  explicit BaseException(const std::string &msg);
+  explicit BaseException(const QString &msg);
   ~BaseException() throw() override = default;
 
   //! Reason for exception
@@ -29,9 +31,9 @@ public:
 
 protected:
   //! Get a human readable string describing the exception
-  virtual std::string getWhat() const noexcept
+  virtual QString getWhat() const noexcept
   {
-    return "";
+    return {};
   }
 
   //! Format a string
@@ -40,8 +42,8 @@ protected:
   no format can be found, then replaces positional parameters in
   the format string and returns the result.
   */
-  virtual std::string format(const char *id, const char *defaultFormat, ...) const noexcept;
+  virtual QString format(const char *id, const char *defaultFormat, ...) const noexcept;
 
 private:
-  mutable std::string m_what;
+  mutable QString m_what;
 };

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -47,7 +47,7 @@ public:
       // do nothing
     }
     bool m_retry = false;
-    std::string m_what;
+    QString m_what;
   };
 
 public:

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -182,7 +182,7 @@ void ClientApp::handleClientFailed(const Event &e)
     // Try next resolved address for current hostname
     std::unique_ptr<Client::FailInfo> info(static_cast<Client::FailInfo *>(e.getData()));
 
-    LOG_WARN("failed to connect to server=%s, trying next resolved address", info->m_what.c_str());
+    LOG_WARN("failed to connect to server=%s, trying next resolved address", qPrintable(info->m_what));
     if (!m_suspended) {
       scheduleClientRestart(retryTime());
     }
@@ -196,7 +196,7 @@ void ClientApp::handleClientFailed(const Event &e)
       handleClientRefused(e);
     } else {
       std::unique_ptr<Client::FailInfo> info(static_cast<Client::FailInfo *>(e.getData()));
-      LOG_WARN("failed to connect to server=%s, trying next server in list", info->m_what.c_str());
+      LOG_WARN("failed to connect to server=%s, trying next server in list", qPrintable(info->m_what));
       if (!m_suspended) {
         scheduleClientRestart(retryTime());
       }
@@ -209,10 +209,10 @@ void ClientApp::handleClientRefused(const Event &e)
   std::unique_ptr<Client::FailInfo> info(static_cast<Client::FailInfo *>(e.getData()));
 
   if (!info->m_retry) {
-    LOG_ERR("failed to connect to server: %s", info->m_what.c_str());
+    LOG_ERR("failed to connect to server: %s", qPrintable(info->m_what));
     getEvents()->addEvent(Event(EventTypes::Quit));
   } else {
-    LOG_WARN("failed to connect to server: %s", info->m_what.c_str());
+    LOG_WARN("failed to connect to server: %s", qPrintable(info->m_what));
     if (!m_suspended) {
       scheduleClientRestart(retryTime());
       m_retryCount++;

--- a/src/lib/deskflow/DeskflowException.cpp
+++ b/src/lib/deskflow/DeskflowException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -13,7 +13,7 @@
 // BadClientException
 //
 
-std::string BadClientException::getWhat() const throw()
+QString BadClientException::getWhat() const throw()
 {
   return "BadClientException";
 }
@@ -22,7 +22,7 @@ std::string BadClientException::getWhat() const throw()
 // InvalidProtocolException
 //
 
-std::string InvalidProtocolException::getWhat() const throw()
+QString InvalidProtocolException::getWhat() const throw()
 {
   return "InvalidProtocolException; Check the options section of the server "
          "configuration file has a valid protocol defined.\nProtocol must be barrier (default) or synergy."
@@ -48,7 +48,7 @@ int IncompatibleClientException::getMinor() const noexcept
   return m_minor;
 }
 
-std::string IncompatibleClientException::getWhat() const throw()
+QString IncompatibleClientException::getWhat() const throw()
 {
   return format(
       "IncompatibleClientException", "incompatible client %{1}.%{2}", deskflow::string::sprintf("%d", m_major).c_str(),
@@ -70,7 +70,7 @@ const std::string &DuplicateClientException::getName() const noexcept
   return m_name;
 }
 
-std::string DuplicateClientException::getWhat() const throw()
+QString DuplicateClientException::getWhat() const throw()
 {
   return format("DuplicateClientException", "duplicate client %{1}", m_name.c_str());
 }
@@ -89,7 +89,7 @@ const std::string &UnknownClientException::getName() const noexcept
   return m_name;
 }
 
-std::string UnknownClientException::getWhat() const throw()
+QString UnknownClientException::getWhat() const throw()
 {
   return format("UnknownClientException", "unknown client %{1}", m_name.c_str());
 }
@@ -108,7 +108,7 @@ int ExitAppException::getCode() const noexcept
   return m_code;
 }
 
-std::string ExitAppException::getWhat() const throw()
+QString ExitAppException::getWhat() const throw()
 {
   return format("ExitAppException", "exiting with code %{1}", deskflow::string::sprintf("%d", m_code).c_str());
 }

--- a/src/lib/deskflow/DeskflowException.h
+++ b/src/lib/deskflow/DeskflowException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -26,7 +26,7 @@ class BadClientException : public DeskflowException
   using DeskflowException::DeskflowException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -37,7 +37,7 @@ class InvalidProtocolException : public DeskflowException
   using DeskflowException::DeskflowException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 //! Incompatible client exception
@@ -60,7 +60,7 @@ public:
   //@}
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   int m_major;
@@ -87,7 +87,7 @@ public:
   //@}
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   std::string m_name;
@@ -113,7 +113,7 @@ public:
   //@}
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   std::string m_name;
@@ -135,7 +135,7 @@ public:
   int getCode() const noexcept;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   int m_code;

--- a/src/lib/deskflow/ProtocolUtil.cpp
+++ b/src/lib/deskflow/ProtocolUtil.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -567,7 +568,7 @@ void ProtocolUtil::readBytes(deskflow::IStream *stream, uint32_t len, std::strin
 // XIOReadMismatch
 //
 
-std::string XIOReadMismatch::getWhat() const throw()
+QString XIOReadMismatch::getWhat() const throw()
 {
   return format("XIOReadMismatch", "ProtocolUtil::readf() mismatch");
 }

--- a/src/lib/deskflow/ProtocolUtil.h
+++ b/src/lib/deskflow/ProtocolUtil.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -102,5 +103,5 @@ class XIOReadMismatch : public IOException
 {
 public:
   // BaseException overrides
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };

--- a/src/lib/deskflow/ScreenException.cpp
+++ b/src/lib/deskflow/ScreenException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -12,7 +12,7 @@
 // ScreenOpenFailureException
 //
 
-std::string ScreenOpenFailureException::getWhat() const throw()
+QString ScreenOpenFailureException::getWhat() const throw()
 {
   return format("ScreenOpenFailureException", "unable to open screen");
 }
@@ -21,7 +21,7 @@ std::string ScreenOpenFailureException::getWhat() const throw()
 // ScreenUnavailableException
 //
 
-std::string ScreenUnavailableException::getWhat() const throw()
+QString ScreenUnavailableException::getWhat() const throw()
 {
   return format("ScreenUnavailableException", "unable to open screen");
 }

--- a/src/lib/deskflow/ScreenException.h
+++ b/src/lib/deskflow/ScreenException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -26,7 +26,7 @@ class ScreenOpenFailureException : public ScreenException
   using ScreenException::ScreenException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 //! Screen unavailable exception
@@ -42,5 +42,5 @@ public:
   //@}
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };

--- a/src/lib/io/IOException.cpp
+++ b/src/lib/io/IOException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -12,7 +12,7 @@
 // IOClosedException
 //
 
-std::string IOClosedException::getWhat() const throw()
+QString IOClosedException::getWhat() const throw()
 {
   return format("IOClosedException", "already closed");
 }
@@ -21,7 +21,7 @@ std::string IOClosedException::getWhat() const throw()
 // IOEndOfStreamException
 //
 
-std::string IOEndOfStreamException::getWhat() const throw()
+QString IOEndOfStreamException::getWhat() const throw()
 {
   return format("IOEndOfStreamException", "reached end of stream");
 }
@@ -30,7 +30,7 @@ std::string IOEndOfStreamException::getWhat() const throw()
 // IOWouldBlockException
 //
 
-std::string IOWouldBlockException::getWhat() const throw()
+QString IOWouldBlockException::getWhat() const throw()
 {
   return format("IOWouldBlockException", "stream operation would block");
 }

--- a/src/lib/io/IOException.h
+++ b/src/lib/io/IOException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -34,7 +34,7 @@ class IOClosedException : public IOException
   using IOException::IOException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -45,7 +45,7 @@ class IOEndOfStreamException : public IOException
   using IOException::IOException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -56,5 +56,5 @@ class IOWouldBlockException : public IOException
   using IOException::IOException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };

--- a/src/lib/mt/MTException.cpp
+++ b/src/lib/mt/MTException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -12,7 +12,7 @@
 // MTThreadUnavailableException
 //
 
-std::string MTThreadUnavailableException::getWhat() const throw()
+QString MTThreadUnavailableException::getWhat() const throw()
 {
   return format("MTThreadUnavailableException", "cannot create thread");
 }

--- a/src/lib/mt/MTException.h
+++ b/src/lib/mt/MTException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -26,5 +26,5 @@ class MTThreadUnavailableException : public MTException
   using MTException::MTException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };

--- a/src/lib/net/SocketException.cpp
+++ b/src/lib/net/SocketException.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -36,7 +36,7 @@ int SocketAddressException::getPort() const noexcept
   return m_port;
 }
 
-std::string SocketAddressException::getWhat() const throw()
+QString SocketAddressException::getWhat() const throw()
 {
   static const char *s_errorID[] = {
       "SocketAddressUnknownException", "SocketAddressNotFoundException", "SocketAddressNoAddressException",
@@ -57,7 +57,7 @@ std::string SocketAddressException::getWhat() const throw()
 // SocketIOCloseException
 //
 
-std::string SocketIOCloseException::getWhat() const throw()
+QString SocketIOCloseException::getWhat() const throw()
 {
   return format("SocketIOCloseException", "close: %{1}", what());
 }
@@ -66,7 +66,7 @@ std::string SocketIOCloseException::getWhat() const throw()
 // SocketBindException
 //
 
-std::string SocketBindException::getWhat() const throw()
+QString SocketBindException::getWhat() const throw()
 {
   return format("SocketBindException", "cannot bind address: %{1}", what());
 }
@@ -75,7 +75,7 @@ std::string SocketBindException::getWhat() const throw()
 // SocketAddressInUseException
 //
 
-std::string SocketAddressInUseException::getWhat() const throw()
+QString SocketAddressInUseException::getWhat() const throw()
 {
   return format("SocketAddressInUseException", "cannot bind address: %{1}", what());
 }
@@ -84,7 +84,7 @@ std::string SocketAddressInUseException::getWhat() const throw()
 // SocketConnectException
 //
 
-std::string SocketConnectException::getWhat() const throw()
+QString SocketConnectException::getWhat() const throw()
 {
   return format("SocketConnectException", "cannot connect socket: %{1}", what());
 }
@@ -93,7 +93,7 @@ std::string SocketConnectException::getWhat() const throw()
 // SocketCreateException
 //
 
-std::string SocketCreateException::getWhat() const throw()
+QString SocketCreateException::getWhat() const throw()
 {
   return format("SocketCreateException", "cannot create socket: %{1}", what());
 }

--- a/src/lib/net/SocketException.h
+++ b/src/lib/net/SocketException.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -53,7 +53,7 @@ public:
 
 protected:
   // BaseException overrides
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   SocketError m_error;
@@ -71,7 +71,7 @@ public:
   {
     // do nothing
   }
-  explicit SocketIOCloseException(const std::string &msg) : IOCloseException(msg), m_state(kFirst)
+  explicit SocketIOCloseException(const QString &msg) : IOCloseException(msg), m_state(kFirst)
   {
     // do nothing
   }
@@ -85,14 +85,14 @@ public:
       m_state = kDone;
     }
     if (m_state == kDone) {
-      return m_formatted.c_str();
+      return qPrintable(m_formatted);
     } else {
       return IOCloseException::what();
     }
   }
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   enum EState
@@ -102,7 +102,7 @@ private:
     kDone
   };
   mutable EState m_state;
-  mutable std::string m_formatted;
+  mutable QString m_formatted;
 };
 
 /**
@@ -115,7 +115,7 @@ public:
   {
     // do nothing
   }
-  explicit SocketWithWhatException(const std::string &msg) : SocketException(msg), m_state(kFirst)
+  explicit SocketWithWhatException(const QString &msg) : SocketException(msg), m_state(kFirst)
   {
     // do nothing
   }
@@ -129,7 +129,7 @@ public:
       m_state = kDone;
     }
     if (m_state == kDone) {
-      return m_formatted.c_str();
+      return qPrintable(m_formatted);
     } else {
       return SocketException::what();
     }
@@ -143,7 +143,7 @@ private:
     kDone
   };
   mutable EState m_state;
-  mutable std::string m_formatted;
+  mutable QString m_formatted;
 };
 
 /**
@@ -154,7 +154,7 @@ class SocketBindException : public SocketWithWhatException
   using SocketWithWhatException::SocketWithWhatException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -166,7 +166,7 @@ class SocketAddressInUseException : public SocketWithWhatException
   using SocketWithWhatException::SocketWithWhatException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -177,7 +177,7 @@ class SocketConnectException : public SocketWithWhatException
   using SocketWithWhatException::SocketWithWhatException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };
 
 /**
@@ -188,5 +188,5 @@ class SocketCreateException : public SocketWithWhatException
   using SocketWithWhatException::SocketWithWhatException;
 
 protected:
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 };

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -2066,7 +2066,7 @@ ServerConfigReadException::ServerConfigReadException(
   // do nothing
 }
 
-std::string ServerConfigReadException::getWhat() const throw()
+QString ServerConfigReadException::getWhat() const throw()
 {
   return format("ServerConfigReadException", "read error: %{1}", m_error.c_str());
 }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -537,7 +538,7 @@ public:
 
 protected:
   // BaseException overrides
-  std::string getWhat() const throw() override;
+  QString getWhat() const throw() override;
 
 private:
   std::string m_error;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Changes all the exceptions to use QStrings instead of std::string

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Moving away from std::strings

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

Run locally