### PR TITLE
chore: remove old OpenSSL support

### DIFF
--- a/src/lib/net/SslLogger.cpp
+++ b/src/lib/net/SslLogger.cpp
@@ -45,15 +45,8 @@ void logLocalSecureCipherInfo(const SSL *ssl)
 
 void logRemoteSecureCipherInfo(const SSL *ssl)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-  // ssl->session->ciphers is not forward compatable,
-  // In future release of OpenSSL, it's not visible,
-  // however, LibreSSL still uses this.
-  auto cStack = ssl->session->ciphers;
-#else
-  // Use SSL_get_client_ciphers() for newer versions of OpenSSL.
   auto cStack = SSL_get_client_ciphers(ssl);
-#endif
+
   if (cStack) {
     LOG_VERBOSE("available remote ciphers:");
     showCipherStackDesc(cStack);


### PR DESCRIPTION
## Description
Removed code for `OPENSSL_VERSION_NUMBER < 0x10100000L` (older than OpenSSL 1.1).
Deskflow requires OpenSSL 3.5 or later, so this old code is not used.
And, modern LibreSSL have `SSL_get_client_ciphers()` (LibreSSL 2.9.0 or later), so no problem to remove.

<!--- Describe what your changes do -->

## AI tools used for this PR
None.

## Fixed/related issues
None.

## How has this been tested?
Compare binaries (built on Debian-13/amd64) between changes. No difference.