### PR TITLE
fix: remove unneeded EVP_PKEY_new() (causes memory leak)

### DIFF
--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -66,13 +66,11 @@ void generatePemSelfSignedCert(const QString &path, int keyLength)
 {
   auto expirationDays = 365;
 
-  auto *privateKey = EVP_PKEY_new();
+  auto *privateKey = EVP_RSA_gen(keyLength);
   if (!privateKey) {
-    throw std::runtime_error("could not allocate private key for certificate");
+    throw std::runtime_error("failed to generate a " + std::to_string(keyLength) + "bit key for certificate");
   }
   auto privateKeyFree = finally([privateKey]() { EVP_PKEY_free(privateKey); });
-
-  privateKey = EVP_RSA_gen(keyLength);
 
   auto *cert = X509_new();
   if (!cert) {


### PR DESCRIPTION
## Description
remove unneeded EVP_KEY_new() call, it causes memory leak.
to obtain RSA key, simply call EVP_RSA_gen().

## AI tools used for this PR
none.

## Fixed/related issues
none.

## How has this been tested?
on OpenBSD-7.8/amd64 (with EVP_RSA_gen() emulation for LibreSSL)