### PR TITLE
Wayland per-barrier position mapping for multi monitor setup

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -16,6 +16,9 @@
 #include "common/Settings.h"
 #endif
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <sys/socket.h> // for EIS fd hack, remove
 #include <sys/un.h>     // for EIS fd hack, remove
 
@@ -37,6 +40,118 @@ const char *PortalInputCapture::barrierSideName(BarrierSide side)
   }
 
   return "unknown";
+}
+
+int PortalInputCapture::scaleCoordinateBetweenRanges(
+    double value, int sourceMin, int sourceMax, int destinationMin, int destinationMax
+)
+{
+  if (sourceMax <= sourceMin || destinationMax <= destinationMin) {
+    return destinationMin;
+  }
+
+  const auto clamped = std::clamp(value, static_cast<double>(sourceMin), static_cast<double>(sourceMax));
+  const auto fraction = (clamped - sourceMin) / (sourceMax - sourceMin);
+  const auto mapped = static_cast<int>(std::lround(destinationMin + fraction * (destinationMax - destinationMin)));
+  return std::clamp(mapped, destinationMin, destinationMax);
+}
+
+bool PortalInputCapture::getPortalBounds(Bounds &bounds) const
+{
+  if (m_barrierInfo.empty()) {
+    return false;
+  }
+
+  bounds.left = std::numeric_limits<gint>::max();
+  bounds.top = std::numeric_limits<gint>::max();
+  bounds.right = std::numeric_limits<gint>::min();
+  bounds.bottom = std::numeric_limits<gint>::min();
+
+  for (const auto &info : m_barrierInfo) {
+    bounds.left = std::min(bounds.left, info.x);
+    bounds.top = std::min(bounds.top, info.y);
+    bounds.right = std::max(bounds.right, info.x + static_cast<gint>(info.width) - 1);
+    bounds.bottom = std::max(bounds.bottom, info.y + static_cast<gint>(info.height) - 1);
+  }
+
+  return true;
+}
+
+bool PortalInputCapture::getClosestReleaseBarrier(
+    double x, double y, int screenLeft, int screenTop, int screenRight, int screenBottom, const Bounds &portalBounds,
+    BarrierInfo &barrier
+) const
+{
+  const auto activeSides = m_screen->activeSides();
+  using enum DirectionMask;
+
+  auto side = BarrierSide::Left;
+  auto sideDistance = std::numeric_limits<double>::max();
+  const auto considerSide = [&side, &sideDistance](BarrierSide candidateSide, double candidateDistance) {
+    if (candidateDistance < sideDistance) {
+      side = candidateSide;
+      sideDistance = candidateDistance;
+    }
+  };
+
+  if (activeSides & static_cast<int>(LeftMask)) {
+    considerSide(BarrierSide::Left, std::abs(x - screenLeft));
+  }
+  if (activeSides & static_cast<int>(RightMask)) {
+    considerSide(BarrierSide::Right, std::abs(x - screenRight));
+  }
+  if (activeSides & static_cast<int>(TopMask)) {
+    considerSide(BarrierSide::Top, std::abs(y - screenTop));
+  }
+  if (activeSides & static_cast<int>(BottomMask)) {
+    considerSide(BarrierSide::Bottom, std::abs(y - screenBottom));
+  }
+  if (sideDistance == std::numeric_limits<double>::max()) {
+    return false;
+  }
+
+  const auto portalX = scaleCoordinateBetweenRanges(x, screenLeft, screenRight, portalBounds.left, portalBounds.right);
+  const auto portalY = scaleCoordinateBetweenRanges(y, screenTop, screenBottom, portalBounds.top, portalBounds.bottom);
+
+  auto bestDistance = std::numeric_limits<int>::max();
+  for (const auto &info : m_barrierInfo) {
+    if (info.side != side) {
+      continue;
+    }
+
+    const auto left = info.x;
+    const auto top = info.y;
+    const auto right = info.x + static_cast<gint>(info.width) - 1;
+    const auto bottom = info.y + static_cast<gint>(info.height) - 1;
+    auto distance = 0;
+
+    switch (side) {
+    case BarrierSide::Left:
+    case BarrierSide::Right:
+      if (portalY < top) {
+        distance = top - portalY;
+      } else if (portalY > bottom) {
+        distance = portalY - bottom;
+      }
+      break;
+
+    case BarrierSide::Top:
+    case BarrierSide::Bottom:
+      if (portalX < left) {
+        distance = left - portalX;
+      } else if (portalX > right) {
+        distance = portalX - right;
+      }
+      break;
+    }
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      barrier = info;
+    }
+  }
+
+  return bestDistance != std::numeric_limits<int>::max();
 }
 
 PortalInputCapture::PortalInputCapture(EiScreen *screen, IEventQueue *events)
@@ -189,6 +304,7 @@ void PortalInputCapture::handleSetPointerBarriers(const GObject *, GAsyncResult 
           LOG_WARN("failed to apply barrier %d (%d/%d-%d/%d)", id, x1, y1, x2, y2);
           g_object_unref(*elem);
           m_barriers.erase(elem);
+          std::erase_if(m_barrierInfo, [id](const auto &info) { return info.id == id; });
           break;
         }
       }
@@ -198,6 +314,110 @@ void PortalInputCapture::handleSetPointerBarriers(const GObject *, GAsyncResult 
   g_list_free_full(failed_list, g_object_unref);
 
   enable();
+}
+
+std::pair<int, int>
+PortalInputCapture::mapPortalActivationToScreenPosition(guint barrierId, double rawX, double rawY) const
+{
+  auto x = static_cast<int>(rawX);
+  auto y = static_cast<int>(rawY);
+
+  const auto it = std::ranges::find_if(m_barrierInfo, [barrierId](const auto &info) { return info.id == barrierId; });
+  if (it == m_barrierInfo.end()) {
+    LOG_DEBUG("activated barrier %u is not in the current pointer barrier set", barrierId);
+    return {x, y};
+  }
+
+  const auto zoneLeft = it->x;
+  const auto zoneTop = it->y;
+  const auto zoneRight = it->x + static_cast<gint>(it->width) - 1;
+  const auto zoneBottom = it->y + static_cast<gint>(it->height) - 1;
+
+  std::int32_t screenX;
+  std::int32_t screenY;
+  std::int32_t screenW;
+  std::int32_t screenH;
+  m_screen->getShape(screenX, screenY, screenW, screenH);
+
+  Bounds portalBounds;
+  if (getPortalBounds(portalBounds)) {
+    x = scaleCoordinateBetweenRanges(rawX, portalBounds.left, portalBounds.right, screenX, screenX + screenW - 1);
+    y = scaleCoordinateBetweenRanges(rawY, portalBounds.top, portalBounds.bottom, screenY, screenY + screenH - 1);
+  } else {
+    x = std::clamp(x, zoneLeft, zoneRight);
+    y = std::clamp(y, zoneTop, zoneBottom);
+  }
+
+  // The portal reports per-output zones, while Deskflow models the whole computer as one screen.
+  // Use the activated barrier to preserve the intended switch direction in Deskflow's aggregate coordinates.
+  using enum BarrierSide;
+  switch (it->side) {
+  case Left:
+    x = screenX;
+    break;
+  case Right:
+    x = screenX + screenW - 1;
+    break;
+  case Top:
+    y = screenY;
+    break;
+  case Bottom:
+    y = screenY + screenH - 1;
+    break;
+  }
+
+  return {x, y};
+}
+
+std::pair<double, double> PortalInputCapture::mapPortalReleasePosition(double x, double y) const
+{
+  std::int32_t screenX;
+  std::int32_t screenY;
+  std::int32_t screenW;
+  std::int32_t screenH;
+  m_screen->getShape(screenX, screenY, screenW, screenH);
+
+  const auto screenLeft = screenX;
+  const auto screenTop = screenY;
+  const auto screenRight = screenX + screenW - 1;
+  const auto screenBottom = screenY + screenH - 1;
+  const auto jumpZoneSize = m_screen->getJumpZoneSize();
+  Bounds portalBounds;
+  if (!getPortalBounds(portalBounds)) {
+    return {x, y};
+  }
+
+  auto mappedX = scaleCoordinateBetweenRanges(x, screenLeft, screenRight, portalBounds.left, portalBounds.right);
+  auto mappedY = scaleCoordinateBetweenRanges(y, screenTop, screenBottom, portalBounds.top, portalBounds.bottom);
+  BarrierInfo releaseBarrier;
+  if (getClosestReleaseBarrier(x, y, screenLeft, screenTop, screenRight, screenBottom, portalBounds, releaseBarrier)) {
+    const Bounds releaseBounds = {
+        releaseBarrier.x, releaseBarrier.y, releaseBarrier.x + static_cast<gint>(releaseBarrier.width) - 1,
+        releaseBarrier.y + static_cast<gint>(releaseBarrier.height) - 1
+    };
+
+    using enum BarrierSide;
+    switch (releaseBarrier.side) {
+    case Left:
+      mappedX = std::min(releaseBounds.left + jumpZoneSize, releaseBounds.right);
+      mappedY = std::clamp(mappedY, releaseBounds.top, releaseBounds.bottom);
+      break;
+    case Right:
+      mappedX = std::max(releaseBounds.right - jumpZoneSize, releaseBounds.left);
+      mappedY = std::clamp(mappedY, releaseBounds.top, releaseBounds.bottom);
+      break;
+    case Top:
+      mappedX = std::clamp(mappedX, releaseBounds.left, releaseBounds.right);
+      mappedY = std::min(releaseBounds.top + jumpZoneSize, releaseBounds.bottom);
+      break;
+    case Bottom:
+      mappedX = std::clamp(mappedX, releaseBounds.left, releaseBounds.right);
+      mappedY = std::max(releaseBounds.bottom - jumpZoneSize, releaseBounds.top);
+      break;
+    }
+  }
+
+  return {mappedX, mappedY};
 }
 
 void PortalInputCapture::addBarrier(
@@ -241,6 +461,7 @@ void PortalInputCapture::addBarrier(
   m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
       g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr)
   ));
+  m_barrierInfo.push_back({id, side, zoneX, zoneY, zoneWidth, zoneHeight, x1, y1, x2, y2});
 }
 
 gboolean PortalInputCapture::initSession()
@@ -345,8 +566,11 @@ void PortalInputCapture::release()
 
 void PortalInputCapture::release(double x, double y)
 {
-  LOG_DEBUG("releasing input capture session, id=%d x=%.1f y=%.1f", m_activationId, x, y);
-  xdp_input_capture_session_release_at(m_session, m_activationId, x, y);
+  const auto [mappedX, mappedY] = mapPortalReleasePosition(x, y);
+  LOG_DEBUG(
+      "releasing input capture session, id=%d x=%.1f y=%.1f mapped=%.1f,%.1f", m_activationId, x, y, mappedX, mappedY
+  );
+  xdp_input_capture_session_release_at(m_session, m_activationId, mappedX, mappedY);
   m_isActive = false;
 }
 
@@ -385,7 +609,27 @@ void PortalInputCapture::handleActivated(
     gdouble x;
     gdouble y;
     if (g_variant_lookup(options, "cursor_position", "(dd)", &x, &y)) {
-      m_screen->warpCursor((int)x, (int)y);
+      auto warpX = static_cast<int>(x);
+      auto warpY = static_cast<int>(y);
+
+      guint barrierId = 0;
+      const bool hasBarrierId = g_variant_lookup(options, "barrier_id", "u", &barrierId);
+
+      if (hasBarrierId && barrierId > 0) {
+        auto [mappedX, mappedY] = mapPortalActivationToScreenPosition(barrierId, x, y);
+        warpX = mappedX;
+        warpY = mappedY;
+      } else if (!hasBarrierId) {
+        LOG_DEBUG("portal activation has no barrier id, using raw cursor position");
+      } else {
+        LOG_DEBUG("portal activation barrier id is zero, using raw cursor position");
+      }
+
+      m_screen->warpCursor(warpX, warpY);
+      m_events->addEvent(Event(
+          EventTypes::PrimaryScreenMotionOnPrimary, m_screen->getEventTarget(),
+          IPrimaryScreen::MotionInfo::alloc(warpX, warpY)
+      ));
     } else {
       LOG_WARN("failed to get cursor position");
     }
@@ -406,16 +650,17 @@ void PortalInputCapture::handleDeactivated(
 
 void PortalInputCapture::handleZonesChanged(XdpInputCaptureSession *session, const GVariant *)
 {
-
   for (auto b : m_barriers)
     g_object_unref(b);
   m_barriers.clear();
+  m_barrierInfo.clear();
 
   const auto activeSides = m_screen->activeSides();
   using enum DirectionMask;
 
   // May not correctly handle different sized screens
   auto zones = xdp_input_capture_session_get_zones(session);
+  guint id = 0;
   while (zones != nullptr) {
     guint w;
     guint h;
@@ -424,8 +669,6 @@ void PortalInputCapture::handleZonesChanged(XdpInputCaptureSession *session, con
     g_object_get(zones->data, "width", &w, "height", &h, "x", &x, "y", &y, nullptr);
 
     LOG_DEBUG("input capture zone, %dx%d@%d,%d", w, h, x, y);
-
-    auto id = 0;
 
     if (activeSides & static_cast<int>(LeftMask)) {
       addBarrier(++id, BarrierSide::Left, x, y, w, h);

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2024 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2022 Red Hat, Inc.
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -20,6 +20,24 @@
 #include <sys/un.h>     // for EIS fd hack, remove
 
 namespace deskflow {
+
+const char *PortalInputCapture::barrierSideName(BarrierSide side)
+{
+  using enum BarrierSide;
+
+  switch (side) {
+  case Left:
+    return "left";
+  case Right:
+    return "right";
+  case Top:
+    return "top";
+  case Bottom:
+    return "bottom";
+  }
+
+  return "unknown";
+}
 
 PortalInputCapture::PortalInputCapture(EiScreen *screen, IEventQueue *events)
     : m_screen{screen},
@@ -180,6 +198,49 @@ void PortalInputCapture::handleSetPointerBarriers(const GObject *, GAsyncResult 
   g_list_free_full(failed_list, g_object_unref);
 
   enable();
+}
+
+void PortalInputCapture::addBarrier(
+    guint id, BarrierSide side, gint zoneX, gint zoneY, guint zoneWidth, guint zoneHeight
+)
+{
+  gint x1 = 0;
+  gint x2 = 0;
+  gint y1 = 0;
+  gint y2 = 0;
+
+  using enum BarrierSide;
+  switch (side) {
+  case Left:
+    x1 = zoneX;
+    y1 = zoneY;
+    x2 = zoneX;
+    y2 = zoneY + static_cast<gint>(zoneHeight) - 1;
+    break;
+  case Right:
+    x1 = zoneX + static_cast<gint>(zoneWidth);
+    y1 = zoneY;
+    x2 = x1;
+    y2 = zoneY + static_cast<gint>(zoneHeight) - 1;
+    break;
+  case Top:
+    x1 = zoneX;
+    y1 = zoneY;
+    x2 = zoneX + static_cast<gint>(zoneWidth) - 1;
+    y2 = zoneY;
+    break;
+  case Bottom:
+    x1 = zoneX;
+    y1 = zoneY + static_cast<gint>(zoneHeight);
+    x2 = zoneX + static_cast<gint>(zoneWidth) - 1;
+    y2 = y1;
+    break;
+  }
+
+  LOG_DEBUG("barrier (%s) %u at %d,%d-%d,%d", barrierSideName(side), id, x1, y1, x2, y2);
+  m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(
+      g_object_new(XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr)
+  ));
 }
 
 gboolean PortalInputCapture::initSession()
@@ -364,59 +425,22 @@ void PortalInputCapture::handleZonesChanged(XdpInputCaptureSession *session, con
 
     LOG_DEBUG("input capture zone, %dx%d@%d,%d", w, h, x, y);
 
-    int x1;
-    int x2;
-    int y1;
-    int y2;
-
     auto id = 0;
 
     if (activeSides & static_cast<int>(LeftMask)) {
-      id++;
-      x1 = x;
-      y1 = y;
-      x2 = x;
-      y2 = y + h - 1;
-      LOG_DEBUG("barrier (left) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
-      m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(g_object_new(
-          XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr
-      )));
+      addBarrier(++id, BarrierSide::Left, x, y, w, h);
     }
 
     if (activeSides & static_cast<int>(RightMask)) {
-      id++;
-      x1 = x + w;
-      y1 = y;
-      x2 = x + w;
-      y2 = y + h - 1;
-      LOG_DEBUG("barrier (right) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
-      m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(g_object_new(
-          XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr
-      )));
+      addBarrier(++id, BarrierSide::Right, x, y, w, h);
     }
 
     if (activeSides & static_cast<int>(TopMask)) {
-      id++;
-      x1 = x;
-      y1 = y;
-      x2 = x + w - 1;
-      y2 = y;
-      LOG_DEBUG("barrier (top) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
-      m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(g_object_new(
-          XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr
-      )));
+      addBarrier(++id, BarrierSide::Top, x, y, w, h);
     }
 
     if (activeSides & static_cast<int>(BottomMask)) {
-      id++;
-      x1 = x;
-      y1 = y + h;
-      x2 = x + w - 1;
-      y2 = y + h;
-      LOG_DEBUG("barrier (bottom) %zd at %d,%d-%d,%d", id, x1, y1, x2, y2);
-      m_barriers.push_back(XDP_INPUT_CAPTURE_POINTER_BARRIER(g_object_new(
-          XDP_TYPE_INPUT_CAPTURE_POINTER_BARRIER, "id", id, "x1", x1, "y1", y1, "x2", x2, "y2", y2, nullptr
-      )));
+      addBarrier(++id, BarrierSide::Bottom, x, y, w, h);
     }
     zones = zones->next;
   }

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <map>
+#include <utility>
 #include <vector>
 
 namespace deskflow {
@@ -95,7 +96,38 @@ private:
     Bottom
   };
 
+  struct BarrierInfo
+  {
+    guint id = 0;
+    BarrierSide side = BarrierSide::Left;
+    gint x = 0;
+    gint y = 0;
+    guint width = 0;
+    guint height = 0;
+    gint x1 = 0;
+    gint y1 = 0;
+    gint x2 = 0;
+    gint y2 = 0;
+  };
+
+  struct Bounds
+  {
+    gint left = 0;
+    gint top = 0;
+    gint right = 0;
+    gint bottom = 0;
+  };
+
   static const char *barrierSideName(BarrierSide side);
+  static int
+  scaleCoordinateBetweenRanges(double value, int sourceMin, int sourceMax, int destinationMin, int destinationMax);
+  bool getPortalBounds(Bounds &bounds) const;
+  bool getClosestReleaseBarrier(
+      double x, double y, int screenLeft, int screenTop, int screenRight, int screenBottom, const Bounds &portalBounds,
+      BarrierInfo &barrier
+  ) const;
+  std::pair<int, int> mapPortalActivationToScreenPosition(guint barrierId, double rawX, double rawY) const;
+  std::pair<double, double> mapPortalReleasePosition(double x, double y) const;
   void addBarrier(guint id, BarrierSide side, gint zoneX, gint zoneY, guint zoneWidth, guint zoneHeight);
 
   EiScreen *m_screen = nullptr;
@@ -121,6 +153,7 @@ private:
   std::uint32_t m_activationId = 0;
 
   std::vector<XdpInputCapturePointerBarrier *> m_barriers;
+  std::vector<BarrierInfo> m_barrierInfo;
 };
 
 } // namespace deskflow

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2024 Symless Ltd.
  * SPDX-FileCopyrightText: (C) 2022 Red Hat, Inc.
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -14,6 +14,10 @@
 #include <glib.h>
 #include <libportal/inputcapture.h>
 #include <libportal/portal.h>
+
+#include <cstdint>
+#include <map>
+#include <vector>
 
 namespace deskflow {
 
@@ -82,6 +86,17 @@ private:
     Deactivated,
     ZonesChanged
   };
+
+  enum class BarrierSide : uint8_t
+  {
+    Left,
+    Right,
+    Top,
+    Bottom
+  };
+
+  static const char *barrierSideName(BarrierSide side);
+  void addBarrier(guint id, BarrierSide side, gint zoneX, gint zoneY, guint zoneWidth, guint zoneHeight);
 
   EiScreen *m_screen = nullptr;
   IEventQueue *m_events = nullptr;


### PR DESCRIPTION
## Description
Two changes:
1. Some new functions/generalization to promote DRY, also used in the second change.
2. Implemented per-barrier position mapping on activations and on releases so that multi monitor setups would handle  per-monitor scaling properly.

## AI tools used for this PR
T3 Code - Codex - GPT-5.5 - used for debugging, commit messages and R&D.

## Related Issue
fixes: #9745

## How Has This Been Tested?
### Setup
Tested on Arch Linux, DMS shell.

I have tested this on hyprland with XDPH at ~[extra-salad/xdg-desktop-portal-hyprland/feat/input-capture-impl](https://github.com/extra-salad/xdg-desktop-portal-hyprland/tree/feat/input-capture-impl)~ (now merged into) [3l0w/xdg-desktop-portal-hyprland/feat/input-capture-impl](https://github.com/3l0w/xdg-desktop-portal-hyprland/tree/feat/input-capture-impl)
and Hyprland (Input Capture) at [extra-salad/Hyprland/feat/input-capture-impl](https://github.com/extra-salad/Hyprland/tree/feat/input-capture-impl).

I have only tested this with 2 monitor setup.

My default monitor setup:
```conf
monitor = DP-2, 2560x1440@165.002, 0x0, 1, vrr, 0
monitor = HDMI-A-1, 1920x1080@60.000, 2560x180, 1, vrr, 0
```

<img width="1095" height="241" alt="image" src="https://github.com/user-attachments/assets/bf0db8f0-d8d1-4ce4-b223-91832b77c294" />

Also, for test purposes, I used custom Deskflow config with all borders and loopback enabled:
```conf
section: links
	client:
		right = server
		left = server
		down = server
		up = server
	server:
		left = client
		right = client
		down = client
		up = client
end
```

### Test cases (monitor layouts)
```
# 1. Aligned, DP-2 left, HDMI-A-1 right, both scale 1.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 2560x0, 1, vrr, 0
#
# 2. Offset, DP-2 left, HDMI-A-1 right, both scale 1.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 2560x180, 1, vrr, 0
#
# 3. Fractional scale, DP-2 left, HDMI-A-1 right, aligned.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1.25, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 2048x0, 1, vrr, 0
#
# 4. Matching logical size, DP-2 left, HDMI-A-1 right.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1.333333, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 1920x0, 1, vrr, 0
#
# 5. Swapped, HDMI-A-1 left, DP-2 right, both scale 1.
# monitor = HDMI-A-1, 1920x1080@60.000, 0x0, 1, vrr, 0
# monitor = DP-2, 2560x1440@165.002, 1920x0, 1, vrr, 0
#
# 6. Swapped with offset, HDMI-A-1 left, DP-2 right, both scale 1.
# monitor = HDMI-A-1, 1920x1080@60.000, 0x180, 1, vrr, 0
# monitor = DP-2, 2560x1440@165.002, 1920x0, 1, vrr, 0
#
# 7. Vertical, DP-2 above, HDMI-A-1 below, both scale 1.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 0x1440, 1, vrr, 0
#
# 8. Vertical, HDMI-A-1 above, DP-2 below, both scale 1.
# monitor = HDMI-A-1, 1920x1080@60.000, 0x0, 1, vrr, 0
# monitor = DP-2, 2560x1440@165.002, 0x1080, 1, vrr, 0
#
# 9. Vertical with DP-2 scaled, DP-2 above, HDMI-A-1 below.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1.25, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 0x1152, 1, vrr, 0
#
# 10. Both scaled equally, DP-2 left, HDMI-A-1 right.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1.25, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 2048x0, 1.25, vrr, 0
#
# 11. Both scaled, matching logical size, DP-2 left, HDMI-A-1 right.
# monitor = DP-2, 2560x1440@165.002, 0x0, 1.666667, vrr, 0
# monitor = HDMI-A-1, 1920x1080@60.000, 1536x0, 1.25, vrr, 0
```

You can generate these test cases config for your own 2 monitor setups [with this JS IIFE](https://gist.github.com/extra-salad/9f611740e7328fc6d709b3113325561c).

### Testing process
1. Stop Deskflow if running (might not be necessary, but avoids server port getting permanently busy/taken/stuck)
2. (Un)comment one of the test layouts
3. `systemctl --user restart xdg-desktop-portal-hyprland xdg-desktop-portal`
4. `hyprctl reload`
5. Start Deskflow
6. Go through all the border combinations (see image below)
7. Repeat

The image of paths I tested. Paths 1 and 2 are the most important, paths 3 and 4 were only relevant because of another implementation that I tried, but kept testing those just in case.
<img width="1654" height="900" alt="image" src="https://github.com/user-attachments/assets/8f160d8e-4c9f-412b-a633-493b53ac89b5" />

### Notes
1. I haven't tried the corner setup (`switchCorners = <corners>`)
2. ~I haven't tried ranges (`up(50,100)  = client(0,50)`)~ Tested now, left a comment
3. Test case number 4 might crash Deskflow server when using 3l0w's Hyprland branch
4. ~Test cases  3, 9 and 11 might crash Deskflow server when using 3l0w's xdg-desktop-portal-hyprland branch~ (that change is now merged on 3l0w's branch)