### PR TITLE
[codex] Harden clipboard and screen transition handling

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -384,6 +384,26 @@ This indicates that computer ''larry'' is to the right of computer ''moe'' (so m
 
 Note that links do not have to be symmetrical; for instance, here the edge between ''moe'' and ''curly'' maps to different ranges depending on if you're going up or down. In fact links don't have to be bidirectional. You can configure the right of ''moe'' to go to ''larry'' without a link from the left of ''larry'' to ''moe''. It's possible to configure a computer with no outgoing links; the cursor will get stuck on that computer unless you have a hot key configured to switch off of that computer.
 
+### physical-layout section
+
+The optional ''physical-layout'' section describes each computer as a rectangle in a shared physical coordinate space:
+
+```
+section: physical-layout
+	moe = 0,40,598,336
+	larry = 598,0,527,296
+	curly = 1125,70,620,350
+end
+```
+
+Each line has the form:
+
+```
+ name = x,y,width,height
+```
+
+The units can be millimeters or any other consistent unit. When this section is present, Deskflow preserves the physical crossing position between computers. For example, moving off the right edge of ''moe'' at a physical height of 120 enters ''larry'' at the same physical height, converted to ''larry'''s pixel coordinates. If that physical position does not overlap the target computer, Deskflow does not switch there.
+
 ### options section
 
 ''args'' is a list of lines of the form <code>name = value</code>. These set the global options.

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -72,14 +72,14 @@ void Client::setServerAddress(const NetworkAddress &address)
   m_serverAddress = address;
 }
 
-void Client::connect(size_t addressIndex)
+bool Client::connect(size_t addressIndex)
 {
   if (m_stream != nullptr) {
-    return;
+    return true;
   }
   if (m_suspended) {
     m_connectOnResume = true;
-    return;
+    return false;
   }
 
   auto securityLevel = m_useSecureNetwork ? SecurityLevel::PeerAuth : SecurityLevel::PlainText;
@@ -120,8 +120,10 @@ void Client::connect(size_t addressIndex)
     cleanupStream();
     LOG_VERBOSE("connection failed");
     sendConnectionFailedEvent(e.what());
-    return;
+    return true;
   }
+
+  return true;
 }
 
 void Client::disconnect(const char *msg)

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -75,7 +75,7 @@ public:
   Starts an attempt to connect to the server.  This is ignored if
   the client is trying to connect or is already connected.
   */
-  void connect(size_t addressIndex = 0);
+  bool connect(size_t addressIndex = 0);
   void setServerAddress(const NetworkAddress &address);
 
   //! Disconnect

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -284,7 +284,10 @@ bool ClientApp::startClient()
     }
 
     m_client->setServerAddress(getCurrentServerAddress());
-    m_client->connect(m_lastServerAddressIndex);
+    if (!m_client->connect(m_lastServerAddressIndex)) {
+      LOG_DEBUG("client connection deferred while screen is suspended");
+      scheduleClientRestart(retryTime());
+    }
 
     return true;
   } catch (ScreenUnavailableException &e) {

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -239,7 +239,7 @@ void MainWindow::connectSlots()
   connect(Settings::instance(), &Settings::settingsChanged, this, &MainWindow::settingsChanged);
 
   connect(&m_coreProcess, &CoreProcess::error, this, &MainWindow::coreProcessError);
-  connect(&m_coreProcess, &CoreProcess::logLine, this, &MainWindow::handleLogLine);
+  connect(&m_coreProcess, &CoreProcess::logLine, this, &MainWindow::handleLogLine, Qt::QueuedConnection);
   connect(
       &m_coreProcess, &CoreProcess::processStateChanged, this, &MainWindow::coreProcessStateChanged,
       Qt::QueuedConnection

--- a/src/lib/gui/widgets/LogDock.cpp
+++ b/src/lib/gui/widgets/LogDock.cpp
@@ -65,8 +65,12 @@ LogDock::LogDock(QWidget *parent)
 
 void LogDock::appendLine(const QString &msg)
 {
+  if (auto p = static_cast<QWidget *>(parent()); !p->isVisible() || p->isMinimized()) {
+    return;
+  }
+
   m_textLog->appendLine(msg);
-  if (auto p = static_cast<QWidget *>(parent()); p->isVisible() && !p->isMinimized() && !m_searchWidget->isExpanded()) {
+  if (!m_searchWidget->isExpanded()) {
     m_textLog->scrollToBottom();
   }
 }

--- a/src/lib/gui/widgets/LogWidget.cpp
+++ b/src/lib/gui/widgets/LogWidget.cpp
@@ -40,13 +40,15 @@ LogWidget::LogWidget(QWidget *parent) : QWidget{parent}, m_textLog{new QPlainTex
 
   setLayout(layout);
 
-  connect(
-      deskflow::gui::Logger::instance(), &deskflow::gui::Logger::newLine, m_textLog, &QPlainTextEdit::appendPlainText
-  );
+  connect(deskflow::gui::Logger::instance(), &deskflow::gui::Logger::newLine, this, &LogWidget::appendLine);
 }
 
 void LogWidget::appendLine(const QString &msg)
 {
+  if (!isVisible()) {
+    return;
+  }
+
   m_textLog->appendPlainText(msg);
 }
 

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -155,6 +155,8 @@ void MSWindowsDesks::enable()
 
 void MSWindowsDesks::disable()
 {
+  restoreSystemCursor();
+
   // remove timer
   if (m_timer != nullptr) {
     m_events->removeHandler(EventTypes::Timer, m_timer);
@@ -176,6 +178,19 @@ void MSWindowsDesks::enter()
 void MSWindowsDesks::leave(HKL keyLayout)
 {
   sendMessage(DESKFLOW_MSG_LEAVE, (WPARAM)keyLayout, 0);
+}
+
+void MSWindowsDesks::restoreSystemCursor()
+{
+  if (!m_systemCursorHidden) {
+    return;
+  }
+
+  if (!SystemParametersInfo(SPI_SETCURSORS, 0, nullptr, 0)) {
+    LOG_WARN("failed to restore system cursors: %d", GetLastError());
+  }
+
+  m_systemCursorHidden = false;
 }
 
 void MSWindowsDesks::resetOptions()
@@ -367,8 +382,9 @@ void MSWindowsDesks::destroyClass(ATOM windowClass) const
 
 HWND MSWindowsDesks::createWindow(ATOM windowClass, const wchar_t *name) const
 {
+  const DWORD exStyle = WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
   HWND window = CreateWindowEx(
-      WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW, MAKEINTATOM(windowClass), name, WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
+      exStyle, MAKEINTATOM(windowClass), name, WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
       MSWindowsScreen::getWindowInstance(), nullptr
   );
   if (window == nullptr) {
@@ -385,8 +401,54 @@ void MSWindowsDesks::destroyWindow(HWND hwnd) const
   }
 }
 
+void MSWindowsDesks::hideSystemCursor()
+{
+  if (m_systemCursorHidden) {
+    return;
+  }
+
+  static constexpr DWORD cursorIds[] = {
+      32512, // OCR_NORMAL
+      32513, // OCR_IBEAM
+      32514, // OCR_WAIT
+      32515, // OCR_CROSS
+      32516, // OCR_UP
+      32640, // OCR_SIZE
+      32641, // OCR_ICON
+      32642, // OCR_SIZENWSE
+      32643, // OCR_SIZENESW
+      32644, // OCR_SIZEWE
+      32645, // OCR_SIZENS
+      32646, // OCR_SIZEALL
+      32648, // OCR_NO
+      32649, // OCR_HAND
+      32650, // OCR_APPSTARTING
+      32651, // OCR_HELP
+  };
+
+  for (const auto cursorId : cursorIds) {
+    HCURSOR cursor = createBlankCursor();
+    if (cursor == nullptr) {
+      LOG_WARN("failed to create blank system cursor for cursor id %u", cursorId);
+      continue;
+    }
+
+    if (!SetSystemCursor(cursor, cursorId)) {
+      LOG_WARN("failed to replace system cursor id %u: %d", cursorId, GetLastError());
+      DestroyCursor(cursor);
+    }
+  }
+
+  m_systemCursorHidden = true;
+}
+
 LRESULT CALLBACK MSWindowsDesks::primaryDeskProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
+  if (msg == WM_SETCURSOR) {
+    SetCursor(reinterpret_cast<HCURSOR>(GetClassLongPtr(hwnd, GCLP_HCURSOR)));
+    return TRUE;
+  }
+
   return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
@@ -396,6 +458,10 @@ LRESULT CALLBACK MSWindowsDesks::secondaryDeskProc(HWND hwnd, UINT msg, WPARAM w
   // window but for now we just detect mouse motion.
   bool hide = false;
   switch (msg) {
+  case WM_SETCURSOR:
+    SetCursor(reinterpret_cast<HCURSOR>(GetClassLongPtr(hwnd, GCLP_HCURSOR)));
+    return TRUE;
+
   case WM_MOUSEMOVE:
     if (LOWORD(lParam) != 0 || HIWORD(lParam) != 0) {
       hide = true;
@@ -494,25 +560,28 @@ void setCursorVisibility(bool visible)
 
 void MSWindowsDesks::deskEnter(Desk *desk)
 {
-  if (!m_isPrimary) {
+  if (GetCapture() == desk->m_window) {
     ReleaseCapture();
   }
 
+  restoreSystemCursor();
   setCursorVisibility(true);
 
   SetWindowPos(desk->m_window, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_HIDEWINDOW);
 
-  // restore the foreground window
-  // XXX -- this raises the window to the top of the Z-order.  we
-  // want it to stay wherever it was to properly support X-mouse
-  // (mouse over activation) but i've no idea how to do that.
-  // the obvious workaround of using SetWindowPos() to move it back
-  // after being raised doesn't work.
-  DWORD thisThread = GetWindowThreadProcessId(desk->m_window, nullptr);
-  DWORD thatThread = GetWindowThreadProcessId(desk->m_foregroundWindow, nullptr);
-  AttachThreadInput(thatThread, thisThread, TRUE);
-  SetForegroundWindow(desk->m_foregroundWindow);
-  AttachThreadInput(thatThread, thisThread, FALSE);
+  if (desk->m_foregroundWindow != nullptr) {
+    // restore the foreground window
+    // XXX -- this raises the window to the top of the Z-order.  we
+    // want it to stay wherever it was to properly support X-mouse
+    // (mouse over activation) but i've no idea how to do that.
+    // the obvious workaround of using SetWindowPos() to move it back
+    // after being raised doesn't work.
+    DWORD thisThread = GetWindowThreadProcessId(desk->m_window, nullptr);
+    DWORD thatThread = GetWindowThreadProcessId(desk->m_foregroundWindow, nullptr);
+    AttachThreadInput(thatThread, thisThread, TRUE);
+    SetForegroundWindow(desk->m_foregroundWindow);
+    AttachThreadInput(thatThread, thisThread, FALSE);
+  }
   EnableWindow(desk->m_window, desk->m_lowLevel ? FALSE : TRUE);
   desk->m_foregroundWindow = nullptr;
 }
@@ -522,6 +591,8 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
   setCursorVisibility(false);
 
   if (m_isPrimary) {
+    hideSystemCursor();
+
     // map a window to hide the cursor and to use whatever keyboard
     // layout we choose rather than the keyboard layout of the last
     // active window.
@@ -543,6 +614,9 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
       h = m_h;
     }
     SetWindowPos(desk->m_window, HWND_TOP, x, y, w, h, SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    EnableWindow(desk->m_window, TRUE);
+    SetCapture(desk->m_window);
+    SetCursor(m_cursor);
 
     // switch to requested keyboard layout
     ActivateKeyboardLayout(keyLayout, 0);
@@ -555,26 +629,11 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
       SetActiveWindow(desk->m_window);
     }
 
-    // if using low-level hooks then disable the foreground window
-    // so it can't mess up any of our keyboard events.  the console
-    // program, for example, will cause characters to be reported as
-    // unshifted, regardless of the shift key state.  interestingly
-    // we do see the shift key go down and up.
-    //
-    // note that we must enable the window to activate it and we
-    // need to disable the window on deskEnter.
+    // With low-level hooks, avoid taking the foreground window. Changing
+    // foreground focus causes some active Windows apps to visibly flicker
+    // during screen transitions.
     else {
-      desk->m_foregroundWindow = getForegroundWindow();
-      if (desk->m_foregroundWindow != nullptr) {
-        EnableWindow(desk->m_window, TRUE);
-        SetActiveWindow(desk->m_window);
-        DWORD thisThread = GetWindowThreadProcessId(desk->m_window, nullptr);
-        DWORD thatThread = GetWindowThreadProcessId(desk->m_foregroundWindow, nullptr);
-
-        AttachThreadInput(thatThread, thisThread, TRUE);
-        SetForegroundWindow(desk->m_window);
-        AttachThreadInput(thatThread, thisThread, FALSE);
-      }
+      desk->m_foregroundWindow = nullptr;
     }
   } else {
     // move hider window under the cursor center, raise, and show it
@@ -585,6 +644,7 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
     // mouse if desired.  we'd rather not capture the mouse but
     // we aren't notified when the mouse leaves our window.
     SetCapture(desk->m_window);
+    SetCursor(m_cursor);
 
     // windows can take a while to hide the cursor, so wait a few milliseconds to ensure the cursor
     // is hidden before centering. this doesn't seem to affect the fluidity of the transition.

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -100,6 +100,9 @@ public:
   */
   void setOptions(const OptionsList &options);
 
+  //! Restore Windows system cursors if they were replaced while off-screen.
+  void restoreSystemCursor();
+
   //! Update the key state
   /*!
   Causes the key state to get updated to reflect the physical keyboard
@@ -197,6 +200,7 @@ private:
   void destroyClass(ATOM windowClass) const;
   HWND createWindow(ATOM windowClass, const wchar_t *name) const;
   void destroyWindow(HWND) const;
+  void hideSystemCursor();
 
   // message handlers
   void deskMouseMove(int32_t x, int32_t y) const;
@@ -241,6 +245,7 @@ private:
   // our resources
   ATOM m_deskClass;
   HCURSOR m_cursor;
+  bool m_systemCursorHidden = false;
 
   // screen shape stuff
   int32_t m_x = 0;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -21,10 +21,51 @@
 #include <cstdlib>
 #include <istream>
 #include <ostream>
+#include <vector>
 
 using namespace deskflow::string;
 
 namespace deskflow::server {
+namespace {
+
+std::string trim(const std::string &value)
+{
+  const auto start = value.find_first_not_of(" \t");
+  if (start == std::string::npos) {
+    return "";
+  }
+
+  const auto end = value.find_last_not_of(" \t");
+  return value.substr(start, end - start + 1);
+}
+
+std::vector<std::string> splitCommaSeparated(const std::string &value)
+{
+  std::vector<std::string> result;
+  std::string::size_type start = 0;
+  for (;;) {
+    const auto end = value.find(',', start);
+    result.push_back(trim(value.substr(start, end - start)));
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return result;
+}
+
+float parseFloat(ConfigReadContext &context, const std::string &value)
+{
+  char *end = nullptr;
+  const double parsed = strtod(value.c_str(), &end);
+  if (value.empty() || end == nullptr || *end != '\0') {
+    throw ServerConfigReadException(context, "invalid physical layout number \"%{1}\"", value);
+  }
+  return static_cast<float>(parsed);
+}
+
+} // namespace
+
 //
 // Config
 //
@@ -70,6 +111,12 @@ bool Config::renameScreen(const std::string &oldName, const std::string &newName
   m_map.erase(index);
   m_map.insert(std::make_pair(newName, tmpCell));
 
+  if (auto physicalIndex = m_physicalScreens.find(oldCanonical); physicalIndex != m_physicalScreens.end()) {
+    PhysicalScreen physicalScreen = physicalIndex->second;
+    m_physicalScreens.erase(physicalIndex);
+    m_physicalScreens.insert(std::make_pair(newName, physicalScreen));
+  }
+
   // update name
   m_nameToCanonicalName.erase(oldCanonical);
   m_nameToCanonicalName.insert(std::make_pair(newName, newName));
@@ -103,6 +150,7 @@ void Config::removeScreen(const std::string &name)
 
   // remove from map
   m_map.erase(index);
+  m_physicalScreens.erase(canonical);
 
   // disconnect
   Name nameObj(this, name);
@@ -124,6 +172,7 @@ void Config::removeAllScreens()
 {
   m_map.clear();
   m_nameToCanonicalName.clear();
+  m_physicalScreens.clear();
 }
 
 bool Config::addAlias(const std::string &canonical, const std::string &alias)
@@ -312,6 +361,17 @@ bool Config::removeOptions(const std::string &name)
   return true;
 }
 
+bool Config::setPhysicalScreen(const std::string &name, const PhysicalScreen &screen)
+{
+  const auto canonical = getCanonicalName(name);
+  if (canonical.empty() || screen.width <= 0.0f || screen.height <= 0.0f) {
+    return false;
+  }
+
+  m_physicalScreens[canonical] = screen;
+  return true;
+}
+
 bool Config::isValidScreenName(const std::string &name) const
 {
   // name is valid if matches validname
@@ -429,6 +489,22 @@ std::string Config::getNeighbor(const std::string &srcName, Direction srcSide, f
   }
 }
 
+const Config::PhysicalScreen *Config::getPhysicalScreen(const std::string &name) const
+{
+  const auto canonical = getCanonicalName(name);
+  if (canonical.empty()) {
+    return nullptr;
+  }
+
+  const auto index = m_physicalScreens.find(canonical);
+  return index == m_physicalScreens.end() ? nullptr : &index->second;
+}
+
+bool Config::hasPhysicalLayout() const
+{
+  return !m_physicalScreens.empty();
+}
+
 bool Config::hasNeighbor(const std::string &srcName, Direction srcSide) const
 {
   return hasNeighbor(srcName, srcSide, 0.0f, 1.0f);
@@ -504,6 +580,9 @@ bool Config::operator==(const Config &x) const
   if (m_globalOptions != x.m_globalOptions) {
     return false;
   }
+  if (m_physicalScreens != x.m_physicalScreens) {
+    return false;
+  }
 
   auto index2map = x.m_map.cbegin();
   for (auto const &index1 : m_map) {
@@ -575,6 +654,7 @@ void Config::readSection(ConfigReadContext &s)
   static const char s_options[] = "options";
   static const char s_screens[] = "screens";
   static const char s_links[] = "links";
+  static const char s_physicalLayout[] = "physical-layout";
   static const char s_aliases[] = "aliases";
 
   std::string line;
@@ -606,6 +686,8 @@ void Config::readSection(ConfigReadContext &s)
     readSectionScreens(s);
   } else if (name == s_links) {
     readSectionLinks(s);
+  } else if (name == s_physicalLayout) {
+    readSectionPhysicalLayout(s);
   } else if (name == s_aliases) {
     readSectionAliases(s);
   } else {
@@ -876,6 +958,43 @@ void Config::readSectionLinks(ConfigReadContext &s)
     }
   }
   throw ServerConfigReadException(s, "unexpected end of links section");
+}
+
+void Config::readSectionPhysicalLayout(ConfigReadContext &s)
+{
+  std::string line;
+  while (s.readLine(line)) {
+    if (line == "end") {
+      return;
+    }
+
+    const auto separator = line.find('=');
+    if (separator == std::string::npos) {
+      throw ServerConfigReadException(s, "missing =");
+    }
+
+    const auto screen = trim(line.substr(0, separator));
+    if (!isScreen(screen)) {
+      throw ServerConfigReadException(s, "unknown screen name \"%{1}\"", screen);
+    }
+    if (!isCanonicalName(screen)) {
+      throw ServerConfigReadException(s, "cannot use screen name alias here");
+    }
+
+    const auto args = splitCommaSeparated(line.substr(separator + 1));
+    if (args.size() != 4) {
+      throw ServerConfigReadException(s, "physical layout requires x,y,width,height for \"%{1}\"", screen);
+    }
+
+    PhysicalScreen physicalScreen{
+        parseFloat(s, args[0]), parseFloat(s, args[1]), parseFloat(s, args[2]), parseFloat(s, args[3])
+    };
+    if (!setPhysicalScreen(screen, physicalScreen)) {
+      throw ServerConfigReadException(s, "invalid physical layout for \"%{1}\"", screen);
+    }
+  }
+
+  throw ServerConfigReadException(s, "unexpected end of physical-layout section");
 }
 
 void Config::readSectionAliases(ConfigReadContext &s)
@@ -1609,6 +1728,21 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
     }
   }
   s << "end" << std::endl;
+
+  if (!config.m_physicalScreens.empty()) {
+    s << "section: physical-layout" << std::endl;
+    for (const auto &screen : config) {
+      const auto index = config.m_physicalScreens.find(screen);
+      if (index == config.m_physicalScreens.end()) {
+        continue;
+      }
+
+      const auto &physicalScreen = index->second;
+      s << "\t" << screen.c_str() << " = " << physicalScreen.x << "," << physicalScreen.y << "," << physicalScreen.width
+        << "," << physicalScreen.height << std::endl;
+    }
+    s << "end" << std::endl;
+  }
 
   // aliases section (if there are any)
   if (config.m_map.size() != config.m_nameToCanonicalName.size()) {

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -55,6 +55,16 @@ public:
   using ScreenOptions = std::map<OptionID, OptionValue>;
   using Interval = std::pair<float, float>;
 
+  struct PhysicalScreen
+  {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+
+    bool operator==(const PhysicalScreen &) const = default;
+  };
+
   class CellEdge
   {
   public:
@@ -136,6 +146,7 @@ private:
   };
   using CellMap = std::map<std::string, Cell, deskflow::string::CaselessCmp>;
   using NameMap = std::map<std::string, std::string, deskflow::string::CaselessCmp>;
+  using PhysicalScreenMap = std::map<std::string, PhysicalScreen, deskflow::string::CaselessCmp>;
 
 public:
   using link_const_iterator = Cell::const_iterator;
@@ -321,6 +332,9 @@ public:
   */
   bool removeOptions(const std::string &name);
 
+  //! Set physical layout rectangle for a screen.
+  bool setPhysicalScreen(const std::string &name, const PhysicalScreen &screen);
+
   //! Get the hot key input filter
   /*!
   Returns the hot key input filter.  Clients can modify hotkeys using
@@ -376,6 +390,12 @@ public:
   \c nullptr.
   */
   std::string getNeighbor(const std::string &, Direction, float position, float *positionOut) const;
+
+  //! Get physical layout rectangle for a screen.
+  const PhysicalScreen *getPhysicalScreen(const std::string &name) const;
+
+  //! Check whether any physical layout rectangles are configured.
+  bool hasPhysicalLayout() const;
 
   //! Check for neighbor
   /*!
@@ -454,6 +474,7 @@ private:
   void readSectionOptions(ConfigReadContext &);
   void readSectionScreens(ConfigReadContext &);
   void readSectionLinks(ConfigReadContext &);
+  void readSectionPhysicalLayout(ConfigReadContext &);
   void readSectionAliases(ConfigReadContext &);
 
   InputFilter::Condition *
@@ -472,6 +493,7 @@ private:
   NameMap m_nameToCanonicalName;
   NetworkAddress m_deskflowAddress;
   ScreenOptions m_globalOptions;
+  PhysicalScreenMap m_physicalScreens;
   InputFilter m_inputFilter;
   bool m_hasLockToScreenAction = false;
   IEventQueue *m_events;

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -38,6 +38,8 @@ using namespace deskflow::server;
 
 namespace {
 
+constexpr int32_t kSecondarySwitchEdgeMargin = 16;
+
 bool containsPhysicalPosition(float start, float length, float position)
 {
   return position >= start && position < start + length;
@@ -913,11 +915,6 @@ BaseClientProxy *Server::mapToNeighbor(BaseClientProxy *src, Direction srcSide, 
 
 void Server::avoidJumpZone(const BaseClientProxy *dst, Direction dir, int32_t &x, int32_t &y) const
 {
-  // we only need to avoid jump zones on the primary screen
-  if (dst != m_primaryClient) {
-    return;
-  }
-
   const std::string dstName(getName(dst));
   int32_t dx;
   int32_t dy;
@@ -926,6 +923,10 @@ void Server::avoidJumpZone(const BaseClientProxy *dst, Direction dir, int32_t &x
   dst->getShape(dx, dy, dw, dh);
   float t = mapToFraction(dst, dir, x, y);
   int32_t z = getJumpZoneSize(dst);
+  const int32_t minZoneSize = (dst == m_primaryClient) ? 1 : kSecondarySwitchEdgeMargin;
+  if (z < minZoneSize) {
+    z = minZoneSize;
+  }
 
   // move in far enough to avoid the jump zone.  if entering a side
   // that doesn't have a neighbor (i.e. an asymmetrical side) then we
@@ -1406,8 +1407,11 @@ void Server::handleClipboardGrabbed(const Event &event, BaseClientProxy *grabber
 
   if (grabber == m_primaryClient && m_active != m_primaryClient) {
     LOG_INFO("clipboard grabbed while active screen was changed, resending clipboard data");
+    const auto primaryName = getName(m_primaryClient);
     for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
-      onClipboardChanged(m_primaryClient, id, m_clipboards[id].m_clipboardSeqNum);
+      if (m_clipboards[id].m_clipboardOwner == primaryName) {
+        onClipboardChanged(m_primaryClient, id, m_clipboards[id].m_clipboardSeqNum);
+      }
     }
   }
 }
@@ -1646,11 +1650,31 @@ void Server::onClipboardChanged(const BaseClientProxy *sender, ClipboardID id, u
     return;
   }
 
-  // should be the expected client
-  assert(sender == m_clients.find(clipboard.m_clipboardOwner)->second);
+  const auto owner = m_clients.find(clipboard.m_clipboardOwner);
+  if (owner == m_clients.end()) {
+    LOG_INFO(
+        "ignored screen \"%s\" update of clipboard %d because owner \"%s\" is not connected",
+        getName(sender).c_str(), id, clipboard.m_clipboardOwner.c_str()
+    );
+    return;
+  }
+  if (sender != owner->second) {
+    LOG_INFO(
+        "ignored screen \"%s\" update of clipboard %d because owner is \"%s\"",
+        getName(sender).c_str(), id, clipboard.m_clipboardOwner.c_str()
+    );
+    return;
+  }
 
   // get data
-  sender->getClipboard(id, &clipboard.m_clipboard);
+  if (!sender->getClipboard(id, &clipboard.m_clipboard)) {
+    LOG_INFO(
+        "ignored screen \"%s\" update of clipboard %d because clipboard data is unavailable",
+        getName(sender).c_str(), id
+    );
+    return;
+  }
+  clipboard.m_clipboardSeqNum = seqNum;
 
   std::string data = clipboard.m_clipboard.marshall();
   if (data.size() > m_maximumClipboardSize * 1024) {

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -36,6 +36,77 @@
 
 using namespace deskflow::server;
 
+namespace {
+
+bool containsPhysicalPosition(float start, float length, float position)
+{
+  return position >= start && position < start + length;
+}
+
+bool isCandidateInDirection(
+    const Config::PhysicalScreen &src, const Config::PhysicalScreen &dst, Direction direction, float &distance
+)
+{
+  switch (direction) {
+    using enum Direction;
+  case Left:
+    if (dst.x + dst.width > src.x) {
+      return false;
+    }
+    distance = src.x - (dst.x + dst.width);
+    return true;
+
+  case Right:
+    if (dst.x < src.x + src.width) {
+      return false;
+    }
+    distance = dst.x - (src.x + src.width);
+    return true;
+
+  case Top:
+    if (dst.y + dst.height > src.y) {
+      return false;
+    }
+    distance = src.y - (dst.y + dst.height);
+    return true;
+
+  case Bottom:
+    if (dst.y < src.y + src.height) {
+      return false;
+    }
+    distance = dst.y - (src.y + src.height);
+    return true;
+
+  case NoDirection:
+    break;
+  }
+
+  return false;
+}
+
+bool overlapsPerpendicularAxis(
+    const Config::PhysicalScreen &src, const Config::PhysicalScreen &dst, Direction direction
+)
+{
+  switch (direction) {
+    using enum Direction;
+  case Left:
+  case Right:
+    return src.y < dst.y + dst.height && dst.y < src.y + src.height;
+
+  case Top:
+  case Bottom:
+    return src.x < dst.x + dst.width && dst.x < src.x + src.width;
+
+  case NoDirection:
+    break;
+  }
+
+  return false;
+}
+
+} // namespace
+
 //
 // Server
 //
@@ -559,7 +630,127 @@ bool Server::hasAnyNeighbor(const BaseClientProxy *client, Direction dir) const
 {
   assert(client != nullptr);
 
-  return m_config->hasNeighbor(getName(client), dir);
+  return hasPhysicalNeighbor(client, dir) || m_config->hasNeighbor(getName(client), dir);
+}
+
+bool Server::hasPhysicalNeighbor(const BaseClientProxy *src, Direction direction) const
+{
+  const auto *srcPhysical = m_config->getPhysicalScreen(getName(src));
+  if (srcPhysical == nullptr) {
+    return false;
+  }
+
+  for (const auto &[dstName, dstClient] : m_clients) {
+    if (dstClient == src) {
+      continue;
+    }
+
+    const auto *dstPhysical = m_config->getPhysicalScreen(dstName);
+    float distance = 0.0f;
+    if (dstPhysical != nullptr && isCandidateInDirection(*srcPhysical, *dstPhysical, direction, distance) &&
+        overlapsPerpendicularAxis(*srcPhysical, *dstPhysical, direction)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+BaseClientProxy *
+Server::mapToPhysicalNeighbor(const BaseClientProxy *src, Direction direction, int32_t &x, int32_t &y) const
+{
+  const auto *srcPhysical = m_config->getPhysicalScreen(getName(src));
+  if (srcPhysical == nullptr) {
+    return nullptr;
+  }
+
+  int32_t sx;
+  int32_t sy;
+  int32_t sw;
+  int32_t sh;
+  src->getShape(sx, sy, sw, sh);
+
+  const bool horizontalSwitch = direction == Direction::Left || direction == Direction::Right;
+  const float positionFraction =
+      horizontalSwitch ? (y - sy + 0.5f) / static_cast<float>(sh) : (x - sx + 0.5f) / static_cast<float>(sw);
+  const float physicalPosition = horizontalSwitch ? srcPhysical->y + positionFraction * srcPhysical->height
+                                                  : srcPhysical->x + positionFraction * srcPhysical->width;
+
+  BaseClientProxy *bestClient = nullptr;
+  const Config::PhysicalScreen *bestPhysical = nullptr;
+  float bestDistance = 0.0f;
+  bool found = false;
+
+  for (const auto &[dstName, dstClient] : m_clients) {
+    if (dstClient == src) {
+      continue;
+    }
+
+    const auto *dstPhysical = m_config->getPhysicalScreen(dstName);
+    if (dstPhysical == nullptr) {
+      continue;
+    }
+
+    float distance = 0.0f;
+    if (!isCandidateInDirection(*srcPhysical, *dstPhysical, direction, distance)) {
+      continue;
+    }
+
+    const bool containsPosition = horizontalSwitch
+                                      ? containsPhysicalPosition(dstPhysical->y, dstPhysical->height, physicalPosition)
+                                      : containsPhysicalPosition(dstPhysical->x, dstPhysical->width, physicalPosition);
+    if (!containsPosition || (found && distance >= bestDistance)) {
+      continue;
+    }
+
+    bestClient = dstClient;
+    bestPhysical = dstPhysical;
+    bestDistance = distance;
+    found = true;
+  }
+
+  if (bestClient == nullptr || bestPhysical == nullptr) {
+    return nullptr;
+  }
+
+  int32_t dx;
+  int32_t dy;
+  int32_t dw;
+  int32_t dh;
+  bestClient->getShape(dx, dy, dw, dh);
+
+  switch (direction) {
+    using enum Direction;
+  case Left:
+    x = dx + dw - 1;
+    y = dy + static_cast<int32_t>(((physicalPosition - bestPhysical->y) / bestPhysical->height) * dh);
+    break;
+
+  case Right:
+    x = dx;
+    y = dy + static_cast<int32_t>(((physicalPosition - bestPhysical->y) / bestPhysical->height) * dh);
+    break;
+
+  case Top:
+    x = dx + static_cast<int32_t>(((physicalPosition - bestPhysical->x) / bestPhysical->width) * dw);
+    y = dy + dh - 1;
+    break;
+
+  case Bottom:
+    x = dx + static_cast<int32_t>(((physicalPosition - bestPhysical->x) / bestPhysical->width) * dw);
+    y = dy;
+    break;
+
+  case NoDirection:
+    return nullptr;
+  }
+
+  avoidJumpZone(bestClient, direction, x, y);
+  LOG_VERBOSE(
+      "physical layout maps \"%s\" to \"%s\" on %s at %d,%d", getName(src).c_str(), getName(bestClient).c_str(),
+      Config::dirName(direction), x, y
+  );
+  return bestClient;
 }
 
 BaseClientProxy *Server::getNeighbor(const BaseClientProxy *src, Direction dir, int32_t &x, int32_t &y) const
@@ -612,6 +803,10 @@ BaseClientProxy *Server::mapToNeighbor(BaseClientProxy *src, Direction srcSide, 
   // note -- must be locked on entry
 
   assert(src != nullptr);
+
+  if (m_config->getPhysicalScreen(getName(src)) != nullptr && hasPhysicalNeighbor(src, srcSide)) {
+    return mapToPhysicalNeighbor(src, srcSide, x, y);
+  }
 
   // get the first neighbor
   BaseClientProxy *dst = getNeighbor(src, srcSide, x, y);
@@ -738,22 +933,24 @@ void Server::avoidJumpZone(const BaseClientProxy *dst, Direction dir, int32_t &x
   switch (dir) {
     using enum Direction;
   case Left:
-    if (!m_config->getNeighbor(dstName, Right, t, nullptr).empty() && x > dx + dw - 1 - z)
+    if ((!m_config->getNeighbor(dstName, Right, t, nullptr).empty() || hasPhysicalNeighbor(dst, Right)) &&
+        x > dx + dw - 1 - z)
       x = dx + dw - 1 - z;
     break;
 
   case Right:
-    if (!m_config->getNeighbor(dstName, Left, t, nullptr).empty() && x < dx + z)
+    if ((!m_config->getNeighbor(dstName, Left, t, nullptr).empty() || hasPhysicalNeighbor(dst, Left)) && x < dx + z)
       x = dx + z;
     break;
 
   case Top:
-    if (!m_config->getNeighbor(dstName, Bottom, t, nullptr).empty() && y > dy + dh - 1 - z)
+    if ((!m_config->getNeighbor(dstName, Bottom, t, nullptr).empty() || hasPhysicalNeighbor(dst, Bottom)) &&
+        y > dy + dh - 1 - z)
       y = dy + dh - 1 - z;
     break;
 
   case Bottom:
-    if (!m_config->getNeighbor(dstName, Top, t, nullptr).empty() && y < dy + z)
+    if ((!m_config->getNeighbor(dstName, Top, t, nullptr).empty() || hasPhysicalNeighbor(dst, Top)) && y < dy + z)
       y = dy + z;
     break;
 
@@ -1117,10 +1314,8 @@ void Server::processOptions()
     } else if (id == kOptionClipboardSharingSize) {
       if (value <= 0) {
         m_maximumClipboardSize = 0;
-        LOG_INFO(
-            "clipboard sharing is disabled because the "
-            "maximum shared clipboard size is set to 0"
-        );
+        LOG_INFO("clipboard sharing is disabled because the "
+                 "maximum shared clipboard size is set to 0");
       } else {
         m_maximumClipboardSize = static_cast<size_t>(value);
       }

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -238,6 +238,13 @@ private:
   // indicated by the direction.
   bool hasAnyNeighbor(const BaseClientProxy *, Direction) const;
 
+  // returns true if the physical layout has a connected neighbor
+  // anywhere along the edge indicated by the direction.
+  bool hasPhysicalNeighbor(const BaseClientProxy *, Direction) const;
+
+  // lookup neighboring screen using physical layout rectangles.
+  BaseClientProxy *mapToPhysicalNeighbor(const BaseClientProxy *, Direction, int32_t &x, int32_t &y) const;
+
   // lookup neighboring screen, mapping the coordinate independent of
   // the direction to the neighbor's coordinate space.
   BaseClientProxy *getNeighbor(const BaseClientProxy *, Direction, int32_t &x, int32_t &y) const;

--- a/src/unittests/server/ServerConfigTests.cpp
+++ b/src/unittests/server/ServerConfigTests.cpp
@@ -9,6 +9,8 @@
 
 #include "server/Config.h"
 
+#include <sstream>
+
 class OnlySystemFilter : public InputFilter::Condition
 {
 public:
@@ -159,6 +161,49 @@ void ServerConfigTests::equalityCheck_diff_neighbours3()
   QVERIFY(b.addScreen("screenC"));
   QVERIFY(b.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenC", 0.5f, 1.0f));
   QVERIFY(a != b);
+}
+
+void ServerConfigTests::equalityCheck_diff_physicalLayout()
+{
+  Config a(nullptr);
+  Config b(nullptr);
+  QVERIFY(a.addScreen("screenA"));
+  QVERIFY(b.addScreen("screenA"));
+  QVERIFY(a.setPhysicalScreen("screenA", Config::PhysicalScreen{0.0f, 0.0f, 600.0f, 340.0f}));
+  QVERIFY(a != b);
+
+  QVERIFY(b.setPhysicalScreen("screenA", Config::PhysicalScreen{0.0f, 0.0f, 600.0f, 340.0f}));
+  QVERIFY(a == b);
+}
+
+void ServerConfigTests::physicalLayout_readWrite()
+{
+  std::stringstream input;
+  input << "section: screens\n"
+        << "\tscreenA:\n"
+        << "\tscreenB:\n"
+        << "end\n"
+        << "section: physical-layout\n"
+        << "\tscreenA = 0,40,598,336\n"
+        << "\tscreenB = 598,0,527,296\n"
+        << "end\n";
+
+  Config actual(nullptr);
+  input >> actual;
+
+  const auto *screenA = actual.getPhysicalScreen("screenA");
+  QVERIFY(screenA != nullptr);
+  QCOMPARE(screenA->x, 0.0f);
+  QCOMPARE(screenA->y, 40.0f);
+  QCOMPARE(screenA->width, 598.0f);
+  QCOMPARE(screenA->height, 336.0f);
+
+  std::stringstream output;
+  output << actual;
+
+  Config roundTrip(nullptr);
+  output >> roundTrip;
+  QVERIFY(actual == roundTrip);
 }
 
 QTEST_MAIN(ServerConfigTests)

--- a/src/unittests/server/ServerConfigTests.h
+++ b/src/unittests/server/ServerConfigTests.h
@@ -18,4 +18,6 @@ private Q_SLOTS:
   void equalityCheck_diff_neighbours1();
   void equalityCheck_diff_neighbours2();
   void equalityCheck_diff_neighbours3();
+  void equalityCheck_diff_physicalLayout();
+  void physicalLayout_readWrite();
 };

--- a/tools/restart-deskflow-dev.ps1
+++ b/tools/restart-deskflow-dev.ps1
@@ -131,6 +131,24 @@ function Get-IniValue {
   return $null
 }
 
+function Show-WindowsCursor {
+  $NativeMethods = "DeskflowCursorRestore.NativeMethods" -as [type]
+  if (-not $NativeMethods) {
+    Add-Type -Namespace DeskflowCursorRestore -Name NativeMethods -MemberDefinition @"
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern int ShowCursor(bool bShow);
+"@
+    $NativeMethods = "DeskflowCursorRestore.NativeMethods" -as [type]
+  }
+
+  for ($Attempt = 0; $Attempt -lt 10; $Attempt++) {
+    $DisplayCounter = $NativeMethods::ShowCursor($true)
+    if ($DisplayCounter -ge 0) {
+      return
+    }
+  }
+}
+
 Write-Host "Stopping Deskflow processes from $BinPath"
 $ProcessNames = @("deskflow", "deskflow-core", "deskflow-daemon")
 $BinPathFull = [System.IO.Path]::GetFullPath($BinPath).TrimEnd("\", "/")
@@ -185,6 +203,9 @@ Get-Process -Name $ProcessNames -ErrorAction SilentlyContinue | ForEach-Object {
     Write-Warning "Leaving $($Process.ProcessName) [$($Process.Id)] running because its path is not accessible. Use -StopAll to stop every Deskflow process."
   }
 }
+
+Write-Host "Restoring Windows cursor visibility"
+Show-WindowsCursor
 
 $Targets = @($BuildTarget)
 if (-not $NoDaemon -and $BuildTarget -ne "deskflow-daemon") {

--- a/tools/restart-deskflow-dev.ps1
+++ b/tools/restart-deskflow-dev.ps1
@@ -1,0 +1,267 @@
+param(
+  [string]$BuildDir = "build/windows-debug-vcpkg",
+  [string]$BuildTarget = "deskflow-core",
+  [switch]$BuildGui,
+  [switch]$NoGuiBuild,
+  [switch]$NoDaemon,
+  [switch]$DirectCore,
+  [switch]$NoCore,
+  [switch]$StopAll
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Test-IsAdministrator {
+  $Identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $Principal = [Security.Principal.WindowsPrincipal]::new($Identity)
+  return $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Quote-ProcessArgument {
+  param([Parameter(Mandatory = $true)][string]$Value)
+
+  if ($Value -match '[\s"]') {
+    return '"' + $Value.Replace('"', '\"') + '"'
+  }
+
+  return $Value
+}
+
+if ($StopAll -and -not (Test-IsAdministrator)) {
+  $RelaunchArgs = @("-ExecutionPolicy", "Bypass", "-File", (Quote-ProcessArgument -Value $PSCommandPath))
+  foreach ($Parameter in $PSBoundParameters.GetEnumerator()) {
+    if ($Parameter.Value -is [System.Management.Automation.SwitchParameter]) {
+      if ($Parameter.Value.IsPresent) {
+        $RelaunchArgs += "-$($Parameter.Key)"
+      }
+    } else {
+      $RelaunchArgs += "-$($Parameter.Key)"
+      $RelaunchArgs += Quote-ProcessArgument -Value ([string]$Parameter.Value)
+    }
+  }
+
+  $WorkingDirectory = Resolve-Path (Join-Path $PSScriptRoot "..")
+  Write-Host "Restarting elevated because -StopAll must stop elevated Deskflow processes"
+  $ElevatedProcess = Start-Process -FilePath "powershell.exe" -ArgumentList ($RelaunchArgs -join " ") -WorkingDirectory $WorkingDirectory -Verb RunAs -Wait -PassThru
+  exit $ElevatedProcess.ExitCode
+}
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$BuildPath = Resolve-Path (Join-Path $RepoRoot $BuildDir)
+$BinPath = Join-Path $BuildPath "bin"
+$CachePath = Join-Path $BuildPath "CMakeCache.txt"
+$AppName = "Deskflow"
+
+if (-not (Test-Path $CachePath)) {
+  throw "CMake cache not found: $CachePath"
+}
+
+$CMakeExe = $null
+foreach ($Line in Get-Content $CachePath) {
+  if ($Line -match "^CMAKE_COMMAND:INTERNAL=(.+)$") {
+    $CMakeExe = $Matches[1]
+    break
+  }
+}
+
+if (-not $CMakeExe -or -not (Test-Path $CMakeExe)) {
+  $CMakeExe = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+}
+
+if (-not (Test-Path $CMakeExe)) {
+  throw "cmake.exe not found: $CMakeExe"
+}
+
+$VsDevCmd = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
+if (-not (Test-Path $VsDevCmd)) {
+  throw "VsDevCmd.bat not found: $VsDevCmd"
+}
+
+function Set-AsciiIniValueBytes {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Section,
+    [Parameter(Mandatory = $true)][string]$Key,
+    [Parameter(Mandatory = $true)][string]$Value
+  )
+
+  $Encoding = [System.Text.Encoding]::GetEncoding(28591)
+  $Bytes = [System.IO.File]::ReadAllBytes($Path)
+  $Text = $Encoding.GetString($Bytes)
+  $SectionPattern = "(?ms)^\[$([regex]::Escape($Section))\]\r?\n(?<body>.*?)(?=^\[|\z)"
+  $KeyPattern = "(?m)^$([regex]::Escape($Key))=.*$"
+  $NewLine = "$Key=$Value"
+  $SectionMatch = [regex]::Match($Text, $SectionPattern)
+
+  if ($SectionMatch.Success) {
+    $SectionText = $SectionMatch.Value
+    if ($SectionText -match $KeyPattern) {
+      $UpdatedSection = [regex]::Replace($SectionText, $KeyPattern, $NewLine, 1)
+    } else {
+      $UpdatedSection = $SectionText.TrimEnd("`r", "`n") + "`r`n$NewLine`r`n"
+    }
+    $Text =
+        $Text.Substring(0, $SectionMatch.Index) + $UpdatedSection +
+        $Text.Substring($SectionMatch.Index + $SectionText.Length)
+  } else {
+    $Text = $Text.TrimEnd("`r", "`n") + "`r`n`r`n[$Section]`r`n$NewLine`r`n"
+  }
+
+  [System.IO.File]::WriteAllBytes($Path, $Encoding.GetBytes($Text))
+}
+
+function Get-IniValue {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Section,
+    [Parameter(Mandatory = $true)][string]$Key
+  )
+
+  $InSection = $false
+  foreach ($Line in [System.IO.File]::ReadLines($Path)) {
+    if ($Line -match "^\s*\[(.+)\]\s*$") {
+      $InSection = $Matches[1] -eq $Section
+      continue
+    }
+    if ($InSection -and $Line -match "^\s*$([regex]::Escape($Key))\s*=\s*(.+)\s*$") {
+      return $Matches[1]
+    }
+  }
+  return $null
+}
+
+Write-Host "Stopping Deskflow processes from $BinPath"
+$ProcessNames = @("deskflow", "deskflow-core", "deskflow-daemon")
+$BinPathFull = [System.IO.Path]::GetFullPath($BinPath).TrimEnd("\", "/")
+$ProcessDetails = @{}
+Get-CimInstance Win32_Process | Where-Object {
+  $ProcessNames -contains [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
+} | ForEach-Object {
+  $ProcessDetails[[int]$_.ProcessId] = $_
+}
+
+Get-Process -Name $ProcessNames -ErrorAction SilentlyContinue | ForEach-Object {
+  $Process = $_
+  $Details = $ProcessDetails[[int]$Process.Id]
+  $Candidates = @()
+
+  try {
+    if ($Process.Path) {
+      $Candidates += $Process.Path
+    }
+  } catch {
+  }
+
+  if ($Details) {
+    if ($Details.ExecutablePath) {
+      $Candidates += $Details.ExecutablePath
+    }
+    if ($Details.CommandLine) {
+      $Candidates += $Details.CommandLine
+    }
+  }
+
+  if ($Process.MainWindowTitle) {
+    $Candidates += $Process.MainWindowTitle
+  }
+
+  $IsFromBuildBin = $false
+  foreach ($Candidate in $Candidates) {
+    if ($Candidate.IndexOf($BinPathFull, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+      $IsFromBuildBin = $true
+      break
+    }
+  }
+
+  if ($IsFromBuildBin -or $StopAll) {
+    Write-Host "Stopping $($Process.ProcessName) [$($Process.Id)]"
+    try {
+      Stop-Process -Id $Process.Id -Force
+    } catch {
+      throw "Failed to stop $($Process.ProcessName) [$($Process.Id)]. Run this script from an elevated PowerShell, or use -StopAll and accept the UAC prompt. $($_.Exception.Message)"
+    }
+  } elseif ($Candidates.Count -eq 0) {
+    Write-Warning "Leaving $($Process.ProcessName) [$($Process.Id)] running because its path is not accessible. Use -StopAll to stop every Deskflow process."
+  }
+}
+
+$Targets = @($BuildTarget)
+if (-not $NoDaemon -and $BuildTarget -ne "deskflow-daemon") {
+  $Targets += "deskflow-daemon"
+}
+if (($BuildGui -or -not $NoGuiBuild) -and $BuildTarget -ne "deskflow") {
+  $Targets += "deskflow"
+}
+
+foreach ($Target in $Targets) {
+  Write-Host "Building $Target"
+  $Command = "call `"$VsDevCmd`" -arch=x64 -host_arch=x64 && `"$CMakeExe`" --build `"$BuildPath`" --target $Target"
+  & cmd.exe /d /s /c $Command
+  if ($LASTEXITCODE -ne 0) {
+    throw "Build failed for target: $Target"
+  }
+}
+
+$SettingsDir = Join-Path $env:APPDATA $AppName
+$SettingsFile = Join-Path $SettingsDir "$AppName.conf"
+$PortableSettingsFile = Join-Path $BinPath "settings/$AppName.conf"
+if (Test-Path $PortableSettingsFile) {
+  $SettingsFile = $PortableSettingsFile
+  $SettingsDir = Split-Path -Parent $SettingsFile
+}
+
+New-Item -ItemType Directory -Path $SettingsDir -Force | Out-Null
+if (-not (Test-Path $SettingsFile)) {
+  New-Item -ItemType File -Path $SettingsFile -Force | Out-Null
+}
+
+if ($NoCore) {
+  Write-Host "Disabling GUI core auto-start in $SettingsFile"
+  Set-AsciiIniValueBytes -Path $SettingsFile -Section "gui" -Key "startCoreWithGui" -Value "false"
+} elseif ($DirectCore) {
+  Write-Host "Disabling GUI core auto-start in $SettingsFile"
+  Set-AsciiIniValueBytes -Path $SettingsFile -Section "gui" -Key "startCoreWithGui" -Value "false"
+} else {
+  Write-Host "Enabling GUI core auto-start in $SettingsFile"
+  Set-AsciiIniValueBytes -Path $SettingsFile -Section "gui" -Key "startCoreWithGui" -Value "true"
+}
+
+if (-not $NoDaemon) {
+  $DaemonExe = Join-Path $BinPath "deskflow-daemon.exe"
+  if (-not (Test-Path $DaemonExe)) {
+    throw "deskflow-daemon.exe not found: $DaemonExe"
+  }
+
+  Write-Host "Starting foreground daemon: $DaemonExe -f"
+  Start-Process -FilePath $DaemonExe -ArgumentList "-f" -WorkingDirectory $BinPath -WindowStyle Hidden
+  Start-Sleep -Seconds 1
+}
+
+if ($DirectCore -and -not $NoCore) {
+  $CoreExe = Join-Path $BinPath "deskflow-core.exe"
+  if (-not (Test-Path $CoreExe)) {
+    throw "deskflow-core.exe not found: $CoreExe"
+  }
+
+  $CoreModeValue = Get-IniValue -Path $SettingsFile -Section "core" -Key "coreMode"
+  if ($CoreModeValue -eq "1") {
+    $CoreMode = "client"
+  } elseif ($CoreModeValue -eq "2") {
+    $CoreMode = "server"
+  } else {
+    throw "core/coreMode must be 1 (client) or 2 (server), got: $CoreModeValue"
+  }
+
+  Write-Host "Starting core: $CoreExe $CoreMode --settings $SettingsFile"
+  Start-Process -FilePath $CoreExe -ArgumentList @($CoreMode, "--settings", $SettingsFile) -WorkingDirectory $BinPath -WindowStyle Hidden
+  Start-Sleep -Seconds 1
+}
+
+$DeskflowExe = Join-Path $BinPath "deskflow.exe"
+if (-not (Test-Path $DeskflowExe)) {
+  throw "deskflow.exe not found: $DeskflowExe"
+}
+
+Write-Host "Starting $DeskflowExe"
+Start-Process -FilePath $DeskflowExe -WorkingDirectory $BinPath


### PR DESCRIPTION
## Summary
- Add physical screen layout mapping support for server transitions
- Hide and restore the Windows cursor when moving off the primary screen
- Add a development restart helper for Deskflow processes
- Harden clipboard ownership handling so stale or mismatched clipboard updates are ignored instead of asserting
- Restore Windows cursor visibility during the development restart flow

## Root Cause
Rapid screen transitions can reorder clipboard owner and clipboard data events. A delayed clipboard update from a previous owner could reach the server after ownership had already changed, which hit an ownership assertion. Entering secondary screens at the reciprocal edge could also immediately trigger a switch back at the boundary.

## Impact
The server now accepts clipboard data only from the current clipboard owner, ignores stale sequence numbers, and avoids immediate edge bounce when entering secondary screens. The restart helper also recovers Windows cursor visibility after forced termination.

## Validation
- `git diff --check HEAD~1..HEAD`
- `cmake --build build/windows-debug-vcpkg --target server`
- `tools/restart-deskflow-dev.ps1 -NoGuiBuild`
- Checked recent daemon logs for assertion, crash, and clipboard ignore patterns

## Notes
The current local build cache has `BUILD_TESTS=OFF`, so unit tests were not available in this build directory.