### PR TITLE
feat: add search evdev.xml path for NetBSD/OpenBSD

### DIFF
--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -46,9 +46,15 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
 
 #if WINAPI_XWINDOWS
   // Check /usr/local first used on bsd and some systems
-  m_evdev = "/usr/local/share/X11/xkb/rules/evdev.xml";
-  if (!std::filesystem::exists(m_evdev))
-    m_evdev = "/usr/share/X11/xkb/rules/evdev.xml";
+  std::vector<std::string> evdev_candidate = {
+      "/usr/share/X11/xkb/rules/evdev.xml",       // Linux
+      "/usr/local/share/X11/xkb/rules/evdev.xml", // FreeBSD, DragonFlyBSD
+      "/usr/X11R7/lib/X11/xkb/rules/evdev.xml",   // NetBSD
+      "/usr/X11R6/share/X11/xkb/rules/evdev.xml", // OpenBSD
+  };
+
+  for (auto it = evdev_candidate.begin(); it != evdev_candidate.end() && !std::filesystem::exists(m_evdev = *it); it++)
+    ;
   layoutLangCodes = X11LayoutsParser::getX11LanguageList(m_evdev);
 
 #elif defined(Q_OS_MAC)


### PR DESCRIPTION
## Description
Currently, searching evdev.xml code in src/lib/deskflow/unix/AppUtilUnix.cpp supports FreeBSD and Linux only.
To support other *BSDs, such as NetBSD and OpenBSD, adding suitable path is needed.

(I am now struggling to run deskflow on OpenBSD-7.8/amd64.)

## AI tools used for this PR
None

## Related Issue
None

## How Has This Been Tested?
run `deskflow-core server` on FreeBSD and Linux(Debian-13), and no error message related evdev.xml.
