### PR TITLE
[WIP] dont check cached clipboard oversize

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -474,12 +474,9 @@ void Server::switchScreen(BaseClientProxy *dst, int32_t x, int32_t y, bool forSc
     m_active->enter(x, y, m_seqNum, m_primaryClient->getToggleMask(), forScreensaver);
 
     if (m_enableClipboard) {
-      // send the clipboard data to new active screen
+      // send the clipboard data to new active screen. oversized data is
+      // filtered upstream in onClipboardChanged so the cache here is safe.
       for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
-        // Hackity hackity hack
-        if (m_clipboards[id].m_clipboard.marshall().size() > (m_maximumClipboardSize * 1024)) {
-          continue;
-        }
         m_active->setClipboard(id, &m_clipboards[id].m_clipboard);
       }
     }
@@ -1454,10 +1451,12 @@ void Server::onClipboardChanged(const BaseClientProxy *sender, ClipboardID id, u
   // should be the expected client
   assert(sender == m_clients.find(clipboard.m_clipboardOwner)->second);
 
-  // get data
-  sender->getClipboard(id, &clipboard.m_clipboard);
+  // read into a temporary so oversized data never lands in the cached
+  // clipboard. otherwise the next switchScreen would forward it on.
+  Clipboard incoming;
+  sender->getClipboard(id, &incoming);
 
-  std::string data = clipboard.m_clipboard.marshall();
+  std::string data = incoming.marshall();
   if (data.size() > m_maximumClipboardSize * 1024) {
     LOG_INFO(
         "not updating clipboard because it's over the size limit (%i KB) configured by the server",
@@ -1474,6 +1473,7 @@ void Server::onClipboardChanged(const BaseClientProxy *sender, ClipboardID id, u
 
   // got new data
   LOG_INFO("screen \"%s\" updated clipboard %d", clipboard.m_clipboardOwner.c_str(), id);
+  Clipboard::copy(&clipboard.m_clipboard, &incoming);
   clipboard.m_clipboardData = data;
 
   // tell all clients except the sender that the clipboard is dirty


### PR DESCRIPTION
## Description

I noticed after digging into this comment:
https://github.com/deskflow/deskflow/blob/62a8ee749f0ec36b60fae3282143446f1b872d05/src/lib/server/Server.cpp#L479

On the server, we are checking the clipboard limit twice, because we copy it into cache and then check the limit. 

So it seems reasonable to not copy it into clipboard cache until after we've checked the size, then we don't have to do the check twice.

## Disclosure of AI use
Claude Opus 4.7 to figure out what the "Hackity hackity hack" comment was talking about.

## Related Issue
None? Found it while implementing clipboard features in #9431

## How Has This Been Tested?
Copy/paste to/from Windows server

## To do
- [ ] Muck about with clipboard size limits