### PR TITLE
fix(macos): avoid non-selectable IME layouts for remote keys

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -173,6 +173,33 @@ bool isModifier(uint8_t virtualKey)
   return (modifiers.find(virtualKey) != modifiers.end());
 }
 
+AutoTISInputSourceRef copyKeyboardLayoutForKeyTranslation()
+{
+  std::lock_guard<std::mutex> lock(g_tisMutex);
+
+  AutoTISInputSourceRef keyboardLayout(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
+  AutoTISInputSourceRef inputSource(TISCopyCurrentKeyboardInputSource(), CFRelease);
+
+  const bool inputSourceHasLayout =
+      inputSource && TISGetInputSourceProperty(inputSource.get(), kTISPropertyUnicodeKeyLayoutData) != nullptr;
+
+  CFBooleanRef isSelectCapable = nullptr;
+  if (keyboardLayout) {
+    isSelectCapable =
+        (CFBooleanRef)TISGetInputSourceProperty(keyboardLayout.get(), kTISPropertyInputSourceIsSelectCapable);
+  }
+  const bool keyboardLayoutIsSelectCapable = isSelectCapable && CFBooleanGetValue(isSelectCapable);
+
+  if (inputSource && keyboardLayout && !inputSourceHasLayout && !keyboardLayoutIsSelectCapable) {
+    AutoTISInputSourceRef asciiKeyboardLayout(TISCopyCurrentASCIICapableKeyboardLayoutInputSource(), CFRelease);
+    if (asciiKeyboardLayout) {
+      return asciiKeyboardLayout;
+    }
+  }
+
+  return keyboardLayout;
+}
+
 } // namespace
 
 //
@@ -293,11 +320,10 @@ KeyButton OSXKeyState::mapKeyFromEvent(KeyIDs &ids, KeyModifierMask *maskOut, CG
   }
 
   // get keyboard info
-  AutoTISInputSourceRef currentKeyboardLayout(nullptr, CFRelease);
+  AutoTISInputSourceRef currentKeyboardLayout = copyKeyboardLayoutForKeyTranslation();
   CFDataRef ref = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    currentKeyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
     if (currentKeyboardLayout)
       ref = (CFDataRef)TISGetInputSourceProperty(currentKeyboardLayout.get(), kTISPropertyUnicodeKeyLayoutData);
   }


### PR DESCRIPTION
## Description
macOS input methods can expose non-user-selectable keyboard layouts bundled with the input method rather than the user's real selectable keyboard layout. Translating remote key events through those layouts can send IME punctuation semantics to clients instead of the expected ASCII punctuation.

Use the current ASCII-capable keyboard layout when the active input source has no Unicode key layout data and the reported keyboard layout is not directly selectable. Normal selectable keyboard layouts continue to use the existing translation path.

This affects macOS servers forwarding keyboard input to remote clients while an input-method-bundled layout is active.

## AI tools used for this PR
* Codex GPT-5.5 High: Write reproduction scripts, assist with log analysis, help identify root cause & check change impact.
* Claude Code Sonnet 4.6 Adaptive: Assist with cross-validating change impact; help me understand the overall project architecture.

## Fixed/related issues
#9465 
#9791

## How has this been tested?
**Environment:**

- macOS 15.7.5, Apple Silicon
- Debug build
- CMake 4.3.2, Ninja 1.13.2, Qt 6.11.1

**Checks:**

- Ran `clang-format 20.1.0 --dry-run --Werror src/lib/platform/OSXKeyState.cpp`.
- Built `Deskflow` and `deskflow-core` successfully.
- Verified `deskflow-core --version` starts successfully:
  `deskflow-core v1.26.0.210 (bf65080b), protocol v1.8`
- Ran the unit tests: 23/24 passed.

Note: `OSXKeyStateTests::fakePollShift`, `OSXKeyStateTests::fakePollChar`, and `OSXKeyStateTests::fakePollCharWithModifier` fail in this local environment. These are local macOS HID key injection/polling checks and are unrelated to the changed `mapKeyFromEvent` translation path.

Manual validation:

- macOS server (build), Windows client (1.26.0.207).
- With macOS Simplified Chinese Pinyin active, verified that affected punctuation keys now produce ASCII punctuation on the Windows client.
- Verified that switching macOS back to ABC still produces the expected punctuation.
- Verified macOS official Japanese Hiragana/Romaji input still produces ASCII punctuation on the Windows client.
- Verified the client option "Use server's keyboard language on this computer" remains disabled during the test.
