### PR TITLE
fix(client): restore cursor positions locally In relative mouse mode

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016, 2026 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -154,6 +154,9 @@ void Client::handshakeComplete()
 {
   m_ready = true;
   m_screen->enable();
+  if (m_relativeMouseMoves && !m_hasRelativeRestorePosition) {
+    saveRelativeRestorePosition();
+  }
   sendEvent(EventTypes::ClientConnected);
 }
 
@@ -195,12 +198,20 @@ void Client::getCursorPos(int32_t &x, int32_t &y) const
 void Client::enter(int32_t xAbs, int32_t yAbs, uint32_t, KeyModifierMask mask, bool)
 {
   m_active = true;
+  if (m_relativeMouseMoves && m_hasRelativeRestorePosition) {
+    xAbs = m_relativeRestoreX;
+    yAbs = m_relativeRestoreY;
+    LOG_VERBOSE("using relative restore position: %d,%d", xAbs, yAbs);
+  }
   m_screen->mouseMove(xAbs, yAbs);
   m_screen->enter(mask);
 }
 
 bool Client::leave()
 {
+  if (m_relativeMouseMoves) {
+    saveRelativeRestorePosition();
+  }
   m_active = false;
 
   m_screen->leave();
@@ -283,6 +294,8 @@ void Client::screensaver(bool activate)
 
 void Client::resetOptions()
 {
+  m_relativeMouseMoves = false;
+  m_hasRelativeRestorePosition = false;
   m_screen->resetOptions();
 }
 
@@ -303,6 +316,14 @@ void Client::setOptions(const OptionsList &options)
       if (index != options.end()) {
         m_maximumClipboardSize = *index;
       }
+    } else if (id == kOptionRelativeMouseMoves) {
+      index++;
+      if (index != options.end()) {
+        m_relativeMouseMoves = (*index != 0);
+        if (m_relativeMouseMoves && m_ready && !m_hasRelativeRestorePosition) {
+          saveRelativeRestorePosition();
+        }
+      }
     }
   }
 
@@ -312,6 +333,13 @@ void Client::setOptions(const OptionsList &options)
   }
 
   m_screen->setOptions(options);
+}
+
+void Client::saveRelativeRestorePosition()
+{
+  m_screen->getCursorPos(m_relativeRestoreX, m_relativeRestoreY);
+  m_hasRelativeRestorePosition = true;
+  LOG_VERBOSE("saved relative restore position: %d,%d", m_relativeRestoreX, m_relativeRestoreY);
 }
 
 std::string Client::getName() const

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016, 2026 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -155,6 +155,7 @@ public:
   std::string getName() const override;
 
 private:
+  void saveRelativeRestorePosition();
   void sendClipboard(ClipboardID);
   void sendEvent(deskflow::EventTypes);
   void sendConnectionFailedEvent(const char *msg);
@@ -200,6 +201,10 @@ private:
   IEventQueue *m_events = nullptr;
   bool m_useSecureNetwork = false;
   bool m_enableClipboard = true;
+  bool m_relativeMouseMoves = false;
+  bool m_hasRelativeRestorePosition = false;
+  int32_t m_relativeRestoreX = 0;
+  int32_t m_relativeRestoreY = 0;
   size_t m_maximumClipboardSize = INT_MAX;
   size_t m_resolvedAddressesCount = 0;
 };

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2004 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -181,6 +181,10 @@ void MSWindowsDesks::leave(HKL keyLayout)
 void MSWindowsDesks::resetOptions()
 {
   m_leaveForegroundOption = false;
+  m_relativeMouseMoves = false;
+  for (auto &entry : m_desks) {
+    entry.second->m_hasRelativeRestorePosition = false;
+  }
 }
 
 void MSWindowsDesks::setOptions(const OptionsList &options)
@@ -189,6 +193,8 @@ void MSWindowsDesks::setOptions(const OptionsList &options)
     if (options[i] == kOptionWin32KeepForeground) {
       m_leaveForegroundOption = (options[i + 1] != 0);
       LOG_VERBOSE("%s the foreground window", m_leaveForegroundOption ? "don\'t grab" : "grab");
+    } else if (options[i] == kOptionRelativeMouseMoves) {
+      m_relativeMouseMoves = (options[i + 1] != 0);
     }
   }
 }
@@ -307,6 +313,39 @@ void MSWindowsDesks::fakeMouseRelativeMove(int32_t dx, int32_t dy) const
 void MSWindowsDesks::fakeMouseWheel(int32_t xDelta, int32_t yDelta) const
 {
   sendMessage(DESKFLOW_MSG_FAKE_WHEEL, xDelta, yDelta);
+}
+
+void MSWindowsDesks::saveRelativeRestorePosition(Desk *desk) const
+{
+  POINT pos{0, 0};
+  if (!GetCursorPos(&pos)) {
+    LOG_DEBUG(
+        "could not save relative restore position on desk \"%ls\", error: %lu", desk->m_name.c_str(), GetLastError()
+    );
+    return;
+  }
+
+  desk->m_relativeRestoreX = pos.x;
+  desk->m_relativeRestoreY = pos.y;
+  desk->m_hasRelativeRestorePosition = true;
+  LOG_VERBOSE(
+      "saved relative restore position on desk \"%ls\": %+d,%+d", desk->m_name.c_str(), desk->m_relativeRestoreX,
+      desk->m_relativeRestoreY
+  );
+}
+
+bool MSWindowsDesks::restoreRelativeCursorPosition(Desk *desk) const
+{
+  if (!desk->m_hasRelativeRestorePosition) {
+    return false;
+  }
+
+  LOG_VERBOSE(
+      "restoring relative cursor position on desk \"%ls\": %+d,%+d", desk->m_name.c_str(), desk->m_relativeRestoreX,
+      desk->m_relativeRestoreY
+  );
+  deskMouseMove(desk->m_relativeRestoreX, desk->m_relativeRestoreY);
+  return true;
 }
 
 void MSWindowsDesks::sendMessage(UINT msg, WPARAM wParam, LPARAM lParam) const
@@ -496,6 +535,9 @@ void MSWindowsDesks::deskEnter(Desk *desk)
 {
   if (!m_isPrimary) {
     ReleaseCapture();
+    if (m_relativeMouseMoves) {
+      restoreRelativeCursorPosition(desk);
+    }
   }
 
   setCursorVisibility(true);
@@ -519,6 +561,10 @@ void MSWindowsDesks::deskEnter(Desk *desk)
 
 void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
 {
+  if (!m_isPrimary && m_relativeMouseMoves) {
+    saveRelativeRestorePosition(desk);
+  }
+
   setCursorVisibility(false);
 
   if (m_isPrimary) {

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2004 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -187,6 +187,9 @@ private:
     HWND m_window;
     HWND m_foregroundWindow;
     bool m_lowLevel;
+    bool m_hasRelativeRestorePosition = false;
+    int32_t m_relativeRestoreX = 0;
+    int32_t m_relativeRestoreY = 0;
   };
   using Desks = std::map<std::wstring, Desk *>;
 
@@ -201,6 +204,8 @@ private:
   // message handlers
   void deskMouseMove(int32_t x, int32_t y) const;
   void deskMouseRelativeMove(int32_t dx, int32_t dy) const;
+  void saveRelativeRestorePosition(Desk *desk) const;
+  bool restoreRelativeCursorPosition(Desk *desk) const;
   void deskEnter(Desk *desk);
   void deskLeave(Desk *desk, HKL keyLayout);
   void deskThread(const void *vdesk);
@@ -276,6 +281,7 @@ private:
 
   // options
   bool m_leaveForegroundOption;
+  bool m_relativeMouseMoves = false;
 
   IEventQueue *m_events;
 };


### PR DESCRIPTION
## Description
**Root Issue:**

In relative mouse mode, the server intentionally stops updating its absolute coordinate model (m_x/m_y) to avoid drift from in-game cursor warping. When switching away, it saves this stale coordinate as the jump position. Since BaseClientProxy initializes the jump position to (0, 0), the next enter sends (0, 0) to the client, resetting the cursor to the top-left.

This affects any use of relative mouse moves, not just games — switching back to the client on a plain desktop also causes the cursor to jump to (0, 0), forcing users to toggle the option off for non-game sessions.

**Solution:**

server-side tracking is unreliable due to in-game cursor warping In relative mode, whereas the client can always get its exact physical position. So this fix delegates position-restoration memory to the client. The client caches its actual local cursor position on leave and restores it on enter. On Windows, coordinates are saved per-desktop to prevent UAC and secure desktop transitions from polluting the position.

**Scope:** relativeMouseMoves enabled path only. Normal absolute movement paths are unaffected.

## AI tools used for this PR
**Codex GPT-5.5 High:** help identify root cause & check change impact.
**Claude Code Sonnet 4.6 Adaptive:** Assist with cross-validating change impact; help me understand the project architecture.

## Fixed/related issues
fixes: #9788 

## How has this been tested?
**Environment & Config:**

* macOS 15.7.5, Apple Silicon — server (official release v1.26.0.207)
* Windows 10 LTSC (build 19044) — client (debug and release build from this branch, commit dbd5f5fd)
* relativeMouseMoves = true, defaultLockToScreenState = true, hotkey: switchInDirection
* Windows display: 1920×1080, 100% scaling

**Checks:**

1. Ran clang-format 20.1.0 on modified files.
2. Built on Windows: CMake 4.3.2, Ninja 1.13.2, MSVC 19.44.35207, Qt 6.10.2 — build succeeded, unit tests 23/23 passed.
3. macOS and Linux compilation not verified locally; relying on CI. MSWindowsDesks.cpp is Windows-only; Client.cpp changes are minimal conditional logic.

**Manual validation:**

1. Start and connect the server and the client.
2. Use hotkey to switch between mac and win.
3. repeat and observe.

**Before fix:** cursor restored to (0, 0) on each switch from macOS to Windows.
**After fix:** cursor restored to the last known position on the Windows desktop. Verified on both debug and release builds, including both on the UAC secure desktop itself and within UAC-elevated application windows.
**Regression check (relativeMouseMoves = false):** behavior unchanged.
