### PR TITLE
ci: do not block via debconf

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -219,7 +219,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{matrix.target.like}}" == "debian" ]; then
-            apt update -qqq > /dev/null && apt install -qqq git devscripts > /dev/null
+            apt update -qqq > /dev/null && DEBIAN_FRONTEND=noninteractive apt install -qqq git devscripts > /dev/null
           elif [ "${{matrix.target.like}}" == "fedora" ]; then
             dnf install -y git
           elif [ "${{matrix.target.like}}" == "suse" ]; then


### PR DESCRIPTION
## Description

Try not to block via debconf.
 
## AI tools used for this PR

N/A

## Fixed/related issues

See github actions for debian-arm64 and testing-arm64.


## How has this been tested?

tested in forked actions
https://github.com/kenhys/deskflow/actions/runs/26752450254/job/78843763035?pr=1