### PR TITLE
Fix FTBFS with OpenSSL 4.0.0

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -474,9 +474,6 @@ int SecureSocket::secureConnect(int socket)
 
   LOG_VERBOSE("connecting secure socket");
 
-  // enable hostname verification.
-  const auto name = Settings::value(Settings::Core::ComputerName).toString().toStdString();
-  SSL_set1_host(m_ssl->m_ssl, name.c_str());
   int r = SSL_connect(m_ssl->m_ssl);
 
   static int retry;

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -84,9 +84,14 @@ void generatePemSelfSignedCert(const QString &path, int keyLength)
   X509_gmtime_adj(X509_get_notAfter(cert), expirationDays * 24 * 3600);
   X509_set_pubkey(cert, privateKey);
 
-  auto *name = X509_get_subject_name(cert);
+  auto *name = X509_NAME_new();
+  if (!name) {
+    throw std::runtime_error("could not allocate subject name");
+  }
   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char *>("Deskflow"), -1, -1, 0);
+  X509_set_subject_name(cert, name);
   X509_set_issuer_name(cert, name);
+  X509_NAME_free(name);
 
   X509_sign(cert, privateKey, EVP_sha256());
   const QFile file(path);


### PR DESCRIPTION
## Description

* fix: invalid type conversion for OpenSSL 4.0.0
* fix: deprecated SSL_set1_host for OpenSSL 4.0.0


## AI tools used for this PR

I referred to the output from Gemini as a clue for exploring alternative solutions,
but sample code itself was changed initial suggestion from Gemini.

## Fixed/related issues

fixes: #9806

## How has this been tested?

* did rebuilt for HEAD
* did rebuilt for debian unstable (experimental)
* not tested on daily driver environment yet, so please help to test it.