### PR TITLE
fix: use Qt localized path for open cert

### DIFF
--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -14,6 +14,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include <QFile>
 #include <algorithm>
 #include <filesystem>
 #include <stdexcept>
@@ -88,8 +89,9 @@ void generatePemSelfSignedCert(const QString &path, int keyLength)
   X509_set_issuer_name(cert, name);
 
   X509_sign(cert, privateKey, EVP_sha256());
+  const QFile file(path);
+  const std::filesystem::path fsPath = file.filesystemFileName();
 
-  const std::filesystem::path fsPath = path.toStdString();
 #if defined(Q_OS_WIN)
   auto fp = _wfopen(fsPath.native().c_str(), L"w");
 #else


### PR DESCRIPTION


## Description
<!--- Describe what your changes do -->
Some non latin chars seem to cause an issue w/ ssl's cert generation . I suspect  we are providing the wrong path when we do `QString::toStdString()` in this case. In an attempt to fix this we instead use `QFile::filesystemFileName`.
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->

fixes: #9764

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

Tested locally by regenerating my cert 

@liocapz , @jm1990-md can you try this and see if it fixes your cert generation issue ? 