### PR TITLE
ci: use Qt 6.11.1 for windows and mac os (x86 mac is locked at 6.9.x)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,7 +99,7 @@ jobs:
             config-args: "-G Ninja"
             vcpkg-triplet: x64-windows-release
             arch: "amd64"
-            qt-version: 6.10.2
+            qt-version: 6.10.3
 
           - name: "windows-2022-arm64"
             runs-on: "windows-11-arm"
@@ -107,12 +107,12 @@ jobs:
             config-args: "-G Ninja"
             vcpkg-triplet: arm64-windows
             arch: "arm64"
-            qt-version: 6.10.2
+            qt-version: 6.11.1
 
           - name: "macos-arm64"
             runs-on: macos-15
             timeout: 10
-            qt-version: 6.10.2
+            qt-version: 6.11.1
             config-args: '-DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=14'
 
           - name: "macos-x64"


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Update CI to use qt 6.11.1 on windows and mac os (x86 mac is locked to 6.9.x) 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None ? 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run