### PR TITLE
Mv grid info outof server config

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -144,6 +144,7 @@ This section contains options used when in server mode it will begin with `[serv
 |:-------------------|:-----------------:|:-----------|
 | externalConfig     | `true` or `false` | When true use the external config path |
 | externalConfigFile | Filepath          | Path the server config file if it does not exist the GUI will it generated based on the `internalConfig` section.|
+| gridHeight         | int               | Height of the server's intenal grid used for the computer layout (default: 3)|
 | gridWidth          | int               | Width of the server's intenal grid used for the computer layout (default: 5) |
 | protocol           | `barrier` or `synergy` | The protocol to use when saying hello to clients. Can be set to barrier or synergy. If not set barrier is used as the default |
 | xdpRestoreToken   | UUID               | Restore token provided by XDG portals |

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -144,6 +144,7 @@ This section contains options used when in server mode it will begin with `[serv
 |:-------------------|:-----------------:|:-----------|
 | externalConfig     | `true` or `false` | When true use the external config path |
 | externalConfigFile | Filepath          | Path the server config file if it does not exist the GUI will it generated based on the `internalConfig` section.|
+| gridWidth          | int               | Width of the server's intenal grid used for the computer layout (default: 5) |
 | protocol           | `barrier` or `synergy` | The protocol to use when saying hello to clients. Can be set to barrier or synergy. If not set barrier is used as the default |
 | xdpRestoreToken   | UUID               | Restore token provided by XDG portals |
 

--- a/src/lib/common/Constants.h.in
+++ b/src/lib/common/Constants.h.in
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2024 - 2025 Chris Rizzitello <sithlord48@gmail.com>
+ * SPDX-FileCopyrightText: (C) 2024 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -22,6 +22,8 @@ const auto kCopyright = //
 
 const auto kCoreBinName = "@CORE_BINARY@";
 const auto kCoreIpcName = "@CMAKE_PROJECT_NAME@-core";
+
+const auto kServerGridWidth = 5;
 
 #ifdef _WIN32
 

--- a/src/lib/common/Constants.h.in
+++ b/src/lib/common/Constants.h.in
@@ -23,6 +23,7 @@ const auto kCopyright = //
 const auto kCoreBinName = "@CORE_BINARY@";
 const auto kCoreIpcName = "@CMAKE_PROJECT_NAME@-core";
 
+const auto kServerGridHeight = 3;
 const auto kServerGridWidth = 5;
 
 #ifdef _WIN32

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -213,6 +213,9 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Server::GridWidth)
     return kServerGridWidth;
 
+  if (key == Server::GridHeight)
+    return kServerGridHeight;
+
   return QVariant();
 }
 

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -111,7 +111,7 @@ void Settings::cleanSettings()
 {
   const QStringList keys = m_settings->allKeys();
   for (const QString &key : keys) {
-    if (key.startsWith(QStringLiteral("internalConfig/protocol")))
+    if (m_oldServerConfigKeys.contains(key))
       m_settings->remove(key);
     if (key.startsWith(QStringLiteral("internalConfig")))
       continue;
@@ -209,6 +209,9 @@ QVariant Settings::defaultValue(const QString &key)
 
   if (key == Server::Protocol)
     return QVariant::fromValue(NetworkProtocol::Barrier);
+
+  if (key == Server::GridWidth)
+    return kServerGridWidth;
 
   return QVariant();
 }

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -105,6 +105,7 @@ public:
   {
     inline static const auto ExternalConfig = QStringLiteral("server/externalConfig");
     inline static const auto ExternalConfigFile = QStringLiteral("server/externalConfigFile");
+    inline static const auto GridHeight = QStringLiteral("server/gridHeight");
     inline static const auto GridWidth = QStringLiteral("server/gridWidth");
     inline static const auto Protocol = QStringLiteral("server/protocol");
     inline static const auto XdpRestoreToken = QStringLiteral("server/xdpRestoreToken");
@@ -242,6 +243,7 @@ private:
     , Settings::Security::TlsEnabled
     , Settings::Server::ExternalConfig
     , Settings::Server::ExternalConfigFile
+    , Settings::Server::GridHeight
     , Settings::Server::GridWidth
     , Settings::Server::Protocol
     , Settings::Server::XdpRestoreToken
@@ -291,6 +293,7 @@ private:
   inline static const QStringList m_oldServerConfigKeys = {
       QStringLiteral("internalConfig/protocol")
     , QStringLiteral("internalConfig/numColumns")
+    , QStringLiteral("internalConfig/numRows")
   };
   // clang-format on
 };

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -105,6 +105,7 @@ public:
   {
     inline static const auto ExternalConfig = QStringLiteral("server/externalConfig");
     inline static const auto ExternalConfigFile = QStringLiteral("server/externalConfigFile");
+    inline static const auto GridWidth = QStringLiteral("server/gridWidth");
     inline static const auto Protocol = QStringLiteral("server/protocol");
     inline static const auto XdpRestoreToken = QStringLiteral("server/xdpRestoreToken");
   };
@@ -241,6 +242,7 @@ private:
     , Settings::Security::TlsEnabled
     , Settings::Server::ExternalConfig
     , Settings::Server::ExternalConfigFile
+    , Settings::Server::GridWidth
     , Settings::Server::Protocol
     , Settings::Server::XdpRestoreToken
   };
@@ -284,6 +286,11 @@ private:
   inline static const QMap<QString, QString> m_upgradedMap = {
     /*             OLD KEY                        NEW KEY          */
     {QStringLiteral("core/screenName"), Settings::Core::ComputerName}
+  };
+  // Contains settings removed from server-configuration file
+  inline static const QStringList m_oldServerConfigKeys = {
+      QStringLiteral("internalConfig/protocol")
+    , QStringLiteral("internalConfig/numColumns")
   };
   // clang-format on
 };

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -102,8 +102,6 @@ void ServerConfig::commit()
   settings().beginGroup("internalConfig");
   settings().remove("");
 
-  settings().setValue("numRows", numRows());
-
   settings().setValue("hasHeartbeat", hasHeartbeat());
   settings().setValue("heartbeat", heartbeat());
   settings().setValue("relativeMouseMoves", relativeMouseMoves());
@@ -149,7 +147,7 @@ void ServerConfig::recall()
   settings().beginGroup("internalConfig");
 
   setNumColumns(Settings::value(Settings::Server::GridWidth).toInt());
-  setNumRows(settings().value("numRows", 3).toInt());
+  setNumRows(Settings::value(Settings::Server::GridHeight).toInt());
 
   // we need to know the number of columns and rows before we can set up
   // ourselves

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -33,7 +33,7 @@ static const struct
 
 const int serverDefaultIndex = 7;
 
-ServerConfig::ServerConfig(int columns, int rows) : m_Screens(columns), m_Columns(columns), m_Rows(rows)
+ServerConfig::ServerConfig(int columns, int rows) : m_Screens(columns), m_columns(columns), m_rows(rows)
 {
   recall();
 }
@@ -53,8 +53,6 @@ bool ServerConfig::save(const QString &fileName) const
 bool ServerConfig::operator==(const ServerConfig &sc) const
 {
   return m_Screens == sc.m_Screens &&                                   //
-         m_Columns == sc.m_Columns &&                                   //
-         m_Rows == sc.m_Rows &&                                         //
          m_HasHeartbeat == sc.m_HasHeartbeat &&                         //
          m_Heartbeat == sc.m_Heartbeat &&                               //
          m_Protocol == sc.m_Protocol &&                                 //
@@ -91,7 +89,7 @@ void ServerConfig::setupScreens()
 
   // There must always be screen objects for each cell in the screens QList.
   // Unused screens are identified by having an empty name.
-  for (int i = 0; i < numColumns() * numRows(); i++)
+  for (int i = 0; i < m_columns * m_rows; i++)
     addScreen(Screen());
 }
 
@@ -146,8 +144,8 @@ void ServerConfig::recall()
 
   settings().beginGroup("internalConfig");
 
-  setNumColumns(Settings::value(Settings::Server::GridWidth).toInt());
-  setNumRows(Settings::value(Settings::Server::GridHeight).toInt());
+  m_columns = Settings::value(Settings::Server::GridWidth).toInt();
+  m_rows = Settings::value(Settings::Server::GridHeight).toInt();
 
   // we need to know the number of columns and rows before we can set up
   // ourselves
@@ -202,10 +200,10 @@ int ServerConfig::adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) co
 
   // if we're at the left or right end of the table, don't find results going
   // further left or right
-  if ((deltaColumn > 0 && (idx + 1) % numColumns() == 0) || (deltaColumn < 0 && idx % numColumns() == 0))
+  if ((deltaColumn > 0 && (idx + 1) % m_columns == 0) || (deltaColumn < 0 && idx % m_columns == 0))
     return -1;
 
-  int arrayPos = idx + deltaColumn + deltaRow * numColumns();
+  int arrayPos = idx + deltaColumn + deltaRow * m_columns;
 
   if (arrayPos >= screens().size() || arrayPos < 0)
     return -1;

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -102,7 +102,6 @@ void ServerConfig::commit()
   settings().beginGroup("internalConfig");
   settings().remove("");
 
-  settings().setValue("numColumns", numColumns());
   settings().setValue("numRows", numRows());
 
   settings().setValue("hasHeartbeat", hasHeartbeat());
@@ -149,7 +148,7 @@ void ServerConfig::recall()
 
   settings().beginGroup("internalConfig");
 
-  setNumColumns(settings().value("numColumns", 5).toInt());
+  setNumColumns(Settings::value(Settings::Server::GridWidth).toInt());
   setNumRows(settings().value("numRows", 3).toInt());
 
   // we need to know the number of columns and rows before we can set up

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -15,8 +15,6 @@
 
 #include <QList>
 
-const auto kDefaultRows = 3;
-
 class QTextStream;
 class QSettings;
 class QString;
@@ -36,7 +34,7 @@ class ServerConfig : public ScreenConfig
   friend QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);
 
 public:
-  explicit ServerConfig(int columns = kServerGridWidth, int rows = kDefaultRows);
+  explicit ServerConfig(int columns = kServerGridWidth, int rows = kServerGridHeight);
   ~ServerConfig() = default;
 
   bool operator==(const ServerConfig &sc) const;

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -47,14 +47,6 @@ public:
   //
   // New methods
   //
-  int numColumns() const
-  {
-    return m_Columns;
-  }
-  int numRows() const
-  {
-    return m_Rows;
-  }
   bool hasHeartbeat() const
   {
     return m_HasHeartbeat;
@@ -153,14 +145,6 @@ private:
   {
     m_Screens.append(screen);
   }
-  void setNumColumns(int n)
-  {
-    m_Columns = n;
-  }
-  void setNumRows(int n)
-  {
-    m_Rows = n;
-  }
   void haveHeartbeat(bool on)
   {
     m_HasHeartbeat = on;
@@ -251,8 +235,8 @@ private:
   HotkeyList m_Hotkeys;
 
   ScreenList m_Screens;
-  int m_Columns;
-  int m_Rows;
+  int m_columns;
+  int m_rows;
   size_t m_ClipboardSharingSize = defaultClipboardSharingSize();
 };
 

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "common/Constants.h"
 #include "common/NetworkProtocol.h"
 #include "gui/Hotkey.h"
 #include "gui/config/ScreenConfig.h"
@@ -14,7 +15,6 @@
 
 #include <QList>
 
-const auto kDefaultColumns = 5;
 const auto kDefaultRows = 3;
 
 class QTextStream;
@@ -36,7 +36,7 @@ class ServerConfig : public ScreenConfig
   friend QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);
 
 public:
-  explicit ServerConfig(int columns = kDefaultColumns, int rows = kDefaultRows);
+  explicit ServerConfig(int columns = kServerGridWidth, int rows = kDefaultRows);
   ~ServerConfig() = default;
 
   bool operator==(const ServerConfig &sc) const;

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -25,11 +25,13 @@ using enum ScreenConfig::SwitchCorner;
 ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
       ui{std::make_unique<Ui::ServerConfigDialog>()},
+      m_columns{Settings::value(Settings::Server::GridWidth).toInt()},
+      m_rows{Settings::value(Settings::Server::GridHeight).toInt()},
       m_originalServerConfig(config),
       m_originalServerConfigIsExternal(config.useExternalConfig()),
       m_originalServerConfigUsesExternalFile(config.configFile()),
       m_serverConfig(config),
-      m_screenSetupModel(m_serverConfig.screens(), m_serverConfig.numColumns(), m_serverConfig.numRows())
+      m_screenSetupModel(m_serverConfig.screens(), m_columns, m_rows)
 {
   ui->setupUi(this);
 
@@ -164,7 +166,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   if (server == screens.end()) {
     Screen serverScreen(serverConfig().getServerName());
     serverScreen.markAsServer();
-    model().screen(serverConfig().numColumns() / 2, serverConfig().numRows() / 2) = serverScreen;
+    model().screen(m_columns / 2, m_rows / 2) = serverScreen;
   } else {
     server->markAsServer();
   }

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -97,6 +97,8 @@ protected:
 private:
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";
+  int m_columns;
+  int m_rows;
   ServerConfig &m_originalServerConfig;
   NetworkProtocol m_originalProtocol;
   bool m_originalServerConfigIsExternal;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
  - Move the numRows and numColumns out of the server config and into the general one.
  - Remove access to public serverConfig::numColumns / serverConfig::numRows (use `Settings::value`)
  - Removes the old keys from the internalConfig and externalServerConfig
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Working towards a single settings file for options
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run locally 