### PR TITLE
fix: change QString to QByteArray for exception message handling

### DIFF
--- a/src/lib/base/BaseException.cpp
+++ b/src/lib/base/BaseException.cpp
@@ -31,8 +31,8 @@ const char *BaseException::what() const throw()
     return what;
   }
 
-  m_what = getWhat();
-  return qPrintable(m_what);
+  m_what = getWhat().toLocal8Bit();
+  return m_what.constData();
 }
 
 QString BaseException::format(const char * /*id*/, const char *fmt, ...) const noexcept

--- a/src/lib/base/BaseException.h
+++ b/src/lib/base/BaseException.h
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <QByteArray>
 #include <QString>
 
 //! Exception base class
@@ -45,5 +46,5 @@ protected:
   virtual QString format(const char *id, const char *defaultFormat, ...) const noexcept;
 
 private:
-  mutable QString m_what;
+  mutable QByteArray m_what;
 };

--- a/src/lib/net/SocketException.h
+++ b/src/lib/net/SocketException.h
@@ -11,6 +11,8 @@
 #include "base/BaseException.h"
 #include "io/IOException.h"
 
+#include <QByteArray>
+
 /**
  * @brief SocketException generic socket exception
  */
@@ -81,11 +83,11 @@ public:
   {
     if (m_state == kFirst) {
       m_state = kFormat;
-      m_formatted = getWhat();
+      m_formatted = getWhat().toLocal8Bit();
       m_state = kDone;
     }
     if (m_state == kDone) {
-      return qPrintable(m_formatted);
+      return m_formatted.constData();
     } else {
       return IOCloseException::what();
     }
@@ -102,7 +104,7 @@ private:
     kDone
   };
   mutable EState m_state;
-  mutable QString m_formatted;
+  mutable QByteArray m_formatted;
 };
 
 /**
@@ -125,11 +127,11 @@ public:
   {
     if (m_state == kFirst) {
       m_state = kFormat;
-      m_formatted = getWhat();
+      m_formatted = getWhat().toLocal8Bit();
       m_state = kDone;
     }
     if (m_state == kDone) {
-      return qPrintable(m_formatted);
+      return m_formatted.constData();
     } else {
       return SocketException::what();
     }
@@ -143,7 +145,7 @@ private:
     kDone
   };
   mutable EState m_state;
-  mutable QString m_formatted;
+  mutable QByteArray m_formatted;
 };
 
 /**


### PR DESCRIPTION
## Description

I'm seeing memory corruption in logs on Windows:

```
[2026-05-26T16:14:39.080] FATAL: cannot listen for clients: ????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
C:\Projects\deskflow\src\lib\deskflow\ServerApp.cpp:379
```

Desktop mode:
```
[2026-05-26T16:22:24.911] FATAL: cannot listen for clients: r clients:
C:\Projects\deskflow\src\lib\deskflow\ServerApp.cpp:379
```

## AI tools used for this PR
Claude Opus to find cause and fix. 

## Fixed/related issues

None

## How has this been tested?

Run on Windows

## To do

- [ ] Use QString