### PR TITLE
Use AbsoluteFilePath for all settings returned filepaths

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -263,7 +263,7 @@ bool Settings::isPortableMode()
 
 QString Settings::settingsFile()
 {
-  return instance()->m_settings->fileName();
+  return QFileInfo(instance()->m_settings->fileName()).absoluteFilePath();
 }
 
 QString Settings::settingsPath()
@@ -283,12 +283,12 @@ QString Settings::tlsDir()
 
 QString Settings::tlsTrustedServersDb()
 {
-  return QStringLiteral("%1/trusted-servers").arg(instance()->tlsDir());
+  return QFileInfo(QStringLiteral("%1/trusted-servers").arg(instance()->tlsDir())).absoluteFilePath();
 }
 
 QString Settings::tlsTrustedClientsDb()
 {
-  return QStringLiteral("%1/trusted-clients").arg(instance()->tlsDir());
+  return QFileInfo(QStringLiteral("%1/trusted-clients").arg(instance()->tlsDir())).absoluteFilePath();
 }
 
 void Settings::setValue(const QString &key, const QVariant &value)
@@ -330,5 +330,5 @@ QString Settings::portableSettingsFile()
 {
   static const auto filename =
       QStringLiteral("%1/settings/%2.conf").arg(QCoreApplication::applicationDirPath(), kAppName);
-  return filename;
+  return QFileInfo(filename).absoluteFilePath();
 }


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
make sure to use absoluteFilePath for returned settings files 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
hopefully path issues on windows (#9739. #9738)

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

locally run on linux 
@redsigma can you see if this helps your issue on windows  