### PR TITLE
fix: crash on windows if fixed font is missing

### DIFF
--- a/src/lib/gui/widgets/LogWidget.cpp
+++ b/src/lib/gui/widgets/LogWidget.cpp
@@ -20,11 +20,18 @@ LogWidget::LogWidget(QWidget *parent) : QWidget{parent}, m_textLog{new QPlainTex
   m_textLog->setLineWrapMode(QPlainTextEdit::NoWrap);
 
   // setup the log font
-  m_textLog->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-  if (deskflow::platform::isMac()) {
-    auto f = m_textLog->font();
-    f.setPixelSize(12);
+  if (deskflow::platform::isWindows()) {
+    QFont f = font();
+    f.setFamilies({"Hack", "Liberation Mono", "Monospace", "Andale Mono"});
+    f.setStyleHint(QFont::Monospace);
     m_textLog->setFont(f);
+  } else {
+    m_textLog->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    if (deskflow::platform::isMac()) {
+      auto f = m_textLog->font();
+      f.setPixelSize(12);
+      m_textLog->setFont(f);
+    }
   }
 
   auto layout = new QVBoxLayout;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
use font names on windows for the log
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixed: 9765

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
run on mac os 