### PR TITLE
Replace ubuntu 25.10 with rolling

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Build and cache vcpkg
       if: ${{ runner.os == 'Windows' }}
       id: vcpkg
-      uses: johnwason/vcpkg-action@v7
+      uses: johnwason/vcpkg-action@v8
       with:
         pkgs: gtest openssl
         extra-args: --classic --host-triplet=${{inputs.vcpkg-triplet}}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -198,20 +198,6 @@ jobs:
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DEV_DOCS=ON"
 
-          - name: "ubuntu-25.10-x86_64"
-            runs-on: ubuntu-latest
-            container: ubuntu:25.10
-            like: "debian"
-            timeout: 20
-            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
-
-          - name: "ubuntu-25.10-arm64"
-            runs-on: ubuntu-24.04-arm
-            container: ubuntu:25.10
-            like: "debian"
-            timeout: 20
-            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
-
           - name: "ubuntu-26.04-x86_64"
             runs-on: ubuntu-latest
             container: ubuntu:26.04
@@ -222,6 +208,20 @@ jobs:
           - name: "ubuntu-26.04-arm64"
             runs-on: ubuntu-24.04-arm
             container: ubuntu:26.04
+            like: "debian"
+            timeout: 20
+            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
+
+          - name: "ubuntu-rolling-x86_64"
+            runs-on: ubuntu-latest
+            container: ubuntu:rolling
+            like: "debian"
+            timeout: 20
+            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
+
+          - name: "ubuntu-rolling-arm64"
+            runs-on: ubuntu-24.04-arm
+            container: ubuntu:rolling
             like: "debian"
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - ci: replace ubuntu 25.10 with ubuntu rolling
 - update vcpkg action to v8 (node 20 use warnings) 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Related Issue
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
CI 