### PR TITLE
fix(daemon): support portable setup when service mode daemon is used

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <QApplication>
+#include <QCoreApplication>
 #include <QFileInfo>
 #include <QSharedMemory>
 #include <QTextStream>
@@ -70,11 +71,6 @@ App *createApp(const CoreArgParser &parser, EventQueue &events, const QString &p
 int main(int argc, char **argv)
 {
 #if defined(Q_OS_WIN)
-  {
-    // HACK to make sure settings gets the correct qApp path
-    QCoreApplication m(argc, argv);
-  }
-
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
@@ -90,37 +86,47 @@ int main(int argc, char **argv)
 
   CoreArgParser parser(args);
 
-  // Print any parser errors
-  if (!parser.errorText().isEmpty()) {
-    QTextStream(stdout) << parser.errorText() << "\n";
+#if defined(Q_OS_WIN)
+  // Keep a Qt app object alive while parsing args/settings so
+  // portableSettingsFile() can safely use applicationDirPath().
+  {
+    QCoreApplication bootstrapApp(argc, argv);
+#endif
+
+    // Print any parser errors
+    if (!parser.errorText().isEmpty()) {
+      QTextStream(stdout) << parser.errorText() << "\n";
+    }
+
+    if (parser.help()) {
+      showHelp(parser);
+      return s_exitSuccess;
+    }
+
+    if (parser.version()) {
+      QTextStream(stdout) << parser.versionText();
+      return s_exitSuccess;
+    }
+
+    // Before we check any more args we need to check for a duplicate process.
+    // Create a shared memory segment with a unique key
+    // This is to prevent a new instance from running if one is already running
+    QSharedMemory sharedMemory(kCoreBinName);
+
+    // Attempt to attach first and detach in order to clean up stale shm chunks
+    // This can happen if the previous instance was killed or crashed
+    if (sharedMemory.attach())
+      sharedMemory.detach();
+
+    if (!sharedMemory.create(1) && parser.singleInstanceOnly()) {
+      LOG_WARN("an instance of deskflow core is already running");
+      return s_exitDuplicate;
+    }
+
+    parser.parse();
+#if defined(Q_OS_WIN)
   }
-
-  if (parser.help()) {
-    showHelp(parser);
-    return s_exitSuccess;
-  }
-
-  if (parser.version()) {
-    QTextStream(stdout) << parser.versionText();
-    return s_exitSuccess;
-  }
-
-  // Before we check any more args we need to check for a duplicate process.
-  // Create a shared memory segment with a unique key
-  // This is to prevent a new instance from running if one is already running
-  QSharedMemory sharedMemory(kCoreBinName);
-
-  // Attempt to attach first and detach in order to clean up stale shm chunks
-  // This can happen if the previous instance was killed or crashed
-  if (sharedMemory.attach())
-    sharedMemory.detach();
-
-  if (!sharedMemory.create(1) && parser.singleInstanceOnly()) {
-    LOG_WARN("an instance of deskflow core is already running");
-    return s_exitDuplicate;
-  }
-
-  parser.parse();
+#endif
 
   EventQueue events;
   const auto processName = QFileInfo(argv[0]).fileName();


### PR DESCRIPTION
## Description
These changes allow the service mode in deskflow-daemon to be used with a portable setup

<!--- Describe what your changes do -->
- keep a temporary QCoreApplication alive during early core startup parsing
- ensure applicationDirPath() is valid while portable/settings paths are resolved
- destroy bootstrap app before creating runtime QApplication
- avoids QCoreApplication::applicationDirPath warning


## AI tools used for this PR
- Codex GPT 5.3-Codex
- used for code generation and making sure codebase stays coherent 

## Related Issue
fixes: #9739 


## How Has This Been Tested?


0. Have a portable settings folder which contains: `Deskflow.conf` , `deskflow-server.conf` , `tls/trusted-servers`
1. Make sure deskflow-daemon is running
2. Start deskflow server 

2. Run deskflow client in service mode (processMode=0).
3. Connect to the deskflow server
4. Connection works without any ` fingerprint does not match trusted fingerprint` warnings
5. Quit the GUI application and connection still works
6. Restart the service and connection is properly resolved after service has restarted


## Environments


Client: 
Windows 11 Version 23H2

Server:
Deskflow: 1.26.0.177 (c3ecd0b8)
Qt: 6.10.2
System: Windows 10 Version 22H2


