### PR TITLE
Better local fingerprint preview

### DIFF
--- a/src/lib/gui/StyleUtils.h
+++ b/src/lib/gui/StyleUtils.h
@@ -8,6 +8,7 @@
 
 #include <QDir>
 #include <QFileInfoList>
+#include <QFontDatabase>
 #include <QIcon>
 #include <QPalette>
 #include <QStyleHints>
@@ -49,3 +50,18 @@ inline void updateIconTheme()
   QIcon::setFallbackSearchPaths({QStringLiteral(":/icons/%1").arg(themeName)});
 }
 } // namespace deskflow::gui
+
+inline QFont fixedFont()
+{
+#if defined(Q_OS_WIN)
+  QFont f({"Hack", "Liberation Mono", "Monospace", "Andale Mono"});
+  f.setStyleHint(QFont::Monospace);
+#else
+  QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+#endif
+
+#if defined(Q_OS_MAC)
+  f.setPointSize(12);
+#endif
+  return f;
+}

--- a/src/lib/gui/dialogs/FingerprintDialog.cpp
+++ b/src/lib/gui/dialogs/FingerprintDialog.cpp
@@ -23,7 +23,7 @@ FingerprintDialog::FingerprintDialog(
       m_buttonBox{new QDialogButtonBox(QDialogButtonBox::Help, this)}
 {
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-  m_lblHeader->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+  m_lblHeader->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
 
   const bool localMode = mode == FingerprintDialogMode::Local;
   const bool isServer = mode == FingerprintDialogMode::Server;

--- a/src/lib/gui/widgets/FingerprintPreview.cpp
+++ b/src/lib/gui/widgets/FingerprintPreview.cpp
@@ -70,16 +70,11 @@ QLayout *FingerprintPreview::sha256Layout(const Fingerprint &fingerprint, const 
   f.setStyleHint(QFont::Monospace);
   m_lblArt->setFont(f);
 
-  auto innersha256Layout = new QHBoxLayout();
-  innersha256Layout->setContentsMargins(0, 0, 0, 0);
-  innersha256Layout->addWidget(m_lblHash);
-  innersha256Layout->addWidget(m_lblArt);
-
   auto sha256Layout = new QVBoxLayout();
   sha256Layout->setContentsMargins(0, 0, 0, 0);
   sha256Layout->addWidget(labelTitle);
-  sha256Layout->addLayout(innersha256Layout);
-  sha256Layout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Preferred, QSizePolicy::Expanding));
+  sha256Layout->addWidget(m_lblHash);
+  sha256Layout->addWidget(m_lblArt);
 
   auto frameSha256 = new QFrame(this);
   frameSha256->setFrameShape(QFrame::StyledPanel);

--- a/src/lib/gui/widgets/FingerprintPreview.cpp
+++ b/src/lib/gui/widgets/FingerprintPreview.cpp
@@ -10,6 +10,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 
+#include <gui/StyleUtils.h>
 #include <net/SecureUtils.h>
 
 FingerprintPreview::FingerprintPreview(
@@ -59,16 +60,13 @@ QLayout *FingerprintPreview::sha256Layout(const Fingerprint &fingerprint, const 
   m_lblHash->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
   m_lblHash->setTextInteractionFlags(Qt::TextSelectableByMouse);
   m_lblHash->setVisible(hashMode);
+  m_lblHash->setFont(fixedFont());
 
   m_lblArt = new QLabel(deskflow::generateFingerprintArt(fingerprint.data), this);
   m_lblArt->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
   m_lblArt->setTextInteractionFlags(Qt::TextSelectableByMouse);
   m_lblArt->setVisible(!hashMode);
-
-  f = font();
-  f.setFamilies({"Hack", "Liberation Mono", "Monospace", "Andale Mono"});
-  f.setStyleHint(QFont::Monospace);
-  m_lblArt->setFont(f);
+  m_lblArt->setFont(fixedFont());
 
   auto sha256Layout = new QVBoxLayout();
   sha256Layout->setContentsMargins(0, 0, 0, 0);

--- a/src/lib/gui/widgets/FingerprintPreview.cpp
+++ b/src/lib/gui/widgets/FingerprintPreview.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "FingerprintPreview.h"
+#include "common/PlatformInfo.h"
 
 #include <QFont>
 #include <QHBoxLayout>
@@ -26,7 +27,10 @@ FingerprintPreview::FingerprintPreview(
       fingerprint.type == QCryptographicHash::Sha256 ? sha256Layout(fingerprint, titleText, hashMode) : emptyLayout()
   );
   adjustSize();
-  setFixedSize(size());
+  int artPadding = 48;
+  if (deskflow::platform::isMac())
+    artPadding = 32;
+  setFixedSize(m_lblArt->width() + artPadding, height());
 }
 
 void FingerprintPreview::toggleMode(bool hashMode)

--- a/src/lib/gui/widgets/LogWidget.cpp
+++ b/src/lib/gui/widgets/LogWidget.cpp
@@ -5,9 +5,9 @@
  */
 
 #include "LogWidget.h"
-#include "common/PlatformInfo.h"
 
 #include <gui/Logger.h>
+#include <gui/StyleUtils.h>
 
 #include <QPlainTextEdit>
 #include <QScrollBar>
@@ -18,21 +18,7 @@ LogWidget::LogWidget(QWidget *parent) : QWidget{parent}, m_textLog{new QPlainTex
   m_textLog->setReadOnly(true);
   m_textLog->setMaximumBlockCount(10000);
   m_textLog->setLineWrapMode(QPlainTextEdit::NoWrap);
-
-  // setup the log font
-  if (deskflow::platform::isWindows()) {
-    QFont f = font();
-    f.setFamilies({"Hack", "Liberation Mono", "Monospace", "Andale Mono"});
-    f.setStyleHint(QFont::Monospace);
-    m_textLog->setFont(f);
-  } else {
-    m_textLog->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-    if (deskflow::platform::isMac()) {
-      auto f = m_textLog->font();
-      f.setPixelSize(12);
-      m_textLog->setFont(f);
-    }
-  }
+  m_textLog->setFont(fixedFont());
 
   auto layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Remove un needed extra layout from the fingerprint preview
 - Add `deskflow::gui::fixedFont()` to get the fixed size font where needed. 
 - Adjust width of the fingerprint preview to fix the hash nicely

 - Center the title on the fingerprint dialog
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Hash can be cutoff in the fingerprint preview. 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally run on linux 
Someone should check this on windows also.