### PR TITLE
fix(win32): close running Deskflow processes during MSI install

### DIFF
--- a/deploy/windows/wix-patch.xml.in
+++ b/deploy/windows/wix-patch.xml.in
@@ -37,6 +37,38 @@
 
     <Binary Id="CustomDLL" SourceFile="@CMAKE_CURRENT_BINARY_DIR@/wix-custom.dll" />
 
+    <!--
+      Close any running Deskflow processes before file replacement so the
+      installer does not have to schedule files for replace-on-reboot.
+      Legacy names (deskflow-server.exe, deskflow-client.exe) are still
+      listed so upgrades from pre-1.24 installs (separate server/client
+      binaries) also complete without prompting for a reboot.
+    -->
+    <util:CloseApplication
+      Id="CloseDeskflowGui"
+      Target="deskflow.exe"
+      CloseMessage="yes"
+      RebootPrompt="no"
+      TerminateProcess="10" />
+    <util:CloseApplication
+      Id="CloseDeskflowCore"
+      Target="deskflow-core.exe"
+      CloseMessage="yes"
+      RebootPrompt="no"
+      TerminateProcess="10" />
+    <util:CloseApplication
+      Id="CloseDeskflowServer"
+      Target="deskflow-server.exe"
+      CloseMessage="yes"
+      RebootPrompt="no"
+      TerminateProcess="10" />
+    <util:CloseApplication
+      Id="CloseDeskflowClient"
+      Target="deskflow-client.exe"
+      CloseMessage="yes"
+      RebootPrompt="no"
+      TerminateProcess="10" />
+
     <UI>
        <Publish Dialog="ExitDialog"
            Control="Finish"


### PR DESCRIPTION
## Description

The MSI installer currently only stops the `Deskflow` service before file replacement. The `deskflow.exe` tray/GUI and the core process (`deskflow-core.exe`, or `deskflow-server.exe`/`deskflow-client.exe` on pre-1.24 installs) are left running, so any in-place upgrade that needs to overwrite or delete those files falls back to MSI's "files in use" path and prompts the user to reboot.

This adds `util:CloseApplication` entries for all four binary names so Restart Manager closes them gracefully (`WM_CLOSE`, 10s timeout, then terminate) before files are touched.

The legacy `deskflow-server.exe` / `deskflow-client.exe` names matter for upgrades from pre-1.24 (the unified-core release, #8868) — those files are removed by the new package and the running processes hold them open.

## AI tools used for this PR

None.

## Fixed/related issues

No existing issue. Reproduced locally on a pre-1.24 -> latest upgrade.

## How has this been tested?

Draft because not yet tested end-to-end. Plan:

- Build MSI on Windows.
- Install an older Deskflow build (1.23.x), have it running as the service with the tray open, then run the new MSI on top.
- Confirm the install completes without the "must update files or services that cannot be updated while the system is running" prompt.
- Repeat for a same-version reinstall to confirm `deskflow-core.exe` and `deskflow.exe` are handled too.

Will move out of draft once that's verified.