### PR TITLE
fix: add Muhenkan (Non-Convert) key support for Japanese keyboard

### DIFF
--- a/src/lib/deskflow/KeyTypes.cpp
+++ b/src/lib/deskflow/KeyTypes.cpp
@@ -73,6 +73,7 @@ const KeyNameMapEntry kKeyNameMap[] = {
     {"F35", kKeyF35},
     {"Find", kKeyFind},
     {"Help", kKeyHelp},
+    {"Muhenkan", kKeyMuhenkan},
     {"Henkan", kKeyHenkan},
     {"Home", kKeyHome},
     {"Hyper_L", kKeyHyper_L},

--- a/src/lib/deskflow/KeyTypes.h
+++ b/src/lib/deskflow/KeyTypes.h
@@ -114,6 +114,7 @@ static const KeyID kKeyPause = 0xEF13;  /* Pause, hold */
 static const KeyID kKeyScrollLock = 0xEF14;
 static const KeyID kKeySysReq = 0xEF15;
 static const KeyID kKeyEscape = 0xEF1B;
+static const KeyID kKeyMuhenkan = 0xEF22;         /* Cancel Conversion */
 static const KeyID kKeyHenkan = 0xEF23;           /* Start/Stop Conversion */
 static const KeyID kKeyKana = 0xEF26;             /* Kana */
 static const KeyID kKeyHiraganaKatakana = 0xEF27; /* Hiragana/Katakana toggle */

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -55,7 +55,7 @@ const KeyID MSWindowsKeyState::s_virtualKey[] = {
     /* 0x01a */ {kKeyNone},             // undefined
     /* 0x01b */ {kKeyEscape},           // VK_ESCAPE
     /* 0x01c */ {kKeyHenkan},           // VK_CONVERT
-    /* 0x01d */ {kKeyNone},             // VK_NONCONVERT
+    /* 0x01d */ {kKeyMuhenkan},         // VK_NONCONVERT
     /* 0x01e */ {kKeyNone},             // VK_ACCEPT
     /* 0x01f */ {kKeyNone},             // VK_MODECHANGE
     /* 0x020 */ {kKeyNone},             // VK_SPACE
@@ -312,7 +312,7 @@ const KeyID MSWindowsKeyState::s_virtualKey[] = {
     /* 0x11a */ {kKeyNone},         // undefined
     /* 0x11b */ {kKeyNone},         // VK_ESCAPE
     /* 0x11c */ {kKeyNone},         // VK_CONVERT
-    /* 0x11d */ {kKeyNone},         // VK_NONCONVERT
+    /* 0x11d */ {kKeyMuhenkan},     // VK_NONCONVERT
     /* 0x11e */ {kKeyNone},         // VK_ACCEPT
     /* 0x11f */ {kKeyNone},         // VK_MODECHANGE
     /* 0x120 */ {kKeyNone},         // VK_SPACE


### PR DESCRIPTION
## Problem

Currently, Deskflow does not support the "Muhenkan" (Non-Convert) key, which is essential for Japanese keyboard layouts. While a bug report exists (#8492), it remains unresolved. The key is currently ignored.

## Solution

This PR adds full support for the Muhenkan key by:

1. Defining a new `KeyID` for Muhenkan based on its KeySym value.
2. Adding the key to the global key name map.
3. Updating the Windows virtual key (VK) table to recognize `VK_NONCONVERT`.
4. Ensuring proper mapping for both Windows and Linux through existing conversion logic.

## Changes

- **KeyTypes.h**: Defined `kKeyMuhenkan` as `0xEF22`.
- **KeyTypes.cpp**: Added `"Muhenkan"` to `KeyNameMapEntry`.
- **MSWindowsKeyState.cpp**: Updated `s_virtualKey` table to map `0x01d` and `0x11d` (`VK_NONCONVERT`) to `kKeyMuhenkan` instead of `kKeyNone`.

## How Has This Been Tested?

### Testing Environment

* **Server OS**: Windows 11 (Japanese Keyboard)
* **Client OS**: Linux (Ubuntu 26.04/Wayland)
* **Verification**: Built from source with the proposed changes.

### Test Scenarios

1. **Client-side Event Verification (Linux)**:
* Used `xev` on the Linux client to monitor incoming key events from the Windows server.
* **Result**: Confirmed that pressing the "Muhenkan" key on the server correctly generates the following event on the client:
`keycode 102 (keysym 0xff22, Muhenkan)`

2. **Basic Regression**:
* Verified that the **Henkan** (Convert) key and other Japanese-specific keys continue to function normally without any interference from the new mapping.

## Technical Details (Review Notes)

* **KeyID Selection**: `kKeyMuhenkan` is set to `0xEF22`. This aligns with `XK_Muhenkan` (`0xff22`) because Deskflow's internal KeyID for special keys is derived by the bitwise operation `(KeySym & 0x0FFF) | [cite_start]0xE000` (or similar logic used in `XDGKeyUtil`).

* **Cross-Platform Impact**:
  * **Windows**: The `s_virtualKey` update allows the server to capture the key and the client to replay it via the automatically generated `m_keyToVKMap`.
  * **Linux**: `XDGKeyUtil::mapKeySymToKeyID()` will handle the conversion automatically once the KeyID is defined.
  * **macOS**: No changes made as the key does not exist on standard Mac layouts, but compatibility is maintained.
