### PR TITLE
fix(macos): center cursor on primary leave to prevent first-move jump

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -798,6 +798,8 @@ void OSXScreen::leave()
 
   if (m_isPrimary) {
     avoidHesitatingCursor();
+    LOG_VERBOSE("centering cursor on leave: %+d, %+d", m_xCenter, m_yCenter);
+    warpCursor(m_xCenter, m_yCenter);
   }
 
   // now off screen


### PR DESCRIPTION
## Description
When macOS acts as the primary screen, the local cursor isn't centered before the screen is marked off-screen. On the next switch, the first physical mouse movement is calculated as a delta from the wrong baseline, causing the remote cursor to jump.

This fix warps the cursor to the primary screen center before marking it off-screen, matching the existing behavior on Windows and X11.

Scope: macOS primary leave path only. Client-side and non-macOS builds are unaffected.

## AI tools used for this PR
* Codex GPT-5.5 High: Write reproduction scripts, assist with log analysis, help identify root cause & check change impact.
* Claude Code Sonnet 4.6 Adaptive: Assist with cross-validating change impact; help me understand the overall project architecture.

## Fixed/related issues
fixes: #9779 

## How has this been tested?
Environment:
- macOS 15.7.5, Apple Silicon
- Debug build
- CMake 4.3.2, Ninja 1.13.2, Qt 6.11.1

Checks:
- Ran `clang-format 20.1.0` on `src/lib/platform/OSXScreen.mm`.
- Built `Deskflow` and `deskflow-core` on macOS successfully.
- Verified `deskflow-core --version` starts successfully.
- Ran the unit tests: 23/24 passed.

Note: `OSXKeyStateTests::fakePollCharWithModifier` fails in this local environment even on the initial clean build before this change. I have checked It is unrelated to current change.

Manual validation:
- macOS server (build), Windows client (1.26.0.207 (https://github.com/deskflow/deskflow/commit/62a8ee749f0ec36b60fae3282143446f1b872d05))
- Verified that hotkey switching from macOS to Windows no longer produces the first-move cursor jump.