### PR TITLE
Replace stale same-named client on reconnect instead of rejecting with EBusy

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -242,10 +242,27 @@ void Server::adoptClient(BaseClientProxy *client)
 
   // add client to client list
   if (!addClient(client)) {
-    // can only have one screen with a given name at any given time
-    LOG_WARN("a client with name \"%s\" is already connected", getName(client).c_str());
-    closeClient(client, kMsgEBusy);
-    return;
+    // A client with this name is already connected. This is almost always a
+    // stale/half-open connection left behind when the previous client dropped
+    // ungracefully (display sleep, network blip, OOM): the dead client keeps
+    // holding the screen name and there is no keepalive to reap it, so the real
+    // client could never reconnect until the server was restarted. Instead,
+    // disconnect the existing client and let the new one take over.
+    const std::string name = getName(client);
+    BaseClientProxy *stale = nullptr;
+    if (auto it = m_clients.find(name); it != m_clients.end()) {
+      stale = it->second;
+    }
+    if (stale != nullptr && stale != client && stale != m_primaryClient) {
+      LOG_WARN("client \"%s\" already connected; replacing stale connection", name.c_str());
+      closeClient(stale, kMsgCClose);
+    }
+    if (!addClient(client)) {
+      // could not free the name (e.g. it is the primary screen) -- give up
+      LOG_WARN("a client with name \"%s\" is already connected", name.c_str());
+      closeClient(client, kMsgEBusy);
+      return;
+    }
   }
   LOG_DEBUG("client \"%s\" has connected", getName(client).c_str());
   ipcSendConnectionState(deskflow::core::ConnectionState::Connected);


### PR DESCRIPTION
## Description

When a client connects with a screen name that is already present in `m_clients`, `Server::adoptClient()` rejects the **new** connection with `kMsgEBusy` ("a client with name … is already connected") and keeps the existing one.

The problem is that the existing connection is very often a **stale / half-open** one: the previous client dropped *ungracefully* — the client machine's display went to sleep, a network blip, an OOM stall, etc. — so no clean disconnect (FIN/RST) ever reached the server. There is no application-level keepalive that reaps such a dead client, and the TCP socket lingers for the system keepalive default (hours). As a result the dead client **holds the screen name indefinitely**, and the real client can never reconnect — every attempt is refused with EBusy — until the **server is restarted**.

This is a frequent, very confusing failure: the client just reports "connection failed" forever after the laptop/monitor sleeps overnight, even though the network and TLS are fine.

### Change

In `adoptClient()`, when `addClient()` fails because the name is taken, disconnect the existing client through the normal `closeClient()` teardown (which removes it from `m_clients`, installs the close-timeout timer, and jumps off it if it was the active screen) and then let the new client take over. Safeguards:

- The **primary screen is never replaced** (`stale != m_primaryClient`).
- If the name still cannot be freed, the original `kMsgEBusy` rejection is kept as a fallback.

This is the standard "new connection wins" behaviour. The only behaviour change for a *live* duplicate is that the newcomer now takes over instead of being rejected — but two live clients sharing one screen name is already a misconfiguration (names must be unique in the server config), whereas the stale-reconnect case is the common real-world one.

## Disclosure of AI use

This change was written with AI assistance (Claude / Claude Code): the root cause was diagnosed and the patch drafted with the tool, then reviewed against the surrounding `Server` teardown logic (`closeClient`, `removeClient`, `handleClientCloseTimeout`) by a human before submitting.

## Related Issue

Related to the "cannot reconnect after the client dropped/slept" class of reports, e.g. #9639 and #8263. Not marked as `fixes` because those reports cover broader scenarios; this PR addresses the specific stale-same-name-blocks-reconnect mechanism.

## How Has This Been Tested?

- Built `deskflow-core` (tag v1.26.0, the same change applies cleanly to `master`) on Fedora 42 (GCC, CMake, Qt6) and ran it as the server.
- Real-world reproduction on an X11 server (Linux) with a Windows client: after the client dropped ungracefully (monitor sleep), `ss` showed a stale `ESTAB` to the client and every reconnect was refused with "a client with name … is already connected" until the server was restarted. With this change the reconnecting client takes over the stale slot and the session re-establishes without a server restart.
- No automated test added yet — happy to add a `ServerTests` case for the duplicate-name takeover if maintainers prefer.
