### PR TITLE
feat: show remote peer name or IP when accepting a connection

### DIFF
--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -275,6 +275,9 @@ public:
   */
   virtual bool isAnyAddr(ArchNetAddress addr) = 0;
 
+  //! Get the remote peer address from socket
+  [[nodiscard]] virtual ArchNetAddress getRemotePeerAddress(ArchSocket) = 0;
+
   //@}
 
   virtual void init() = 0;

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -696,6 +696,16 @@ bool ArchNetworkBSD::isEqualAddr(ArchNetAddress a, ArchNetAddress b)
   return (a->m_len == b->m_len && memcmp(&a->m_addr, &b->m_addr, a->m_len) == 0);
 }
 
+ArchNetAddress ArchNetworkBSD::getRemotePeerAddress(ArchSocket s)
+{
+  ArchNetAddress addr = newAnyAddr(IArchNetwork::AddressFamily::INet);
+  if (getpeername(s->m_fd, reinterpret_cast<struct sockaddr *>(addr), &addr->m_len) != 0) {
+    closeAddr(addr);
+    return nullptr;
+  }
+  return addr;
+}
+
 const int *ArchNetworkBSD::getUnblockPipe()
 {
   ArchMultithreadPosix *mt = ArchMultithreadPosix::getInstance();

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -99,6 +99,7 @@ public:
   int getAddrPort(ArchNetAddress) override;
   bool isAnyAddr(ArchNetAddress) override;
   bool isEqualAddr(ArchNetAddress, ArchNetAddress) override;
+  [[nodiscard]] ArchNetAddress getRemotePeerAddress(ArchSocket) override;
 
 private:
   const int *getUnblockPipe();

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -826,6 +826,16 @@ bool ArchNetworkWinsock::isEqualAddr(ArchNetAddress a, ArchNetAddress b)
   return (a == b || (a->m_len == b->m_len && memcmp(&a->m_addr, &b->m_addr, a->m_len) == 0));
 }
 
+ArchNetAddress ArchNetworkWinsock::getRemotePeerAddress(ArchSocket s)
+{
+  ArchNetAddress addr = newAnyAddr(IArchNetwork::AddressFamily::INet);
+  if (getpeername(s->m_socket, reinterpret_cast<struct sockaddr *>(addr), &addr->m_len) != 0) {
+    closeAddr(addr);
+    return nullptr;
+  }
+  return addr;
+}
+
 [[noreturn]] void ArchNetworkWinsock::throwError(int err) const
 {
   switch (err) {

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -86,6 +86,7 @@ public:
   int getAddrPort(ArchNetAddress) override;
   bool isAnyAddr(ArchNetAddress) override;
   bool isEqualAddr(ArchNetAddress, ArchNetAddress) override;
+  [[nodiscard]] ArchNetAddress getRemotePeerAddress(ArchSocket) override;
 
 private:
   void initModule(HMODULE);

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -841,9 +841,13 @@ void MainWindow::handleMissingKeyboardLayouts(const QString &layouts)
   }
 }
 
-void MainWindow::handlePeerFingerprint(const QString &fingerprint)
+void MainWindow::handlePeerFingerprint(const QString &payload)
 {
-  const auto sha256Text = QString(fingerprint).remove(':');
+  const auto payloadList = payload.split('|');
+  bool hasPeerInfo = payloadList.size() == 3;
+  const auto sha256Text = QString(payloadList.value(0)).remove(':');
+  const auto localPeer = hasPeerInfo ? payloadList.value(1) : QString{};
+  const auto remotePeer = hasPeerInfo ? payloadList.value(2) : QString{};
   const Fingerprint sha256 = {QCryptographicHash::Sha256, QByteArray::fromHex(sha256Text.toLatin1())};
 
   const bool isClient = m_coreProcess.mode() == CoreMode::Client;
@@ -868,7 +872,7 @@ void MainWindow::handlePeerFingerprint(const QString &fingerprint)
   }
 
   auto mode = isClient ? FingerprintDialogMode::Client : FingerprintDialogMode::Server;
-  FingerprintDialog fingerprintDialog(this, m_fingerprint, mode, sha256);
+  FingerprintDialog fingerprintDialog(this, m_fingerprint, mode, sha256, localPeer, remotePeer);
 
   if (fingerprintDialog.exec() == QDialog::Accepted) {
     db.addTrusted(sha256);

--- a/src/lib/gui/dialogs/FingerprintDialog.cpp
+++ b/src/lib/gui/dialogs/FingerprintDialog.cpp
@@ -15,7 +15,7 @@
 
 FingerprintDialog::FingerprintDialog(
     QWidget *parent, const Fingerprint &localFingerprint, FingerprintDialogMode mode,
-    const Fingerprint &remoteFingerprint
+    const Fingerprint &remoteFingerprint, const QString &localPeer, const QString &remotePeer
 )
     : QDialog(parent),
       m_lblHeader{new QLabel(this)},
@@ -32,7 +32,8 @@ FingerprintDialog::FingerprintDialog(
   layout->addWidget(m_lblHeader);
   layout->addSpacerItem(new QSpacerItem(0, 10, QSizePolicy::Fixed, QSizePolicy::Fixed));
   layout->addLayout(
-      localMode ? makeLocalLayout(localFingerprint) : makeCompareLayout(localFingerprint, isServer, remoteFingerprint)
+      localMode ? makeLocalLayout(localFingerprint)
+                : makeCompareLayout(localFingerprint, isServer, remoteFingerprint, localPeer, remotePeer)
   );
   layout->addWidget(m_lblFooter);
   layout->addWidget(m_buttonBox);
@@ -94,14 +95,16 @@ QLayout *FingerprintDialog::makeLocalLayout(const Fingerprint &localFingerprint)
 }
 
 QLayout *FingerprintDialog::makeCompareLayout(
-    const Fingerprint &localFingerprint, bool isServer, const Fingerprint &remoteFingerprint
+    const Fingerprint &localFingerprint, bool isServer, const Fingerprint &remoteFingerprint, const QString &localPeer,
+    const QString &remotePeer
 )
 {
   const auto serverText = tr("Server Fingerprint");
   const auto clientText = tr("Client Fingerprint");
 
-  m_localPreview = new FingerprintPreview(this, localFingerprint, isServer ? serverText : clientText, false);
-  m_remotePreview = new FingerprintPreview(this, remoteFingerprint, isServer ? clientText : serverText, false);
+  m_localPreview = new FingerprintPreview(this, localFingerprint, isServer ? serverText : clientText, localPeer, false);
+  m_remotePreview =
+      new FingerprintPreview(this, remoteFingerprint, isServer ? clientText : serverText, remotePeer, false);
 
   auto fpLayout = new QHBoxLayout();
   fpLayout->setAlignment(Qt::AlignTop);

--- a/src/lib/gui/dialogs/FingerprintDialog.h
+++ b/src/lib/gui/dialogs/FingerprintDialog.h
@@ -28,14 +28,16 @@ class FingerprintDialog : public QDialog
 public:
   explicit FingerprintDialog(
       QWidget *parent = nullptr, const Fingerprint &localFingerprint = {},
-      FingerprintDialogMode mode = FingerprintDialogMode::Local, const Fingerprint &remoteFingerprint = {}
+      FingerprintDialogMode mode = FingerprintDialogMode::Local, const Fingerprint &remoteFingerprint = {},
+      const QString &localPeer = {}, const QString &remotePeer = {}
   );
   ~FingerprintDialog() override = default;
 
 private:
   QLayout *makeLocalLayout(const Fingerprint &localFingerprint = {});
   QLayout *makeCompareLayout(
-      const Fingerprint &localFingerprint = {}, bool isServer = true, const Fingerprint &remoteFingerprint = {}
+      const Fingerprint &localFingerprint = {}, bool isServer = true, const Fingerprint &remoteFingerprint = {},
+      const QString &localPeer = {}, const QString &remotePeer = {}
   );
   void togglePreviewMode(bool hashMode);
   void updateModeButton(bool hashMode) const;

--- a/src/lib/gui/widgets/FingerprintPreview.cpp
+++ b/src/lib/gui/widgets/FingerprintPreview.cpp
@@ -13,7 +13,7 @@
 #include <net/SecureUtils.h>
 
 FingerprintPreview::FingerprintPreview(
-    QWidget *parent, const Fingerprint &fingerprint, const QString &titleText, bool hashMode
+    QWidget *parent, const Fingerprint &fingerprint, const QString &titleText, const QString &peerInfo, bool hashMode
 )
     : QFrame(parent)
 {
@@ -22,7 +22,8 @@ FingerprintPreview::FingerprintPreview(
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
   setLayout(
-      fingerprint.type == QCryptographicHash::Sha256 ? sha256Layout(fingerprint, titleText, hashMode) : emptyLayout()
+      fingerprint.type == QCryptographicHash::Sha256 ? sha256Layout(fingerprint, titleText, peerInfo, hashMode)
+                                                     : emptyLayout()
   );
   adjustSize();
   setFixedSize(size());
@@ -44,7 +45,9 @@ QLayout *FingerprintPreview::emptyLayout()
   return layout;
 }
 
-QLayout *FingerprintPreview::sha256Layout(const Fingerprint &fingerprint, const QString &titleText, bool hashMode)
+QLayout *FingerprintPreview::sha256Layout(
+    const Fingerprint &fingerprint, const QString &titleText, const QString &peerInfo, bool hashMode
+)
 {
   auto labelTitle = new QLabel(titleText, this);
   auto f = font();
@@ -54,6 +57,11 @@ QLayout *FingerprintPreview::sha256Layout(const Fingerprint &fingerprint, const 
   labelTitle->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
   labelTitle->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   labelTitle->setVisible(!titleText.isEmpty());
+
+  auto labelPeerInfo = new QLabel(peerInfo, this);
+  labelPeerInfo->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
+  labelPeerInfo->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  labelPeerInfo->setVisible(!peerInfo.isEmpty());
 
   m_lblHash = new QLabel(deskflow::formatSSLFingerprintColumns(fingerprint.data), this);
   m_lblHash->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
@@ -78,6 +86,7 @@ QLayout *FingerprintPreview::sha256Layout(const Fingerprint &fingerprint, const 
   auto sha256Layout = new QVBoxLayout();
   sha256Layout->setContentsMargins(0, 0, 0, 0);
   sha256Layout->addWidget(labelTitle);
+  sha256Layout->addWidget(labelPeerInfo);
   sha256Layout->addLayout(innersha256Layout);
   sha256Layout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Preferred, QSizePolicy::Expanding));
 

--- a/src/lib/gui/widgets/FingerprintPreview.h
+++ b/src/lib/gui/widgets/FingerprintPreview.h
@@ -16,14 +16,18 @@ class FingerprintPreview : public QFrame
   Q_OBJECT
 public:
   explicit FingerprintPreview(
-      QWidget *parent, const Fingerprint &fingerprint = {}, const QString &titleText = {}, bool hashMode = false
+      QWidget *parent, const Fingerprint &fingerprint = {}, const QString &titleText = {}, const QString &peerInfo = {},
+      bool hashMode = false
   );
   ~FingerprintPreview() override = default;
   void toggleMode(bool hashMode);
 
 private:
   QLayout *emptyLayout();
-  QLayout *sha256Layout(const Fingerprint &fingerprint = {}, const QString &titleText = {}, bool hashMode = false);
+  QLayout *sha256Layout(
+      const Fingerprint &fingerprint = {}, const QString &titleText = {}, const QString &peerinfo = {},
+      bool hashMode = false
+  );
   QLabel *m_lblHash = nullptr;
   QLabel *m_lblArt = nullptr;
 };

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -48,6 +48,8 @@ public:
   virtual void connect(const NetworkAddress &) = 0;
 
   //@}
+  //! Get the remote peer name or address
+  virtual const std::string &remotePeerNameOrAddress() = 0;
 
   // ISocket overrides
   void close() override;

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -414,8 +414,8 @@ int SecureSocket::secureAccept(int socket)
 
   // set connection socket to SSL state
   SSL_set_fd(m_ssl->m_ssl, socket);
-
-  LOG_VERBOSE("accepting secure socket");
+  const std::string &remotePeer = remotePeerNameOrAddress();
+  LOG_VERBOSE("accepting secure socket from '%s'", remotePeer.c_str());
   int r = SSL_accept(m_ssl->m_ssl);
 
   static int retry;
@@ -433,13 +433,15 @@ int SecureSocket::secureAccept(int socket)
 
   // If not fatal and no retry, state is good
   if (retry == 0) {
-    if (m_securityLevel == SecurityLevel::PeerAuth && !verifyCertFingerprint(Settings::tlsTrustedClientsDb())) {
+    if (const auto &localPeer = Settings::value(Settings::Core::ComputerName).toString().toStdString();
+        m_securityLevel == SecurityLevel::PeerAuth &&
+        !verifyCertFingerprint(Settings::tlsTrustedClientsDb(), localPeer, remotePeer)) {
       retry = 0;
       disconnect();
       return -1; // Fail
     }
     m_secureReady = true;
-    LOG_INFO("accepted secure socket");
+    LOG_INFO("accepted secure socket from '%s'", remotePeer.c_str());
     SslLogger::logSecureCipherInfo(m_ssl->m_ssl);
     SslLogger::logSecureConnectInfo(m_ssl->m_ssl);
     return 1;
@@ -499,7 +501,7 @@ int SecureSocket::secureConnect(int socket)
   retry = 0;
   // No error, set ready, process and return ok
   m_secureReady = true;
-  if (verifyCertFingerprint(Settings::tlsTrustedServersDb())) {
+  if (verifyCertFingerprint(Settings::tlsTrustedServersDb(), name, remotePeerNameOrAddress())) {
     LOG_INFO("connected to secure socket");
     if (!showCertificate()) {
       disconnect();
@@ -619,7 +621,9 @@ void SecureSocket::disconnect()
   sendEvent(StreamInputShutdown);
 }
 
-bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath) const
+bool SecureSocket::verifyCertFingerprint(
+    const QString &FingerprintDatabasePath, const std::string &localPeer, const std::string &remotePeer
+) const
 {
   const auto cert = SSL_get_peer_certificate(m_ssl->m_ssl);
   const auto sha256 = deskflow::sslCertFingerprint(cert, QCryptographicHash::Sha256);
@@ -632,7 +636,12 @@ bool SecureSocket::verifyCertFingerprint(const QString &FingerprintDatabasePath)
 
   const auto fingerprint = deskflow::formatSSLFingerprint(sha256.data, false);
   LOG_DEBUG("peer fingerprint: %s", qPrintable(fingerprint));
-  ipcSendToClient("peerFingerprint", fingerprint);
+  QString payload{};
+  if (!localPeer.empty() && !remotePeer.empty()) {
+    payload = QStringLiteral("%1|%2|%3")
+                  .arg(fingerprint, QString::fromStdString(localPeer), QString::fromStdString(remotePeer));
+  }
+  ipcSendToClient("peerFingerprint", (payload.isEmpty() ? fingerprint : payload));
 
   QFile file(FingerprintDatabasePath);
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -78,7 +78,9 @@ private:
   bool showCertificate() const;
   void checkResult(int n, int &retry);
   void disconnect();
-  bool verifyCertFingerprint(const QString &FingerprintDatabasePath) const;
+  bool verifyCertFingerprint(
+      const QString &FingerprintDatabasePath, const std::string &localPeer = {}, const std::string &remotePeer = {}
+  ) const;
 
   ISocketMultiplexerJob *serviceConnect(ISocketMultiplexerJob *const socket, bool, bool, bool);
 

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -277,6 +277,7 @@ void TCPSocket::init()
   m_connected = false;
   m_readable = false;
   m_writable = false;
+  m_remotePeerNameOrAddress.clear();
 
   try {
     // turn off Nagle algorithm.  we send lots of very short messages
@@ -551,4 +552,24 @@ ISocketMultiplexerJob *TCPSocket::serviceConnected(ISocketMultiplexerJob *job, b
     return newJob();
 
   return job;
+}
+
+const std::string &TCPSocket::remotePeerNameOrAddress()
+{
+  if (!m_remotePeerNameOrAddress.empty()) {
+    return m_remotePeerNameOrAddress;
+  }
+  ArchNetAddress addr = ARCH->getRemotePeerAddress(m_socket);
+  if (!addr) {
+    return m_remotePeerNameOrAddress;
+  }
+  try {
+    const auto fqdn = ARCH->addrToName(addr);
+    m_remotePeerNameOrAddress = fqdn.substr(0, fqdn.find('.'));
+  } catch (const ArchNetworkException &e) {
+    LOG_DEBUG("error fetching peer name: '%s'", e.what());
+    m_remotePeerNameOrAddress = ARCH->addrToString(addr);
+  }
+  ARCH->closeAddr(addr);
+  return m_remotePeerNameOrAddress;
 }

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -56,6 +56,7 @@ public:
 
   // IDataSocket overrides
   void connect(const NetworkAddress &) override;
+  const std::string &remotePeerNameOrAddress() override;
 
   virtual ISocketMultiplexerJob *newJob();
 
@@ -126,6 +127,7 @@ protected:
 
   StreamBuffer m_inputBuffer;
   StreamBuffer m_outputBuffer;
+  std::string m_remotePeerNameOrAddress;
 
 private:
   void init();


### PR DESCRIPTION
## Description
Currently neither the UI nor logs shows the host name or IP of the client which is trying to connect to the server. The PR adds functions to fetch the remote address and uses the available functions to fetch the host name as well. If the host name lookup fails it will use the IP instead. And the local device name will be fetched from the `ComputerName` settings parameter. The fetched information will be shown in FingerprintPreview widget as suggested in #8888.

## AI tools used for this PR
AI was used initially to understand the code base and control flow.
Code is manually written.

## Fixed/related issues
fixes: #8862 

## How has this been tested?
Tested the BSD socket changes and Qt UI changes on Debian 13 gcc 14.2 Qt version 6.8.2
WinSock changes are partially tested on Win 11 with Visual Studio 2026 CE, MSVC v143, Qt 6.7
The changes are not compiled and tested on Mac
