### PR TITLE
fix(server): preserve base key for remapped AltGr input

### DIFF
--- a/src/lib/deskflow/IKeyState.h
+++ b/src/lib/deskflow/IKeyState.h
@@ -163,5 +163,15 @@ public:
   */
   virtual void pollPressedKeys(KeyButtonSet &pressedKeys) const = 0;
 
+  //! Get the base key for a physical button
+  /*!
+  Returns the unmodified key produced by \p button, if the platform can
+  resolve it. The default implementation reports no mapping.
+  */
+  virtual KeyID getKeyIDForButton(KeyButton) const
+  {
+    return kKeyNone;
+  }
+
   //@}
 };

--- a/src/lib/deskflow/PlatformScreen.cpp
+++ b/src/lib/deskflow/PlatformScreen.cpp
@@ -83,6 +83,11 @@ void PlatformScreen::pollPressedKeys(KeyButtonSet &pressedKeys) const
   getKeyState()->pollPressedKeys(pressedKeys);
 }
 
+KeyID PlatformScreen::getKeyIDForButton(KeyButton button) const
+{
+  return getKeyState()->getKeyIDForButton(button);
+}
+
 void PlatformScreen::clearStaleModifiers()
 {
   getKeyState()->clearStaleModifiers();

--- a/src/lib/deskflow/PlatformScreen.h
+++ b/src/lib/deskflow/PlatformScreen.h
@@ -60,6 +60,7 @@ public:
   KeyModifierMask pollActiveModifiers() const override;
   int32_t pollActiveGroup() const override;
   void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
+  KeyID getKeyIDForButton(KeyButton button) const override;
   void clearStaleModifiers() override;
 
   // IPlatformScreen overrides

--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -312,6 +312,39 @@ void EiKeyState::fakeKey(const Keystroke &keystroke)
   m_screen->fakeKey(keystroke.m_data.m_button.m_button, keystroke.m_data.m_button.m_press);
 }
 
+KeyID EiKeyState::mapKeyFromLevel(std::uint32_t keyval, xkb_layout_index_t layout, xkb_level_index_t level) const
+{
+  if (m_xkbKeymap == nullptr || xkb_keymap_num_layouts_for_key(m_xkbKeymap, keyval) == 0) {
+    return kKeyNone;
+  }
+
+  const xkb_keysym_t *syms = nullptr;
+  const auto nsyms = xkb_keymap_key_get_syms_by_level(m_xkbKeymap, keyval, layout, level, &syms);
+  if (nsyms <= 0 || syms == nullptr) {
+    return kKeyNone;
+  }
+
+  auto keysym = static_cast<KeySym>(syms[0]);
+  KeyID keyid = XDGKeyUtil::mapKeySymToKeyID(keysym);
+  LOG_VERBOSE(
+      "mapped key: code=%d layout=%u level=%u keysym=0x%04lx to keyID=%d", keyval, layout, level, keysym, keyid
+  );
+  return keyid;
+}
+
+KeyID EiKeyState::getKeyIDForButton(KeyButton button) const
+{
+  xkb_layout_index_t layout = 0;
+  if (m_xkbState != nullptr) {
+    layout = xkb_state_key_get_layout(m_xkbState, button);
+    if (layout == XKB_LAYOUT_INVALID) {
+      layout = 0;
+    }
+  }
+
+  return mapKeyFromLevel(button, layout, 0);
+}
+
 KeyID EiKeyState::mapKeyFromKeyval(uint32_t keyval) const
 {
   // Get the base keysym from level 0, ignoring current modifiers.

--- a/src/lib/platform/EiKeyState.h
+++ b/src/lib/platform/EiKeyState.h
@@ -33,6 +33,7 @@ public:
   KeyModifierMask pollActiveModifiers() const override;
   std::int32_t pollActiveGroup() const override;
   void pollPressedKeys(KeyButtonSet &pressedKeys) const override;
+  KeyID getKeyIDForButton(KeyButton button) const override;
   KeyID mapKeyFromKeyval(std::uint32_t keyval) const;
   void updateXkbState(std::uint32_t keyval, bool isPressed);
   void clearStaleModifiers() override;
@@ -43,6 +44,7 @@ protected:
   void fakeKey(const Keystroke &keystroke) override;
 
 private:
+  KeyID mapKeyFromLevel(std::uint32_t keyval, xkb_layout_index_t layout, xkb_level_index_t level) const;
   std::uint32_t convertModMask(xkb_mod_mask_t xkbModMaskIn) const;
   void assignGeneratedModifiers(std::uint32_t keycode, KeyMap::KeyItem &item);
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1070,6 +1070,41 @@ void Server::sendOptions(BaseClientProxy *client) const
   client->setOptions(optionsList);
 }
 
+KeyModifierID Server::getModifierMapping(const BaseClientProxy *client, OptionID option, KeyModifierID fallback) const
+{
+  OptionValue mapping = fallback;
+
+  const auto applyOption = [&](const Config::ScreenOptions *options) {
+    if (options == nullptr) {
+      return;
+    }
+
+    if (const auto it = options->find(option); it != options->end()) {
+      mapping = it->second;
+    }
+  };
+
+  applyOption(m_config->getOptions(getName(client)));
+
+  return static_cast<KeyModifierID>(mapping);
+}
+
+KeyID Server::translateKeyForClient(
+    const BaseClientProxy *client, KeyID id, KeyModifierMask mask, KeyButton button
+) const
+{
+  if (client == nullptr || client->isPrimary() || (mask & KeyModifierAltGr) == 0) {
+    return id;
+  }
+
+  if (getModifierMapping(client, kOptionModifierMapForAltGr, kKeyModifierIDAltGr) == kKeyModifierIDAltGr) {
+    return id;
+  }
+
+  KeyID baseKey = m_screen->getPlatformScreen()->getKeyIDForButton(button);
+  return (baseKey != kKeyNone) ? baseKey : id;
+}
+
 void Server::processOptions()
 {
   const Config::ScreenOptions *options = m_config->getOptions("");
@@ -1546,7 +1581,7 @@ void Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const s
 
   // relay
   if (!m_keyboardBroadcasting && IKeyState::KeyInfo::isDefault(screens)) {
-    m_active->keyDown(id, mask, button, lang);
+    m_active->keyDown(translateKeyForClient(m_active, id, mask, button), mask, button, lang);
   } else {
     if (!screens && m_keyboardBroadcasting) {
       screens = m_keyboardBroadcastingScreens.c_str();
@@ -1556,7 +1591,7 @@ void Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const s
     }
     for (ClientList::const_iterator index = m_clients.begin(); index != m_clients.end(); ++index) {
       if (IKeyState::KeyInfo::contains(screens, index->first)) {
-        index->second->keyDown(id, mask, button, lang);
+        index->second->keyDown(translateKeyForClient(index->second, id, mask, button), mask, button, lang);
       }
     }
   }
@@ -1594,7 +1629,7 @@ void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButto
   assert(m_active != nullptr);
 
   // relay
-  m_active->keyRepeat(id, mask, count, button, lang);
+  m_active->keyRepeat(translateKeyForClient(m_active, id, mask, button), mask, count, button, lang);
 }
 
 void Server::onMouseDown(ButtonID id)

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -32,6 +32,7 @@ class Screen;
 class IEventQueue;
 class Thread;
 class ClientListener;
+class ServerTestsAccess;
 
 //! Deskflow server
 /*!
@@ -40,6 +41,8 @@ This class implements the top-level server algorithms for deskflow.
 class Server
 {
   using ServerConfig = deskflow::server::Config;
+
+  friend class ServerTestsAccess;
 
 public:
   //! Lock cursor to screen data
@@ -298,6 +301,9 @@ private:
 
   // send screen options to \c client
   void sendOptions(BaseClientProxy *client) const;
+
+  KeyModifierID getModifierMapping(const BaseClientProxy *client, OptionID option, KeyModifierID fallback) const;
+  KeyID translateKeyForClient(const BaseClientProxy *client, KeyID id, KeyModifierMask mask, KeyButton button) const;
 
   // process options from configuration
   void processOptions();

--- a/src/unittests/server/ServerTests.cpp
+++ b/src/unittests/server/ServerTests.cpp
@@ -7,7 +7,486 @@
 
 #include "ServerTests.h"
 
+#include "../deskflow/MockEventQueue.h"
+#include "deskflow/PlatformScreen.h"
+#include "deskflow/Screen.h"
+#include "server/BaseClientProxy.h"
+#include "server/PrimaryClient.h"
+
 #include "server/Server.h"
+
+class ServerTestsAccess
+{
+public:
+  static bool addClient(Server *server, BaseClientProxy *client)
+  {
+    return server->addClient(client);
+  }
+
+  static void setActive(Server *server, BaseClientProxy *client)
+  {
+    server->m_active = client;
+  }
+
+  static void detachClient(Server *server, BaseClientProxy *client, PrimaryClient *primary)
+  {
+    server->m_active = primary;
+    server->m_clientSet.erase(client);
+    server->m_clients.erase(client->getName());
+  }
+
+  static void onKeyDown(
+      Server *server, KeyID key, KeyModifierMask mask, KeyButton button, const std::string &lang, const char *screens
+  )
+  {
+    server->onKeyDown(key, mask, button, lang, screens);
+  }
+
+  static void
+  onKeyRepeat(Server *server, KeyID key, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang)
+  {
+    server->onKeyRepeat(key, mask, count, button, lang);
+  }
+};
+
+namespace {
+
+class StubKeyState : public IKeyState
+{
+public:
+  explicit StubKeyState(IEventQueue *events) : IKeyState(events)
+  {
+  }
+
+  void updateKeyMap() override
+  {
+  }
+
+  void updateKeyState() override
+  {
+  }
+
+  void setHalfDuplexMask(KeyModifierMask) override
+  {
+  }
+
+  void fakeKeyDown(KeyID, KeyModifierMask, KeyButton, const std::string &) override
+  {
+  }
+
+  bool fakeKeyRepeat(KeyID, KeyModifierMask, int32_t, KeyButton, const std::string &) override
+  {
+    return false;
+  }
+
+  bool fakeKeyUp(KeyButton) override
+  {
+    return false;
+  }
+
+  void fakeAllKeysUp() override
+  {
+  }
+
+  bool fakeCtrlAltDel() override
+  {
+    return false;
+  }
+
+  bool fakeMediaKey(KeyID) override
+  {
+    return false;
+  }
+
+  bool isKeyDown(KeyButton) const override
+  {
+    return false;
+  }
+
+  KeyModifierMask getActiveModifiers() const override
+  {
+    return 0;
+  }
+
+  KeyModifierMask pollActiveModifiers() const override
+  {
+    return 0;
+  }
+
+  int32_t pollActiveGroup() const override
+  {
+    return 0;
+  }
+
+  void pollPressedKeys(KeyButtonSet &) const override
+  {
+  }
+
+  KeyID getKeyIDForButton(KeyButton button) const override
+  {
+    return (button == mappedButton) ? baseKey : kKeyNone;
+  }
+
+  KeyButton mappedButton = 0;
+  KeyID baseKey = kKeyNone;
+};
+
+class StubPlatformScreen : public PlatformScreen
+{
+public:
+  explicit StubPlatformScreen(IEventQueue *events) : PlatformScreen(events), m_keyState(events)
+  {
+  }
+
+  void *getEventTarget() const override
+  {
+    return const_cast<StubPlatformScreen *>(this);
+  }
+
+  bool getClipboard(ClipboardID, IClipboard *) const override
+  {
+    return false;
+  }
+
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override
+  {
+    x = 0;
+    y = 0;
+    width = 1920;
+    height = 1080;
+  }
+
+  void getCursorPos(int32_t &x, int32_t &y) const override
+  {
+    x = 0;
+    y = 0;
+  }
+
+  void reconfigure(uint32_t) override
+  {
+  }
+
+  uint32_t activeSides() override
+  {
+    return 0;
+  }
+
+  void warpCursor(int32_t, int32_t) override
+  {
+  }
+
+  uint32_t registerHotKey(KeyID, KeyModifierMask) override
+  {
+    return 0;
+  }
+
+  void unregisterHotKey(uint32_t) override
+  {
+  }
+
+  void fakeInputBegin() override
+  {
+  }
+
+  void fakeInputEnd() override
+  {
+  }
+
+  int32_t getJumpZoneSize() const override
+  {
+    return 0;
+  }
+
+  bool isAnyMouseButtonDown(uint32_t &) const override
+  {
+    return false;
+  }
+
+  void getCursorCenter(int32_t &x, int32_t &y) const override
+  {
+    x = 960;
+    y = 540;
+  }
+
+  void fakeMouseButton(ButtonID, bool) override
+  {
+  }
+
+  void fakeMouseMove(int32_t, int32_t) override
+  {
+  }
+
+  void fakeMouseRelativeMove(int32_t, int32_t) const override
+  {
+  }
+
+  void fakeMouseWheel(ScrollDelta) const override
+  {
+  }
+
+  void enable() override
+  {
+  }
+
+  void disable() override
+  {
+  }
+
+  void enter() override
+  {
+  }
+
+  bool canLeave() override
+  {
+    return true;
+  }
+
+  void leave() override
+  {
+  }
+
+  bool setClipboard(ClipboardID, const IClipboard *) override
+  {
+    return true;
+  }
+
+  void checkClipboards() override
+  {
+  }
+
+  void openScreensaver(bool) override
+  {
+  }
+
+  void closeScreensaver() override
+  {
+  }
+
+  void screensaver(bool) override
+  {
+  }
+
+  void resetOptions() override
+  {
+  }
+
+  void setOptions(const OptionsList &) override
+  {
+  }
+
+  void setSequenceNumber(uint32_t) override
+  {
+  }
+
+  std::string getSecureInputApp() const override
+  {
+    return {};
+  }
+
+  bool isPrimary() const override
+  {
+    return true;
+  }
+
+  StubKeyState m_keyState;
+
+protected:
+  void updateButtons() override
+  {
+  }
+
+  IKeyState *getKeyState() const override
+  {
+    return const_cast<StubKeyState *>(&m_keyState);
+  }
+
+  void handleSystemEvent(const Event &) override
+  {
+  }
+};
+
+class RecordingClientProxy : public BaseClientProxy
+{
+public:
+  explicit RecordingClientProxy(const std::string &name) : BaseClientProxy(name)
+  {
+  }
+
+  void *getEventTarget() const override
+  {
+    return const_cast<RecordingClientProxy *>(this);
+  }
+
+  bool getClipboard(ClipboardID, IClipboard *) const override
+  {
+    return false;
+  }
+
+  void getShape(int32_t &x, int32_t &y, int32_t &width, int32_t &height) const override
+  {
+    x = 0;
+    y = 0;
+    width = 1920;
+    height = 1080;
+  }
+
+  void getCursorPos(int32_t &x, int32_t &y) const override
+  {
+    x = 0;
+    y = 0;
+  }
+
+  void enter(int32_t, int32_t, uint32_t, KeyModifierMask, bool) override
+  {
+  }
+
+  bool leave() override
+  {
+    return true;
+  }
+
+  void setClipboard(ClipboardID, const IClipboard *) override
+  {
+  }
+
+  void grabClipboard(ClipboardID) override
+  {
+  }
+
+  void setClipboardDirty(ClipboardID, bool) override
+  {
+  }
+
+  void keyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &lang) override
+  {
+    lastKeyDown = id;
+    lastMask = mask;
+    lastButton = button;
+    lastLang = lang;
+  }
+
+  void keyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang) override
+  {
+    lastKeyRepeat = id;
+    lastRepeatCount = count;
+    lastMask = mask;
+    lastButton = button;
+    lastLang = lang;
+  }
+
+  void keyUp(KeyID, KeyModifierMask, KeyButton) override
+  {
+  }
+
+  void mouseDown(ButtonID) override
+  {
+  }
+
+  void mouseUp(ButtonID) override
+  {
+  }
+
+  void mouseMove(int32_t, int32_t) override
+  {
+  }
+
+  void mouseRelativeMove(int32_t, int32_t) override
+  {
+  }
+
+  void mouseWheel(int32_t, int32_t) override
+  {
+  }
+
+  void screensaver(bool) override
+  {
+  }
+
+  void resetOptions() override
+  {
+  }
+
+  void setOptions(const OptionsList &) override
+  {
+  }
+
+  void sendDragInfo(uint32_t, const char *, size_t) override
+  {
+  }
+
+  void fileChunkSending(uint8_t, char *, size_t) override
+  {
+  }
+
+  std::string getSecureInputApp() const override
+  {
+    return {};
+  }
+
+  void secureInputNotification(const std::string &) const override
+  {
+  }
+
+  deskflow::IStream *getStream() const override
+  {
+    return nullptr;
+  }
+
+  KeyID lastKeyDown = kKeyNone;
+  KeyID lastKeyRepeat = kKeyNone;
+  KeyModifierMask lastMask = 0;
+  KeyButton lastButton = 0;
+  int32_t lastRepeatCount = 0;
+  std::string lastLang;
+};
+
+struct ServerHarness
+{
+  explicit ServerHarness(bool remapAltGr)
+  {
+    config.addScreen("server");
+    config.addScreen("client");
+    if (remapAltGr) {
+      config.addOption("client", kOptionModifierMapForAltGr, kKeyModifierIDAlt);
+    }
+
+    platformScreen = new StubPlatformScreen(&eventQueue);
+    screen = new deskflow::Screen(platformScreen, &eventQueue);
+    primary = new PrimaryClient("server", screen);
+    server = new Server(config, primary, screen, &eventQueue);
+    client = new RecordingClientProxy("client");
+    ServerTestsAccess::addClient(server, client);
+    ServerTestsAccess::setActive(server, client);
+  }
+
+  ~ServerHarness()
+  {
+    if (server != nullptr && client != nullptr) {
+      ServerTestsAccess::detachClient(server, client, primary);
+      delete client;
+      client = nullptr;
+    }
+
+    delete server;
+    delete primary;
+    delete screen;
+  }
+
+  MockEventQueue eventQueue;
+  deskflow::server::Config config{&eventQueue};
+  StubPlatformScreen *platformScreen = nullptr;
+  deskflow::Screen *screen = nullptr;
+  PrimaryClient *primary = nullptr;
+  Server *server = nullptr;
+  RecordingClientProxy *client = nullptr;
+};
+
+} // namespace
+
+void ServerTests::initTestCase()
+{
+  m_arch.init();
+}
 
 void ServerTests::SwitchToScreenInfo_alloc_screen()
 {
@@ -22,6 +501,45 @@ void ServerTests::KeyboardBroadcastInfo_alloc_stateAndSceens()
   QCOMPARE(info->m_state, Server::KeyboardBroadcastInfo::State::kOn);
   QCOMPARE(info->m_screens, "test");
   delete info;
+}
+
+void ServerTests::onKeyDown_altGrRemap_usesBaseKey()
+{
+  ServerHarness harness(true);
+  harness.platformScreen->m_keyState.mappedButton = 46;
+  harness.platformScreen->m_keyState.baseKey = 'l';
+
+  ServerTestsAccess::onKeyDown(harness.server, 0x0142, KeyModifierAltGr, 46, "pl", nullptr);
+
+  QCOMPARE(harness.client->lastKeyDown, static_cast<KeyID>('l'));
+  QCOMPARE(harness.client->lastMask, KeyModifierAltGr);
+  QCOMPARE(harness.client->lastButton, static_cast<KeyButton>(46));
+}
+
+void ServerTests::onKeyDown_withoutAltGrRemap_preservesTranslatedKey()
+{
+  ServerHarness harness(false);
+  harness.platformScreen->m_keyState.mappedButton = 46;
+  harness.platformScreen->m_keyState.baseKey = 'l';
+
+  ServerTestsAccess::onKeyDown(harness.server, 0x0142, KeyModifierAltGr, 46, "pl", nullptr);
+
+  QCOMPARE(harness.client->lastKeyDown, static_cast<KeyID>(0x0142));
+  QCOMPARE(harness.client->lastMask, KeyModifierAltGr);
+}
+
+void ServerTests::onKeyRepeat_altGrRemap_usesBaseKey()
+{
+  ServerHarness harness(true);
+  harness.platformScreen->m_keyState.mappedButton = 46;
+  harness.platformScreen->m_keyState.baseKey = 'l';
+
+  ServerTestsAccess::onKeyRepeat(harness.server, 0x0142, KeyModifierAltGr, 3, 46, "pl");
+
+  QCOMPARE(harness.client->lastKeyRepeat, static_cast<KeyID>('l'));
+  QCOMPARE(harness.client->lastRepeatCount, 3);
+  QCOMPARE(harness.client->lastMask, KeyModifierAltGr);
+  QCOMPARE(harness.client->lastButton, static_cast<KeyButton>(46));
 }
 
 QTEST_MAIN(ServerTests)

--- a/src/unittests/server/ServerTests.h
+++ b/src/unittests/server/ServerTests.h
@@ -6,10 +6,21 @@
 
 #include <QTest>
 
+#include "arch/Arch.h"
+#include "base/Log.h"
+
 class ServerTests : public QObject
 {
   Q_OBJECT
 private Q_SLOTS:
+  void initTestCase();
   void SwitchToScreenInfo_alloc_screen();
   void KeyboardBroadcastInfo_alloc_stateAndSceens();
+  void onKeyDown_altGrRemap_usesBaseKey();
+  void onKeyDown_withoutAltGrRemap_preservesTranslatedKey();
+  void onKeyRepeat_altGrRemap_usesBaseKey();
+
+private:
+  Arch m_arch;
+  Log m_log;
 };


### PR DESCRIPTION
## Description
Fixes an issue on Wayland servers where keyboard events are resolved through XKB at Level 3 prior to evaluating the destination client's modifier remapping configuration. 

Previously, when a client configuration remapped a modifier (e.g., `altgr = alt`), pressing `AltGr+l` on a Wayland server (Polish XKB layout) resolved to the Level 3 symbol `ł` (`0x0142`). The server forwarded this resolved symbol along with the translated modifier mask, which the client incorrectly interpreted as `Alt + ł`. 

This PR implements a new hook `IKeyState::getKeyIDForButton()` in the `EiKeyState` layer, allowing the server to enforce a Level 0 XKB resolution when a modifier translation is detected. `Server.cpp` now dynamically retrieves the base `KeyID` (`l` / `0x006C`) when `AltGr` is actively remapped by the destination client, ensuring the client receives the base key and the translated modifier (`Alt + l`). Execution paths without modifier mapping remain unaffected.

## AI tools used for this PR
GitHub Copilot (GPT-5.4). Used for isolating the root cause within the XKB/libei platform layer and generating the initial C++ hook implementations for `Server.cpp` and `EiKeyState.cpp`.

## Fixed/related issues
fixes: #9761
related: #8864 and #8839

## How has this been tested?
Tested locally via automated unit tests and manual verification.

**Test Environment:**
- **Server:** Fedora 43 (GNOME Wayland, Polish XKB layout)
- **Client:** macOS (native Polish layout)
- **Configuration:** `altgr = alt` defined in the server's per-screen config for the client.

**Unit Tests:**
- Executed `ServerTests` target (`./build/src/unittests/server/ServerTests`).
- Result: 7 passed, 0 failed.
- Covered paths: `keyDown` with/without `AltGr` remap, `keyRepeat` with `AltGr` remap.

**Manual Validation:**
- Pressed `AltGr+l` on the Wayland server. 
- Verified that the macOS client correctly received the base key (`l`) and the `Alt` mask, generating the intended system input `ł` instead of the corrupted `Ļ` character.