### PR TITLE
feat(windows): Map fullwidth CJK punctuation to halfwidth for IME handling

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -737,16 +737,68 @@ void MSWindowsKeyState::sendKeyEvent(
   }
 }
 
+KeyID MSWindowsKeyState::normalizeFullwidthKey(KeyID id) const
+{
+  KeyID ascii = kKeyNone;
+
+  if (id >= 0xff01u && id <= 0xff5eu) {
+    ascii = id - 0xfee0u;
+  } else {
+    // CJK punctuations that have no fullwidth-form
+    struct FullwidthKey
+    {
+      KeyID m_fullwidth;
+      KeyID m_ascii;
+    };
+    static const FullwidthKey s_fullwidthKeys[] = {
+        {0x3002, '.'},  // 。
+        {0x3001, '\\'}, // 、
+        {0x300a, '<'},  // 《
+        {0x300b, '>'},  // 》
+        {0x3010, '['},  // 【
+        {0x3011, ']'},  // 】
+        {0x2014, '_'},  // —
+        {0x2026, '^'},  // …
+        {0x201c, '"'},  // “
+        {0x201d, '"'},  // ”
+        {0x2018, '\''}, // ‘
+        {0x2019, '\''}, // ’
+        {0x00b7, '`'},  // ·
+        {0x300c, '{'},  // 「
+        {0x300d, '}'},  // 」
+        {0x00a5, '$'},  // ¥
+        {0xffe5, '$'},  // ￥
+    };
+    for (const auto &entry : s_fullwidthKeys) {
+      if (entry.m_fullwidth == id) {
+        ascii = entry.m_ascii;
+        break;
+      }
+    }
+  }
+
+  if (ascii == kKeyNone) {
+    return id;
+  }
+
+  if (getButton(id, pollActiveGroup()) != 0) {
+    return id;
+  }
+
+  LOG_DEBUG("normalized fullwidth key %04x to %04x", id, ascii);
+  return ascii;
+}
+
 void MSWindowsKeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &lang)
 {
-  KeyState::fakeKeyDown(id, mask, button, lang);
+  KeyState::fakeKeyDown(normalizeFullwidthKey(id), mask, button, lang);
 }
 
 bool MSWindowsKeyState::fakeKeyRepeat(
     KeyID id, KeyModifierMask mask, int32_t count, KeyButton button, const std::string &lang
 )
 {
-  return KeyState::fakeKeyRepeat(id, mask, count, button, lang);
+  return KeyState::fakeKeyRepeat(normalizeFullwidthKey(id), mask, count, button, lang);
 }
 
 // We must use SendSAS (Secure Attention Sequence) to simulate Ctrl+Alt+Del (since Windows Vista).

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -178,6 +178,12 @@ private:
 
   void addKeyEntry(deskflow::KeyMap &keyMap, deskflow::KeyMap::KeyItem &item);
 
+  // Map a fullwidth CJK punctuation KeyID to the ASCII character on the same
+  // physical key when the original glyph can't be produced by the local
+  // keyboard, so the local IME can re-apply the width instead of the key
+  // being dropped.  Returns the original id when no substitution applies.
+  KeyID normalizeFullwidthKey(KeyID id) const;
+
   void init();
 
 private:


### PR DESCRIPTION
## Description
On a secondary (client) Windows machine, punctuation typed from a primary (server) running a CJK input method was silently dropped.

When the server runs a CJK IME (e.g. macOS Pinyin), punctuation arrives as a finished fullwidth glyph — e.g. ， (U+FF0C), 。 (U+3002), 《》 (U+300A/B). The Windows client has no physical key that produces those glyphs, so KeyMap::mapKey() fails to find a button, the keystroke is dropped, and nothing is typed. Latin letters were unaffected (they arrive as ASCII), so only punctuation went missing.

This change adds MSWindowsKeyState::normalizeFullwidthKey(), applied in fakeKeyDown/fakeKeyRepeat before mapping. When an incoming glyph has no local key, it is translated to the ASCII character that lives on the same physical key:

Fullwidth ASCII variants (U+FF01–U+FF5E) → halfwidth (U+0021–U+007E) by the fixed −0xFEE0 offset.
A small table for CJK punctuation that has no fullwidth-form block entry (。、《》【】「」——……""''·¥), each mapped to the ASCII char on its key position.
The client then injects that key, letting the local IME decide the final width according to its own punctuation mode — so the width decision happens on the target side, matching how a directly-attached keyboard behaves. Substitution only happens when the original glyph has no local key, so input that already works is untouched (zero regression).

## AI tools used for this PR
Claude opus 4.8 max (Anthropic) — used for codebase investigation (tracing the key-event pipeline across OSXKeyState → protocol → MSWindowsKeyState/KeyMap), root-cause analysis from server/client verbose logs, and drafting the normalizeFullwidthKey implementation.

## Fixed/related issues
Null

## How has this been tested?
Tested manually with a macOS server (Pinyin input method) and a Windows client:
- Environment: server = macOS, Pinyin IME; client = Windows, Microsoft Pinyin IME.
- Before: typing ，。；：？！《》【】"" … from the server produced nothing on the Windows client (verbose log showed key XXXX is not on keyboard).
- After: the punctuation appears correctly; the verbose log shows normalized fullwidth key XXXX to YYYY.
- With the Windows IME switched to English/halfwidth mode, the same keys produce the halfwidth forms — confirming the width is decided by the local IME.
