### PR TITLE
Do not use Qt::DirectConnection across threads

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -131,9 +131,7 @@ int main(int argc, char **argv)
   QApplication::setApplicationName(QStringLiteral("%1 Core").arg(kAppName));
 
   const auto ipcServer = new deskflow::core::ipc::CoreIpcServer(&app); // NOSONAR - Qt managed
-  QObject::connect(
-      ipcServer, &deskflow::core::ipc::IpcServer::stopProcessRequested, coreApp, &App::quit, Qt::DirectConnection
-  );
+  QObject::connect(ipcServer, &deskflow::core::ipc::IpcServer::stopProcessRequested, coreApp, &App::quit);
   ipcServer->listen();
 
   QThread coreThread;

--- a/src/apps/deskflow-daemon/DaemonApp.cpp
+++ b/src/apps/deskflow-daemon/DaemonApp.cpp
@@ -125,21 +125,11 @@ void DaemonApp::clearSettings()
 
 void DaemonApp::connectIpcServer(const ipc::DaemonIpcServer *ipcServer) const
 {
-  // Use direct connection as this object is on it's own thread,
-  // and so is on a different event loop to the main Qt loop.
-  connect(ipcServer, &ipc::DaemonIpcServer::logLevelChanged, this, &DaemonApp::saveLogLevel, Qt::DirectConnection);
-  connect(ipcServer, &ipc::DaemonIpcServer::configFileChanged, this, &DaemonApp::setConfigFile, Qt::DirectConnection);
-  connect(
-      ipcServer, &ipc::DaemonIpcServer::startProcessRequested, this, &DaemonApp::applyWatchdogCommand,
-      Qt::DirectConnection
-  );
-  connect(
-      ipcServer, &ipc::DaemonIpcServer::stopProcessRequested, this, &DaemonApp::clearWatchdogCommand,
-      Qt::DirectConnection
-  );
-  connect(
-      ipcServer, &ipc::DaemonIpcServer::clearSettingsRequested, this, &DaemonApp::clearSettings, Qt::DirectConnection
-  );
+  connect(ipcServer, &ipc::DaemonIpcServer::logLevelChanged, this, &DaemonApp::saveLogLevel);
+  connect(ipcServer, &ipc::DaemonIpcServer::configFileChanged, this, &DaemonApp::setConfigFile);
+  connect(ipcServer, &ipc::DaemonIpcServer::startProcessRequested, this, &DaemonApp::applyWatchdogCommand);
+  connect(ipcServer, &ipc::DaemonIpcServer::stopProcessRequested, this, &DaemonApp::clearWatchdogCommand);
+  connect(ipcServer, &ipc::DaemonIpcServer::clearSettingsRequested, this, &DaemonApp::clearSettings);
 }
 
 void DaemonApp::run(QThread &daemonThread)


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Remove the `Qt::DirectConnection` for the daemon and ipc quit connections. We will let Qt decided what to do , It will pick Qt::QueuedConnection across threads as using DirectConnection is only for objects within the same thread. 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None ? 

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Needs testing on windows but i have run it locally to see if the ipc server still closes.