### PR TITLE
fix: remove ClipboardSending handler in proxy destructors (use-after-free)

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -55,6 +55,7 @@ ServerProxy::~ServerProxy()
 {
   setKeepAliveRate(-1.0);
   m_events->removeHandler(EventTypes::StreamInputReady, m_stream->getEventTarget());
+  m_events->removeHandler(EventTypes::ClipboardSending, this);
 }
 
 void ServerProxy::resetKeepAliveAlarm()

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -26,6 +26,11 @@ ClientProxy1_6::ClientProxy1_6(const std::string &name, deskflow::IStream *strea
   });
 }
 
+ClientProxy1_6::~ClientProxy1_6()
+{
+  m_events->removeHandler(EventTypes::ClipboardSending, this);
+}
+
 void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard *clipboard)
 {
   // ignore if this clipboard is already clean

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -16,7 +16,7 @@ class ClientProxy1_6 : public ClientProxy1_5
 {
 public:
   ClientProxy1_6(const std::string &name, deskflow::IStream *adoptedStream, Server *server, IEventQueue *events);
-  ~ClientProxy1_6() override = default;
+  ~ClientProxy1_6() override;
 
   void setClipboard(ClipboardID id, const IClipboard *clipboard) override;
   bool recvClipboard() override;


### PR DESCRIPTION
## Description

`ServerProxy` (client side) and `ClientProxy1_6` (server side) each register an
`EventTypes::ClipboardSending` handler bound to `this` in their constructors, but
neither destructor removes it:

- `ServerProxy::~ServerProxy()` removed only `StreamInputReady`.
- `ClientProxy1_6` used a defaulted destructor (`~ClientProxy1_6() override = default;`) that removed nothing.

If a `ClipboardSending` event is still queued when the proxy is destroyed — e.g. a
reconnect/teardown racing an in-flight clipboard transfer — the event loop later
dispatches the handler against the freed proxy. The captured `this` is dangling;
reading `m_stream` off freed memory yields garbage and the subsequent virtual
`IStream::write` call faults.

Observed in the field on macOS (Apple Silicon) as `EXC_BAD_ACCESS` /
`KERN_INVALID_ADDRESS` in `ClipboardChunk::send` → `ProtocolUtil::vwritef`, most
reproducibly when copying a large image (multi-MB pasteboard data is split into
several `ClipboardSending` chunk events, widening the race window) over an
unstable link. The faulting `IStream*` was the small value `0x20`, i.e. a field
read from the freed proxy rather than a valid stream pointer.

The fix removes the `ClipboardSending` handler in both destructors so it can no
longer fire after the proxy is gone, mirroring each constructor's registration.

## AI tools used for this PR

Claude (Anthropic, Opus 4.8) was used, operated by the repository owner, to:
symbolicate the crash reports, locate the constructor/destructor mismatch in the
source, author the one-line-per-class fix, and draft this PR and the linked issue.
All changes were reviewed by a human before submission.

## Fixed/related issues

fixes: #9842

## How has this been tested?

- Environment: macOS 15.7.8 (Darwin 24.6.0), Apple Silicon (M3), Qt 6.11.1, OpenSSL 3.6.2, CMake/Ninja Release build.
- `deskflow-core` builds cleanly with the change; both modified translation units (`ServerProxy.cpp`, `ClientProxy1_6.cpp`) compile, binary links and runs (`deskflow-core version` reports the patched commit).
- Runtime smoke: client mode boots, reads config, starts, retries connection and shuts down cleanly with no crash / no crash report.
- The fix itself is verified by inspection: each constructor's `addHandler(EventTypes::ClipboardSending, this, …)` now has a matching `removeHandler(EventTypes::ClipboardSending, this)` in the destructor. The original SIGSEGV is a teardown race (a `ClipboardSending` event dispatched after the proxy is freed), which is inherently non-deterministic to reproduce on demand; removing the handler at destruction makes the dangling dispatch impossible.

Maintainers: please confirm the `removeHandler` signature/target matches the registration in your event-queue API — happy to adjust if a different overload is preferred.

## Notes

This is distinct from the clipboard-too-large / unmarshal size-check work (receive
side); this is a handler-lifetime use-after-free on the send side, present in both
the client and server clipboard paths.
