### PR TITLE
Cleanup protocol remnents

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -208,7 +208,7 @@ QVariant Settings::defaultValue(const QString &key)
     return 1.0;
 
   if (key == Server::Protocol)
-    return QVariant::fromValue(NetworkProtocol::Barrier);
+    return networkProtocolToOption(NetworkProtocol::Barrier);
 
   if (key == Server::GridWidth)
     return kServerGridWidth;
@@ -222,6 +222,11 @@ QVariant Settings::defaultValue(const QString &key)
 QSettingsProxy &Settings::proxy()
 {
   return *instance()->m_settingsProxy;
+}
+
+NetworkProtocol Settings::networkProtocol()
+{
+  return networkProtocolFromString(Settings::value(Server::Protocol).toString());
 }
 
 void Settings::save(bool emitSaving)

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -12,6 +12,7 @@
 #include <QDir>
 
 #include "common/Constants.h"
+#include "common/NetworkProtocol.h"
 #include "common/QSettingsProxy.h"
 
 class Settings : public QObject
@@ -151,6 +152,7 @@ public:
   static QString tlsTrustedClientsDb();
   static QString logLevelText();
   static QSettingsProxy &proxy();
+  static NetworkProtocol networkProtocol();
   static void save(bool emitSaving = true);
   static QStringList validKeys();
   static QString portableSettingsFile();

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -55,7 +55,6 @@ bool ServerConfig::operator==(const ServerConfig &sc) const
   return m_Screens == sc.m_Screens &&                                   //
          m_HasHeartbeat == sc.m_HasHeartbeat &&                         //
          m_Heartbeat == sc.m_Heartbeat &&                               //
-         m_Protocol == sc.m_Protocol &&                                 //
          m_RelativeMouseMoves == sc.m_RelativeMouseMoves &&             //
          m_Win32KeepForeground == sc.m_Win32KeepForeground &&           //
          m_HasSwitchDelay == sc.m_HasSwitchDelay &&                     //
@@ -153,7 +152,6 @@ void ServerConfig::recall()
 
   haveHeartbeat(settings().value("hasHeartbeat", false).toBool());
   setHeartbeat(settings().value("heartbeat", 5000).toInt());
-  setProtocol(Settings::value(Settings::Server::Protocol).value<NetworkProtocol>());
   setRelativeMouseMoves(settings().value("relativeMouseMoves", false).toBool());
   setWin32KeepForeground(settings().value("win32KeepForeground", false).toBool());
   haveSwitchDelay(settings().value("hasSwitchDelay", false).toBool());
@@ -251,10 +249,6 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
 
   if (config.hasHeartbeat())
     outStream << "\t" << "heartbeat = " << config.heartbeat() << Qt::endl;
-
-  if (config.protocol() == NetworkProtocol::Unknown)
-    qFatal("unrecognized protocol when writing config");
-  outStream << "\t" << "protocol = " << networkProtocolToOption(config.protocol()) << Qt::endl;
 
   outStream << "\t"
             << "relativeMouseMoves = " << (config.relativeMouseMoves() ? "true" : "false") << Qt::endl;

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -8,7 +9,6 @@
 #pragma once
 
 #include "common/Constants.h"
-#include "common/NetworkProtocol.h"
 #include "gui/Hotkey.h"
 #include "gui/config/ScreenConfig.h"
 #include "gui/config/ScreenList.h"
@@ -20,13 +20,6 @@ class QSettings;
 class QString;
 class QFile;
 class ServerConfigDialog;
-
-namespace deskflow::gui {
-
-// The default protocol was decided by a community vote.
-const auto kDefaultProtocol = NetworkProtocol::Barrier;
-
-} // namespace deskflow::gui
 
 class ServerConfig : public ScreenConfig
 {
@@ -54,10 +47,6 @@ public:
   int heartbeat() const
   {
     return m_Heartbeat;
-  }
-  NetworkProtocol protocol() const
-  {
-    return m_Protocol;
   }
   bool relativeMouseMoves() const
   {
@@ -153,10 +142,6 @@ private:
   {
     m_Heartbeat = val;
   }
-  void setProtocol(NetworkProtocol val)
-  {
-    m_Protocol = val;
-  }
   void setRelativeMouseMoves(bool on)
   {
     m_RelativeMouseMoves = on;
@@ -219,7 +204,6 @@ private:
 private:
   bool m_HasHeartbeat = false;
   int m_Heartbeat = 0;
-  NetworkProtocol m_Protocol = deskflow::gui::kDefaultProtocol;
   bool m_RelativeMouseMoves = false;
   bool m_Win32KeepForeground = false;
   bool m_HasSwitchDelay = false;

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -470,8 +470,10 @@ void ServerConfigDialog::toggleExternalConfig(bool checked)
   ui->widgetExternalConfigControls->setEnabled(checked);
   ui->tabWidget->setTabEnabled(0, !checked);
   ui->tabWidget->setTabEnabled(1, !checked);
-  ui->tabWidget->setTabEnabled(2, !checked);
-
+  ui->groupMisc->setEnabled(!checked);
+  ui->groupCorners->setEnabled(!checked);
+  ui->groupSwitch->setEnabled(!checked);
+  ui->widgetHeartbeat->setEnabled(!checked);
   serverConfig().setUseExternalConfig(checked);
   onChange();
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -70,8 +70,9 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->btnBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
   ui->lineConfigFile->setText(serverConfig().configFile());
 
-  ui->rbProtocolSynergy->setChecked(serverConfig().protocol() == NetworkProtocol::Synergy);
-  ui->rbProtocolBarrier->setChecked(serverConfig().protocol() == NetworkProtocol::Barrier);
+  const auto networkProtocol = networkProtocolFromString(Settings::value(Settings::Server::Protocol).toString());
+  ui->rbProtocolSynergy->setChecked(networkProtocol == NetworkProtocol::Synergy);
+  ui->rbProtocolBarrier->setChecked(networkProtocol == NetworkProtocol::Barrier);
   connect(ui->rbProtocolBarrier, &QRadioButton::toggled, this, &ServerConfigDialog::toggleProtocol);
 
   ui->cbHeartbeat->setChecked(serverConfig().hasHeartbeat());
@@ -368,7 +369,6 @@ void ServerConfigDialog::toggleRelativeMouseMoves(bool enabled)
 void ServerConfigDialog::toggleProtocol()
 {
   auto proto = ui->rbProtocolBarrier->isChecked() ? NetworkProtocol::Barrier : NetworkProtocol::Synergy;
-  serverConfig().setProtocol(proto);
   Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(proto));
   onChange();
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -35,7 +35,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
 {
   ui->setupUi(this);
 
-  m_originalProtocol = Settings::value(Settings::Server::Protocol).value<NetworkProtocol>();
+  m_protocol = Settings::networkProtocol();
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ServerConfigDialog::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ServerConfigDialog::reject);
 
@@ -70,7 +70,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->btnBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
   ui->lineConfigFile->setText(serverConfig().configFile());
 
-  const auto networkProtocol = networkProtocolFromString(Settings::value(Settings::Server::Protocol).toString());
+  const auto networkProtocol = Settings::networkProtocol();
   ui->rbProtocolSynergy->setChecked(networkProtocol == NetworkProtocol::Synergy);
   ui->rbProtocolBarrier->setChecked(networkProtocol == NetworkProtocol::Barrier);
   connect(ui->rbProtocolBarrier, &QRadioButton::toggled, this, &ServerConfigDialog::toggleProtocol);
@@ -201,6 +201,7 @@ void ServerConfigDialog::accept()
   // now that the dialog has been accepted, copy the new server config to the
   // original one, which is a reference to the one in MainWindow.
   setOriginalServerConfig(serverConfig());
+  Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(m_protocol));
 
   QDialog::accept();
 }
@@ -368,8 +369,7 @@ void ServerConfigDialog::toggleRelativeMouseMoves(bool enabled)
 
 void ServerConfigDialog::toggleProtocol()
 {
-  auto proto = ui->rbProtocolBarrier->isChecked() ? NetworkProtocol::Barrier : NetworkProtocol::Synergy;
-  Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(proto));
+  m_protocol = ui->rbProtocolBarrier->isChecked() ? NetworkProtocol::Barrier : NetworkProtocol::Synergy;
   onChange();
 }
 
@@ -511,10 +511,9 @@ bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
 
 void ServerConfigDialog::onChange()
 {
-  bool isAppConfigDataEqual =
-      m_originalServerConfigIsExternal == serverConfig().useExternalConfig() &&
-      m_originalServerConfigUsesExternalFile == serverConfig().configFile() &&
-      m_originalProtocol == Settings::value(Settings::Server::Protocol).value<NetworkProtocol>();
+  bool isAppConfigDataEqual = m_originalServerConfigIsExternal == serverConfig().useExternalConfig() &&
+                              m_originalServerConfigUsesExternalFile == serverConfig().configFile() &&
+                              m_protocol == Settings::networkProtocol();
   ui->buttonBox->button(QDialogButtonBox::Ok)
       ->setEnabled(!isAppConfigDataEqual || !(m_originalServerConfig == m_serverConfig));
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ScreenSetupModel.h"
+#include "common/NetworkProtocol.h"
 #include "config/ServerConfig.h"
 
 #include <QDialog>

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -101,7 +101,7 @@ private:
   int m_columns;
   int m_rows;
   ServerConfig &m_originalServerConfig;
-  NetworkProtocol m_originalProtocol;
+  NetworkProtocol m_protocol;
   bool m_originalServerConfigIsExternal;
   QString m_originalServerConfigUsesExternalFile;
   ServerConfig m_serverConfig;

--- a/src/lib/gui/dialogs/ServerConfigDialog.ui
+++ b/src/lib/gui/dialogs/ServerConfigDialog.ui
@@ -546,68 +546,70 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
-           <layout class="QHBoxLayout" name="_4">
-            <property name="spacing">
-             <number>9</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QCheckBox" name="cbHeartbeat">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="whatsThis">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the network heartbeat to ping clients every &lt;span style=&quot; font-style:italic;&quot;&gt;n&lt;/span&gt; seconds. This may help to diagnose network problems by retrying the connection if the client becomes unresponsive.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>&amp;Check clients every</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="spacerNetwork">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="sbHeartbeat">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="suffix">
-               <string>ms</string>
-              </property>
-              <property name="minimum">
-               <number>1000</number>
-              </property>
-              <property name="maximum">
-               <number>30000</number>
-              </property>
-              <property name="singleStep">
-               <number>1000</number>
-              </property>
-              <property name="value">
-               <number>5000</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QWidget" name="widgetHeartbeat" native="true">
+            <layout class="QHBoxLayout" name="groupHeartbeat">
+             <property name="spacing">
+              <number>9</number>
+             </property>
+             <property name="leftMargin">
+              <number>1</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="cbHeartbeat">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="whatsThis">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the network heartbeat to ping clients every &lt;span style=&quot; font-style:italic;&quot;&gt;n&lt;/span&gt; seconds. This may help to diagnose network problems by retrying the connection if the client becomes unresponsive.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>&amp;Check clients every</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="spacerNetwork">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sbHeartbeat">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>ms</string>
+               </property>
+               <property name="minimum">
+                <number>1000</number>
+               </property>
+               <property name="maximum">
+                <number>30000</number>
+               </property>
+               <property name="singleStep">
+                <number>1000</number>
+               </property>
+               <property name="value">
+                <number>5000</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1130,7 +1130,7 @@ void Server::processOptions()
     stopRelativeMoves();
   }
   m_relativeMoves = newRelativeMoves;
-  m_protocol = Settings::value(Settings::Server::Protocol).value<NetworkProtocol>();
+  m_protocol = networkProtocolFromString(Settings::value(Settings::Server::Protocol).toString());
 }
 
 void Server::handleShapeChanged(BaseClientProxy *client)

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1130,7 +1130,7 @@ void Server::processOptions()
     stopRelativeMoves();
   }
   m_relativeMoves = newRelativeMoves;
-  m_protocol = networkProtocolFromString(Settings::value(Settings::Server::Protocol).toString());
+  m_protocol = Settings::networkProtocol();
 }
 
 void Server::handleShapeChanged(BaseClientProxy *client)


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Remove the protocol fully from the server config
 - Add a `Settings::networkProtocol()` method to make reading the set proto easier.
 - Allow users to set the protocol via server settings when external config is selected
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
I had an issue setting barrier as my protocol once i set it set synergy. To get it to reset i had to remove the setting key from the file
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run locally connected a client to be sure the protocol was changing as expected.