### PR TITLE
Add Alt Gr modifier override to Screen Settings Dialog

### DIFF
--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -160,7 +160,7 @@ private:
   QPixmap m_Pixmap = QIcon::fromTheme("video-display").pixmap(QSize(96, 96));
   QString m_Name = {};
   QStringList m_Aliases = {};
-  QList<int> m_Modifiers = {0, 1, 2, 3, 4, 5};
+  QList<int> m_Modifiers = {0, 1, 2, 3, 4, 5, 6};
   QList<bool> m_SwitchCorners = {false, false, false, false};
   int m_SwitchCornerSize = 0;
   QList<bool> m_Fixes{false, false, false, false};

--- a/src/lib/gui/config/ScreenConfig.cpp
+++ b/src/lib/gui/config/ScreenConfig.cpp
@@ -7,7 +7,7 @@
 
 #include "ScreenConfig.h"
 
-const char *ScreenConfig::m_ModifierNames[] = {"shift", "ctrl", "alt", "meta", "super", "none"};
+const char *ScreenConfig::m_ModifierNames[] = {"shift", "ctrl", "alt", "meta", "super", "altgr", "none"};
 
 const char *ScreenConfig::m_FixNames[] = {
     "halfDuplexCapsLock", "halfDuplexNumLock", "halfDuplexScrollLock", "xtestIsXineramaUnaware"

--- a/src/lib/gui/config/ScreenConfig.h
+++ b/src/lib/gui/config/ScreenConfig.h
@@ -25,6 +25,7 @@ public:
     Alt,
     Meta,
     Super,
+    AltGr,
     None,
     NumModifiers
   };

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
@@ -48,6 +48,7 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget *parent, Screen *screen, cons
   ui->comboAlt->setCurrentIndex(m_screen->modifier(static_cast<int>(Alt)));
   ui->comboMeta->setCurrentIndex(m_screen->modifier(static_cast<int>(Meta)));
   ui->comboSuper->setCurrentIndex(m_screen->modifier(static_cast<int>(Super)));
+  ui->comboAltGr->setCurrentIndex(m_screen->modifier(static_cast<int>(AltGr)));
 
   ui->chkDeadTopLeft->setChecked(m_screen->switchCorner(static_cast<int>(TopLeft)));
   ui->chkDeadTopRight->setChecked(m_screen->switchCorner(static_cast<int>(TopRight)));
@@ -102,6 +103,7 @@ void ScreenSettingsDialog::accept()
   m_screen->setModifier(Alt, ui->comboAlt->currentIndex());
   m_screen->setModifier(Meta, ui->comboMeta->currentIndex());
   m_screen->setModifier(Super, ui->comboSuper->currentIndex());
+  m_screen->setModifier(AltGr, ui->comboAltGr->currentIndex());
 
   m_screen->setSwitchCorner(TopLeft, ui->chkDeadTopLeft->isChecked());
   m_screen->setSwitchCorner(TopRight, ui->chkDeadTopRight->isChecked());

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.ui
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.ui
@@ -172,6 +172,11 @@
             </item>
             <item>
              <property name="text">
+              <string>Alt Gr</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>None</string>
              </property>
             </item>
@@ -202,6 +207,11 @@
             <item>
              <property name="text">
               <string>Super</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Alt Gr</string>
              </property>
             </item>
             <item>
@@ -259,6 +269,11 @@
             </item>
             <item>
              <property name="text">
+              <string>Alt Gr</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>None</string>
              </property>
             </item>
@@ -296,6 +311,11 @@
             </item>
             <item>
              <property name="text">
+              <string>Alt Gr</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>None</string>
              </property>
             </item>
@@ -329,6 +349,63 @@
             <item>
              <property name="text">
               <string>Super</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Alt Gr</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelAltGr">
+            <property name="text">
+             <string>Alt &amp;Gr</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboAltGr</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QComboBox" name="comboAltGr">
+            <property name="currentIndex">
+             <number>5</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Shift</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ctrl</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Alt</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Meta</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Super</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Alt Gr</string>
              </property>
             </item>
             <item>
@@ -668,6 +745,7 @@
   <tabstop>comboShift</tabstop>
   <tabstop>comboCtrl</tabstop>
   <tabstop>comboSuper</tabstop>
+  <tabstop>comboAltGr</tabstop>
   <tabstop>comboAlt</tabstop>
   <tabstop>chkDeadTopLeft</tabstop>
   <tabstop>chkDeadTopRight</tabstop>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -895,6 +895,14 @@ Además, verifique que puede %1 el archivo de configuración del servidor: %2</t
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation type="unfinished">El nombre de usuario no puede ser el mismo que un alias. Elimine el alias o cambie el nombre de usuario.</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -895,6 +895,14 @@ Inoltre, verifica di poter %1 il file di configurazione del server: %2</translat
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation>Il nome dello schermo non può essere uguale a un alias. Rimuovi l&apos;alias o modifica il nome dello schermo.</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -897,6 +897,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation>コンピューター名は別名と同じにできません。別名を削除するか、コンピューター名を変更してください。</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -895,6 +895,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation>컴퓨터 이름은 별칭과 같을 수 없습니다. 별칭을 삭제하거나 컴퓨터 이름을 변경하세요.</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -895,6 +895,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation>Имя экрана не может совпадать с псевдонимом. Удалите псевдоним или измените имя экрана.</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -897,6 +897,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>The screen name cannot be the same as an alias. Please either remove the alias or change the screen name.</source>
         <translation>屏幕名称不能与别名相同。请移除别名或更改屏幕名称。</translation>
     </message>
+    <message>
+        <source>Alt Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt &amp;Gr</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>


### PR DESCRIPTION
## Description
The **Modifier Keys** group in Screen Settings had override dropdowns for Shift, Ctrl, Alt, Meta, and Super — but not for **Alt Gr**. The server-side config already parsed and applied `altgr = <modifier>` correctly; only the GUI widget was missing.

Changes:
- Added `AltGr` to the `Modifier` enum in `ScreenConfig.h` between `Super` and `None`
- Added `"altgr"` to `m_ModifierNames[]` at the matching index in `ScreenConfig.cpp`
- Extended `m_Modifiers` default initializer from 6 to 7 elements in `Screen.h`
- Added "Alt Gr" item to all five existing modifier combos and a new **Alt Gr** row with `comboAltGr`, buddy label, and tab order entry in `ScreenSettingsDialog.ui`
- Added `setCurrentIndex` (load) and `setModifier` (save) for `AltGr` in `ScreenSettingsDialog.cpp`

Old configs without a saved AltGr modifier default to the identity mapping via the existing `DefaultMod` fallback in `Screen::modifier()`.

## AI tools used for this PR
Claude Code (claude-sonnet-4-6) was used to implement the changes and write the initial PR description.

## Fixed/related issues
fixes: #8560

## How has this been tested?
The changes were verified by code inspection:
- Confirmed `AltGr` enum placement between `Super` and `None` matches the array index in `m_ModifierNames[]`
- Confirmed the `.ui` additions follow the same structure as the five existing modifier rows
- Confirmed the load/save paths in `ScreenSettingsDialog.cpp` mirror the pattern used by the other modifiers exactly
- Backward compatibility confirmed by inspection: `Screen::modifier()` returns `DefaultMod` for keys not present in the config, so existing configs without `altgr` are unaffected