### PR TITLE
fix: do not use xdisplay to read locale on wayland

### DIFF
--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -8,6 +8,7 @@
 #include "deskflow/unix/AppUtilUnix.h"
 
 #include "base/Log.h"
+#include "common/PlatformInfo.h"
 
 #if WINAPI_XWINDOWS
 #include "deskflow/unix/X11LayoutsParser.h"
@@ -91,9 +92,13 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
   return layoutLangCodes;
 }
 
+// TODO: read the layout for x and wayland via xkbcommon
 std::string AppUtilUnix::getCurrentLanguageCode()
 {
   std::string result = "";
+  if (deskflow::platform::isWayland())
+    return result;
+
 #if WINAPI_XWINDOWS
 
   auto display = XOpenDisplay(nullptr);


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
On wayland do not try to open xdisplay to read the locale 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #9717

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run