### PR TITLE
fix(mac): prevent cursor warps from outside quartz event loop (if active)

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -262,6 +262,14 @@ uint32_t OSXScreen::activeSides()
 
 void OSXScreen::warpCursor(int32_t x, int32_t y)
 {
+  if (m_eventTapRunLoop && CFRunLoopGetCurrent() != m_eventTapRunLoop) {
+    CFRunLoopPerformBlock(m_eventTapRunLoop, kCFRunLoopDefaultMode, ^{
+      warpCursor(x, y);
+    });
+    CFRunLoopWakeUp(m_eventTapRunLoop);
+    return;
+  }
+
   // move cursor without generating events
   CGPoint pos;
   pos.x = x;


### PR DESCRIPTION
## Description
This changes how mouse warps are processed if the event tap quartz loop is active.
This prevent race conditions where the event loop is trying to move the cursor to the correct border position while the quartz event tap is trying to keep the cursor in the center of the screen.

## AI tools used for this PR
Github Copilot Inline Suggestions (using Claude Sonnet 4.6)

## Related Issue
fixes: #9730
relates: #9072 


## How Has This Been Tested?
Tested it over a week on my local setup (macOS 26.4.1 as server and client, and two other Windows 11 as client).

