### PR TITLE
ci: remove ubuntu rolling package names are the as lts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -212,20 +212,6 @@ jobs:
             timeout: 20
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
 
-          - name: "ubuntu-rolling-x86_64"
-            runs-on: ubuntu-latest
-            container: ubuntu:rolling
-            like: "debian"
-            timeout: 20
-            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
-
-          - name: "ubuntu-rolling-arm64"
-            runs-on: ubuntu-24.04-arm
-            container: ubuntu:rolling
-            like: "debian"
-            timeout: 20
-            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
-
     steps:
       # Make sure the container has git before we do anything else
       - name: Install Git on Container


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Ubuntu rolling is using the same code name as the LTS breaking our release , so we have to remove it for now 
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
none
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
release step is broken on last few lands.
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Ci land