### PR TITLE
fix: add #include <stdarg> to avoid 'unknown type name' error

### DIFF
--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdarg>
 #include <string>
 
 //! std::string utilities


### PR DESCRIPTION
## Description
To use `va_list`, `#include <cstdarg>` is required.
Dependencies of include files, `<cstdarg>` is included on Linux/FreeBSD but OpenBSD not.

## AI tools used for this PR
None.

## Fixed/related issues
None.

## How has this been tested?
Build passed on Debian-13/amd64 and FreeBSD-15.0/amd64.
(Also tested on OpenBSD-7.8/amd64 with modified CMakeLists.txt)
