### PR TITLE
fix(macos): honor locally-held modifier keys on synthetic mouse events

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -107,6 +107,14 @@ private:
   bool updateScreenShape(const CGDirectDisplayID, const CGDisplayChangeSummaryFlags);
   void postMouseEvent(CGPoint &) const;
 
+  /**
+   * @brief Modifier flags to apply to synthetic mouse events.
+   *
+   * Combines the server-tracked modifier state with the live session-wide
+   * modifier state.
+   */
+  CGEventFlags getModifiers() const;
+
   // convenience function to send events
   void sendEvent(EventTypes type, void * = nullptr) const;
   void sendClipboardEvent(EventTypes type, ClipboardID id) const;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -466,9 +466,7 @@ void OSXScreen::postMouseEvent(CGPoint &pos) const
   // Dragging events also need the click state
   CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
 
-  // Fix for sticky keys
-  CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
-  CGEventSetFlags(event, modifiers);
+  CGEventSetFlags(event, getModifiers());
 
   // Set movement deltas to fix issues with certain 3D programs
   SInt64 deltaX = pos.x;
@@ -489,6 +487,14 @@ void OSXScreen::postMouseEvent(CGPoint &pos) const
   CGEventPost(kCGHIDEventTap, event);
 
   CFRelease(event);
+}
+
+CGEventFlags OSXScreen::getModifiers() const
+{
+  // Fix for sticky keys
+  CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
+  modifiers |= CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
+  return modifiers;
 }
 
 void OSXScreen::fakeMouseButton(ButtonID id, bool press)
@@ -549,9 +555,7 @@ void OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
   CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
 
-  // Fix for sticky keys
-  CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
-  CGEventSetFlags(event, modifiers);
+  CGEventSetFlags(event, getModifiers());
 
   m_buttonState.set(index, state);
   CGEventPost(kCGHIDEventTap, event);
@@ -609,9 +613,7 @@ void OSXScreen::fakeMouseWheel(ScrollDelta delta) const
     // is the right choice here over kCGScrollEventUnitPixel
     CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitLine, 2, delta.y, delta.x);
 
-    // Fix for sticky keys
-    CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
-    CGEventSetFlags(scrollEvent, modifiers);
+    CGEventSetFlags(scrollEvent, getModifiers());
 
     CGEventPost(kCGHIDEventTap, scrollEvent);
     CFRelease(scrollEvent);


### PR DESCRIPTION
## Description

When a Mac runs as a client and only the mouse is shared from the server (e.g. a Windows server + a local Mac keyboard), modifier keys held on the local Mac keyboard are ignored on clicks coming from the shared mouse. Shift/Command-click multi-selection (Finder, lists, text) only work if the modifier was held on the server's keyboard.

The fix is to OR in the live, session-wide modifier state alongside the server-tracked flags.

## AI tools used for this PR
Claude Code using Opus 4.8

## Fixed/related issues
Fixes: #8682 

## How has this been tested?
I did a local MacOS build and tested that this change works as expected.  I tested both using the PC keyboard and Mac keyboard to make sure existing behavior is working.   Holding down shift or command on the local Mac Keyboard while using the mouse results in the expected results.