### PR TITLE
feat: allow a screen to span multiple columns in the layout grid

### DIFF
--- a/src/lib/gui/ScreenSetupModel.cpp
+++ b/src/lib/gui/ScreenSetupModel.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -11,10 +12,49 @@
 #include <QIODevice>
 #include <QIcon>
 #include <QMimeData>
+#include <QSize>
+
+#include <cstddef>
+#include <vector>
 
 #include "gui/config/Screen.h"
 
 const QString ScreenSetupModel::m_MimeType = "application/x-deskflow-screen";
+
+namespace {
+
+// a layout is valid when every screen stays inside the grid and no two screens
+// claim the same cell. Occupancy has to be tracked across all screens, not
+// checked per-span: a wide screen and a tall screen can cross on a cell that is
+// a covered (raw-empty) cell of both, so a per-span "is this raw cell empty"
+// test would miss the overlap.
+bool isValidLayout(const ScreenList &screens, int numColumns)
+{
+  const int numRows = static_cast<int>(screens.size()) / numColumns;
+  std::vector<bool> occupied(static_cast<std::size_t>(numColumns) * numRows, false);
+  for (int i = 0; i < screens.size(); i++) {
+    const auto &screen = screens[i];
+    if (screen.isNull())
+      continue;
+
+    const int column = i % numColumns;
+    const int row = i / numColumns;
+    if (column + screen.width() > numColumns || row + screen.height() > numRows)
+      return false;
+
+    for (int r = row; r < row + screen.height(); r++) {
+      for (int c = column; c < column + screen.width(); c++) {
+        const std::size_t cell = static_cast<std::size_t>(r) * numColumns + c;
+        if (occupied[cell])
+          return false;
+        occupied[cell] = true;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace
 
 ScreenSetupModel::ScreenSetupModel(ScreenList &screens, int numColumns, int numRows)
     : QAbstractTableModel(nullptr),
@@ -52,11 +92,15 @@ QVariant ScreenSetupModel::data(const QModelIndex &index, int role) const
   case Qt::ToolTipRole:
     return QString(tr("<center>Screen: <b>%1</b></center>"
                       "<br>Double click to edit settings"
-                      "<br>Drag screen to the trashcan to remove it"))
+                      "<br>Drag screen to the trashcan to remove it"
+                      "<br>Drag the right or bottom edge to span more cells"))
         .arg(screen(index).name());
 
   case Qt::DisplayRole:
     return screen(index).name();
+
+  case SpanRole:
+    return QSize(screen(index).width(), screen(index).height());
 
   default:
     break;
@@ -124,6 +168,12 @@ bool ScreenSetupModel::dropMimeData(
   stream >> sourceColumn;
   stream >> sourceRow;
 
+  // the mime payload is external input, the source is either -1/-1 for a
+  // new screen or a cell inside the grid
+  const bool hasSource = sourceColumn != -1 || sourceRow != -1;
+  if (hasSource && (sourceColumn < 0 || sourceColumn >= m_NumColumns || sourceRow < 0 || sourceRow >= m_NumRows))
+    return false;
+
   const auto pColumn = parent.column();
   const auto pRow = parent.row();
 
@@ -134,14 +184,30 @@ bool ScreenSetupModel::dropMimeData(
   Screen droppedScreen;
   stream >> droppedScreen;
 
-  if (auto oldScreen = Screen(screen(pColumn, pRow)); !oldScreen.isNull() && sourceColumn != -1 && sourceRow != -1) {
-    // mark the screen so it isn't deleted after the dragndrop succeeded
-    // see ScreenSetupView::startDrag()
-    oldScreen.setSwapped(true);
-    screen(sourceColumn, sourceRow) = oldScreen;
+  // build the resulting layout and apply it atomically. The dropped screen
+  // takes the target as its new anchor; the moved screen's whole footprint is
+  // lifted first (via its anchor) so a spanning screen can shift by a single
+  // cell or into a corner -- targets that overlap its own previous cells. Any
+  // screen covering the target relocates onto the freed source anchor (a 1:1
+  // swap). The exact state is validated, so a rejected drop leaves the grid
+  // untouched.
+  const int targetIndex = pRow * m_NumColumns + pColumn;
+  ScreenList trial = m_Screens;
+  if (hasSource) {
+    const int sourceIndex = sourceRow * m_NumColumns + sourceColumn;
+    trial[sourceIndex] = Screen();
+    if (const int occupantIndex = m_Screens.screenIndexAt(pColumn, pRow);
+        occupantIndex != -1 && occupantIndex != sourceIndex) {
+      trial[occupantIndex] = Screen();
+      trial[sourceIndex] = m_Screens[occupantIndex];
+    }
   }
+  trial[targetIndex] = droppedScreen;
+  if (!isValidLayout(trial, m_NumColumns))
+    return false;
 
-  screen(pColumn, pRow) = droppedScreen;
+  m_Screens = trial;
+  m_dropHandled = true;
 
   Q_EMIT screensChanged();
 
@@ -154,8 +220,30 @@ void ScreenSetupModel::addScreen(const Screen &newScreen)
   Q_EMIT screensChanged();
 }
 
+bool ScreenSetupModel::trySetSpan(int column, int row, int width, int height)
+{
+  auto &target = screen(column, row);
+  if (target.isNull() || (width == target.width() && height == target.height()))
+    return false;
+
+  ScreenList trial = m_Screens;
+  auto &trialScreen = trial[row * m_NumColumns + column];
+  trialScreen.setWidth(width);
+  trialScreen.setHeight(height);
+  if (!isValidLayout(trial, m_NumColumns))
+    return false;
+
+  target.setWidth(width);
+  target.setHeight(height);
+  Q_EMIT screensChanged();
+  return true;
+}
+
 bool ScreenSetupModel::isFull() const
 {
-  auto emptyScreen = std::ranges::find_if(m_Screens, [](const Screen &item) { return item.isNull(); });
-  return (static_cast<QList<Screen>::const_iterator>(emptyScreen) == m_Screens.cend());
+  for (int i = 0; i < m_Screens.size(); i++) {
+    if (m_Screens.screenIndexAt(i % m_NumColumns, i / m_NumColumns) == -1)
+      return false;
+  }
+  return true;
 }

--- a/src/lib/gui/ScreenSetupModel.h
+++ b/src/lib/gui/ScreenSetupModel.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -25,6 +26,11 @@ class ScreenSetupModel : public QAbstractTableModel
   friend class ServerConfigDialog;
 
 public:
+  // QSize(width, height), in grid cells, of the screen at the index -- so a
+  // delegate can distinguish a 1x1 screen from a spanning one, and a wide span
+  // from a tall one, without reaching into the model
+  static constexpr int SpanRole = Qt::UserRole + 1;
+
   ScreenSetupModel(ScreenList &screens, int numColumns, int numRows);
 
   static const QString &mimeType()
@@ -54,6 +60,10 @@ public:
   QMimeData *mimeData(const QModelIndexList &indexes) const override;
   bool isFull() const;
 
+  //! Resize the screen anchored at the given cell, rejecting spans that
+  //! would leave the grid or cover an occupied cell
+  bool trySetSpan(int column, int row, int width, int height);
+
 Q_SIGNALS:
   void screensChanged();
 
@@ -82,6 +92,10 @@ private:
   ScreenList &m_Screens;
   const int m_NumColumns;
   const int m_NumRows;
+
+  // set by dropMimeData when it moves a screen within the grid, so startDrag
+  // knows the source was already handled and only a trash drop must clear it
+  bool m_dropHandled = false;
 
   static const QString m_MimeType;
 };

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -28,6 +29,8 @@ void Screen::loadSettings(QSettingsProxy &settings)
     return;
 
   setSwitchCornerSize(settings.value("switchCornerSize").toInt());
+  setWidth(settings.value("width", 1).toInt());
+  setHeight(settings.value("height", 1).toInt());
 
   readSettings(settings, modifiers(), "modifier", static_cast<int>(DefaultMod), static_cast<int>(NumModifiers));
   readSettings(settings, switchCorners(), "switchCorner", false, static_cast<int>(NumSwitchCorners));
@@ -48,6 +51,8 @@ void Screen::saveSettings(QSettingsProxy &settings) const
   Settings::setValue(Settings::Screen::Aliases.arg(screenName), m_Aliases);
 
   settings.setValue("switchCornerSize", switchCornerSize());
+  settings.setValue("width", width());
+  settings.setValue("height", height());
 
   writeSettings(settings, modifiers(), "modifier");
   writeSettings(settings, switchCorners(), "switchCorner");
@@ -83,5 +88,6 @@ bool Screen::operator==(const Screen &screen) const
 {
   return m_Name == screen.m_Name && m_Aliases == screen.m_Aliases && m_Modifiers == screen.m_Modifiers &&
          m_SwitchCorners == screen.m_SwitchCorners && m_SwitchCornerSize == screen.m_SwitchCornerSize &&
-         m_Fixes == screen.m_Fixes && m_Swapped == screen.m_Swapped && m_isServer == screen.m_isServer;
+         m_Fixes == screen.m_Fixes && m_isServer == screen.m_isServer && m_Width == screen.m_Width &&
+         m_Height == screen.m_Height;
 }

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -18,6 +19,8 @@
 #include <QString>
 #include <QStringList>
 
+#include <algorithm>
+
 class QSettings;
 class QTextStream;
 class ScreenSettingsDialog;
@@ -31,13 +34,14 @@ class Screen : public ScreenConfig
   friend QDataStream &operator<<(QDataStream &outStream, const Screen &screen)
   {
     return outStream << screen.name() << screen.switchCornerSize() << screen.aliases() << screen.modifiers()
-                     << screen.switchCorners() << screen.fixes() << screen.isServer();
+                     << screen.switchCorners() << screen.fixes() << screen.isServer() << screen.width()
+                     << screen.height();
   }
 
   friend QDataStream &operator>>(QDataStream &inStream, Screen &screen)
   {
     return inStream >> screen.m_Name >> screen.m_SwitchCornerSize >> screen.m_Aliases >> screen.m_Modifiers >>
-           screen.m_SwitchCorners >> screen.m_Fixes >> screen.m_isServer;
+           screen.m_SwitchCorners >> screen.m_Fixes >> screen.m_isServer >> screen.m_Width >> screen.m_Height;
   }
 
 public:
@@ -94,11 +98,6 @@ public:
   [[nodiscard]] QString screensSection() const;
   [[nodiscard]] QString aliasesSection() const;
 
-  [[nodiscard]] bool swapped() const
-  {
-    return m_Swapped;
-  }
-
   void setName(const QString &name)
   {
     m_Name = name;
@@ -110,6 +109,22 @@ public:
   void markAsServer()
   {
     m_isServer = true;
+  }
+  [[nodiscard]] int width() const
+  {
+    return m_Width;
+  }
+  void setWidth(const int width)
+  {
+    m_Width = std::max(width, 1);
+  }
+  [[nodiscard]] int height() const
+  {
+    return m_Height;
+  }
+  void setHeight(const int height)
+  {
+    m_Height = std::max(height, 1);
   }
 
   bool operator==(const Screen &screen) const;
@@ -151,10 +166,6 @@ protected:
   {
     return m_Fixes;
   }
-  void setSwapped(const bool on)
-  {
-    m_Swapped = on;
-  }
 
 private:
   QPixmap m_Pixmap = QIcon::fromTheme("video-display").pixmap(QSize(96, 96));
@@ -164,6 +175,7 @@ private:
   QList<bool> m_SwitchCorners = {false, false, false, false};
   int m_SwitchCornerSize = 0;
   QList<bool> m_Fixes{false, false, false, false};
-  bool m_Swapped = false;
   bool m_isServer = false;
+  int m_Width = 1;
+  int m_Height = 1;
 };

--- a/src/lib/gui/config/ScreenList.cpp
+++ b/src/lib/gui/config/ScreenList.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2021 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -79,9 +80,8 @@ void ScreenList::addScreenByPriority(const Screen &newScreen)
   bool isAdded = false;
   for (const auto &index : indexes) {
     if (index >= 0 && index < size()) {
-      auto &screen = operator[](index);
-      if (screen.isNull()) {
-        screen = newScreen;
+      if (screenIndexAt(index % m_width, index / m_width) == -1) {
+        operator[](index) = newScreen;
         isAdded = true;
         break;
       }
@@ -96,12 +96,30 @@ void ScreenList::addScreenByPriority(const Screen &newScreen)
 void ScreenList::addScreenToFirstEmpty(const Screen &newScreen)
 {
   for (int i = 0; i < size(); ++i) {
-    auto &screen = operator[](i);
-    if (screen.isNull()) {
-      screen = newScreen;
+    if (screenIndexAt(i % m_width, i / m_width) == -1) {
+      operator[](i) = newScreen;
       break;
     }
   }
+}
+
+int ScreenList::screenIndexAt(int column, int row) const
+{
+  if (column < 0 || column >= m_width || row < 0 || (static_cast<qsizetype>(row) + 1) * m_width > size())
+    return -1;
+
+  for (int i = 0; i < size(); ++i) {
+    const auto &screen = at(i);
+    if (screen.isNull())
+      continue;
+    const int anchorColumn = i % m_width;
+    const int anchorRow = i / m_width;
+    if (column >= anchorColumn && column < anchorColumn + screen.width() && row >= anchorRow &&
+        row < anchorRow + screen.height())
+      return i;
+  }
+
+  return -1;
 }
 
 bool ScreenList::operator==(const ScreenList &sc) const

--- a/src/lib/gui/config/ScreenList.h
+++ b/src/lib/gui/config/ScreenList.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2021 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -33,6 +34,12 @@ public:
    * @param newScreen
    */
   void addScreenToFirstEmpty(const Screen &newScreen);
+
+  /**
+   * @brief screenIndexAt returns the index of the screen covering the given
+   * cell, either anchored there or spanning over it, -1 if none
+   */
+  int screenIndexAt(int column, int row) const;
 
   /**
    * @brief Returns true if screens are equal

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -14,24 +15,21 @@
 #include <QAbstractButton>
 #include <QPushButton>
 
+#include <algorithm>
+
 using enum ScreenConfig::Modifier;
 using enum ScreenConfig::SwitchCorner;
 using enum ScreenConfig::Fix;
 
-static const struct
-{
-  int x;
-  int y;
-  const char *name;
-} neighbourDirs[] = {
-    {1, 0, "right"},
-    {-1, 0, "left"},
-    {0, -1, "up"},
-    {0, 1, "down"},
-
-};
-
 const int serverDefaultIndex = 7;
+
+// formats a link range as "(start,end)" percentages, omitted for a full edge
+static QString formatInterval(double start, double end)
+{
+  if (start == 0.0 && end == 1.0)
+    return {};
+  return QStringLiteral("(%1,%2)").arg(qRound(start * 100)).arg(qRound(end * 100));
+}
 
 ServerConfig::ServerConfig(int columns, int rows) : m_Screens(columns), m_columns(columns), m_rows(rows)
 {
@@ -126,6 +124,34 @@ void ServerConfig::recall()
   }
   settings().endArray();
 
+  // clamp spans that no longer fit the grid or would cover another screen
+  const int numRows = screens().size() / m_columns;
+  for (int i = 0; i < screens().size(); i++) {
+    auto &screen = screens()[i];
+    if (screen.isNull())
+      continue;
+    const int column = i % m_columns;
+    const int row = i / m_columns;
+
+    int maxWidth = m_columns - column;
+    for (int next = 1; next < maxWidth; next++) {
+      if (!screens()[i + next].isNull()) {
+        maxWidth = next;
+        break;
+      }
+    }
+    screen.setWidth(std::min(screen.width(), maxWidth));
+
+    int maxHeight = numRows - row;
+    for (int next = 1; next < maxHeight; next++) {
+      if (!screens()[i + next * m_columns].isNull()) {
+        maxHeight = next;
+        break;
+      }
+    }
+    screen.setHeight(std::min(screen.height(), maxHeight));
+  }
+
   int numHotkeys = settings().beginReadArray("hotkeys");
   for (int i = 0; i < numHotkeys; i++) {
     settings().setArrayIndex(i);
@@ -138,22 +164,49 @@ void ServerConfig::recall()
   settings().endGroup();
 }
 
-int ServerConfig::adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) const
+QString ServerConfig::linksSection(int idx) const
 {
-  if (screens()[idx].isNull())
-    return -1;
+  const int row = idx / m_columns;
+  const int column = idx % m_columns;
+  const int width = screens()[idx].width();
+  const int height = screens()[idx].height();
+  const auto lineTemplate = QStringLiteral("\t\t%1%2 = %3%4\n");
 
-  // if we're at the left or right end of the table, don't find results going
-  // further left or right
-  if ((deltaColumn > 0 && (idx + 1) % m_columns == 0) || (deltaColumn < 0 && idx % m_columns == 0))
-    return -1;
+  QString out;
 
-  int arrayPos = idx + deltaColumn + deltaRow * m_columns;
+  // Walk one edge of the screen. A spanning screen can border several
+  // screens along an edge, so each link covers the overlapping part of both
+  // edges as a range. Vertical edges run along rows, horizontal ones along
+  // columns; adjacentLine is the column or row just past that edge.
+  const auto walkEdge = [&](const QString &dirName, bool verticalEdge, int adjacentLine) {
+    const int start = verticalEdge ? row : column;
+    const int extent = verticalEdge ? height : width;
+    for (int p = start; p < start + extent;) {
+      const int i = verticalEdge ? screens().screenIndexAt(adjacentLine, p) : screens().screenIndexAt(p, adjacentLine);
+      if (i == -1) {
+        p++;
+        continue;
+      }
+      const int neighbourStart = verticalEdge ? i / m_columns : i % m_columns;
+      const int neighbourExtent = verticalEdge ? screens()[i].height() : screens()[i].width();
+      const double overlapStart = std::max(start, neighbourStart);
+      const double overlapEnd = std::min(start + extent, neighbourStart + neighbourExtent);
+      out.append(lineTemplate.arg(
+          dirName, formatInterval((overlapStart - start) / extent, (overlapEnd - start) / extent), screens()[i].name(),
+          formatInterval(
+              (overlapStart - neighbourStart) / neighbourExtent, (overlapEnd - neighbourStart) / neighbourExtent
+          )
+      ));
+      p = neighbourStart + neighbourExtent;
+    }
+  };
 
-  if (arrayPos >= screens().size() || arrayPos < 0)
-    return -1;
+  walkEdge(QStringLiteral("right"), true, column + width);
+  walkEdge(QStringLiteral("left"), true, column - 1);
+  walkEdge(QStringLiteral("up"), false, row - 1);
+  walkEdge(QStringLiteral("down"), false, row + height);
 
-  return arrayPos;
+  return out;
 }
 
 QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
@@ -170,14 +223,8 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   outStream << "section: links" << Qt::endl;
 
   for (int i = 0; const auto &screen : config.screens()) {
-    if (!screen.isNull()) {
-      outStream << "\t" << screen.name() << ":\n";
-      for (const auto &neighbour : std::as_const(neighbourDirs)) {
-        int idx = config.adjacentScreenIndex(i, neighbour.x, neighbour.y);
-        if (idx != -1 && !config.screens()[idx].isNull())
-          outStream << "\t\t" << neighbour.name << " = " << config.screens()[idx].name() << Qt::endl;
-      }
-    }
+    if (!screen.isNull())
+      outStream << "\t" << screen.name() << ":\n" << config.linksSection(i);
     i++;
   }
 

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -79,7 +80,7 @@ private:
   {
     return m_Hotkeys;
   }
-  int adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) const;
+  QString linksSection(int idx) const;
   bool findScreenName(const QString &name, int &index);
   bool fixNoServer(const QString &name, int &index);
 

--- a/src/lib/gui/widgets/ScreenSetupView.cpp
+++ b/src/lib/gui/widgets/ScreenSetupView.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -14,10 +15,53 @@
 #include <QDrag>
 #include <QDragEnterEvent>
 #include <QDragMoveEvent>
+#include <QDropEvent>
 #include <QHeaderView>
 #include <QMimeData>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QResizeEvent>
+#include <QStyledItemDelegate>
+
+#include <algorithm>
+
+namespace {
+
+// keeps the icon+name block vertically centred (so a tall screen's label is
+// not stranded at the top) and outlines spanning screens so a wide or tall
+// item reads as a single unit
+class ScreenDelegate : public QStyledItemDelegate
+{
+public:
+  using QStyledItemDelegate::QStyledItemDelegate;
+
+  void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
+  {
+    QStyleOptionViewItem opt = option;
+    const int contentHeight = opt.decorationSize.height() + opt.fontMetrics.height() + 4;
+    if (opt.rect.height() > contentHeight) {
+      const int dy = (opt.rect.height() - contentHeight) / 2;
+      opt.rect.adjust(0, dy, 0, -dy);
+    }
+    QStyledItemDelegate::paint(painter, opt, index);
+
+    if (const QSize span = index.data(ScreenSetupModel::SpanRole).toSize(); span.width() > 1 || span.height() > 1) {
+      painter->save();
+      painter->setRenderHint(QPainter::Antialiasing);
+      // a thin neutral outline so a wide/tall item reads as a single unit.
+      // deliberately NOT the selection highlight, which made spanning screens
+      // look permanently selected
+      QPen pen(option.palette.color(QPalette::Mid));
+      pen.setWidth(1);
+      painter->setPen(pen);
+      painter->setBrush(Qt::NoBrush);
+      painter->drawRoundedRect(QRectF(option.rect).adjusted(1, 1, -1, -1), 6, 6);
+      painter->restore();
+    }
+  }
+};
+
+} // namespace
 
 ScreenSetupView::ScreenSetupView(QWidget *parent) : QTableView(parent)
 {
@@ -31,12 +75,18 @@ ScreenSetupView::ScreenSetupView(QWidget *parent) : QTableView(parent)
   setIconSize(QSize(96, 96));
   horizontalHeader()->hide();
   verticalHeader()->hide();
+  setItemDelegate(new ScreenDelegate(this));
+
+  // needed to show resize cursors when hovering over a screen's edges
+  setMouseTracking(true);
 }
 
 void ScreenSetupView::setModel(QAbstractItemModel *model)
 {
   QTableView::setModel(model);
   setTableSize();
+  connect(this->model(), &ScreenSetupModel::screensChanged, this, &ScreenSetupView::updateSpans);
+  updateSpans();
 }
 
 ScreenSetupModel *ScreenSetupView::model() const
@@ -49,6 +99,108 @@ void ScreenSetupView::showScreenConfig(int col, int row)
   ScreenSettingsDialog dlg(this, &model()->screen(col, row), &model()->m_Screens);
   dlg.exec();
   Q_EMIT model()->screensChanged();
+}
+
+void ScreenSetupView::updateSpans()
+{
+  clearSpans();
+  for (int row = 0; row < model()->rowCount(); row++) {
+    for (int col = 0; col < model()->columnCount(); col++) {
+      if (const auto &screen = model()->screen(col, row);
+          !screen.isNull() && (screen.width() > 1 || screen.height() > 1))
+        setSpan(row, col, screen.height(), screen.width());
+    }
+  }
+}
+
+QModelIndex ScreenSetupView::resizeGripAt(const QPoint &pos, ResizeAxis &axis) const
+{
+  const auto index = indexAt(pos);
+  if (!index.isValid() || model()->screen(index).isNull())
+    return {};
+
+  // visualRect() covers the whole span for a spanning screen
+  const QRect rect = visualRect(index);
+  const int gripSize = 10;
+  const bool nearRight = pos.x() >= rect.right() - gripSize;
+  const bool nearBottom = pos.y() >= rect.bottom() - gripSize;
+
+  if (nearRight && nearBottom)
+    axis = ResizeAxis::Both;
+  else if (nearRight)
+    axis = ResizeAxis::Width;
+  else if (nearBottom)
+    axis = ResizeAxis::Height;
+  else
+    return {};
+
+  return index;
+}
+
+void ScreenSetupView::resizeSpanTo(const QPoint &pos)
+{
+  if (!m_resizeIndex.isValid())
+    return;
+
+  const auto &screen = model()->screen(m_resizeIndex.column(), m_resizeIndex.row());
+  int width = screen.width();
+  int height = screen.height();
+
+  if (m_resizeAxis != ResizeAxis::Height) {
+    int col = columnAt(pos.x());
+    if (col == -1)
+      col = pos.x() < 0 ? 0 : model()->columnCount() - 1;
+    width = std::max(col - m_resizeIndex.column() + 1, 1);
+  }
+  if (m_resizeAxis != ResizeAxis::Width) {
+    int row = rowAt(pos.y());
+    if (row == -1)
+      row = pos.y() < 0 ? 0 : model()->rowCount() - 1;
+    height = std::max(row - m_resizeIndex.row() + 1, 1);
+  }
+
+  model()->trySetSpan(m_resizeIndex.column(), m_resizeIndex.row(), width, height);
+}
+
+void ScreenSetupView::mousePressEvent(QMouseEvent *event)
+{
+  if (event->button() == Qt::LeftButton) {
+    ResizeAxis axis = ResizeAxis::Width;
+    if (const auto grip = resizeGripAt(event->pos(), axis); grip.isValid()) {
+      m_resizeIndex = grip;
+      m_resizeAxis = axis;
+      return;
+    }
+  }
+  QTableView::mousePressEvent(event);
+}
+
+void ScreenSetupView::mouseMoveEvent(QMouseEvent *event)
+{
+  if (m_resizeIndex.isValid()) {
+    resizeSpanTo(event->pos());
+    return;
+  }
+
+  ResizeAxis axis = ResizeAxis::Width;
+  if (resizeGripAt(event->pos(), axis).isValid()) {
+    const auto cursor = axis == ResizeAxis::Both    ? Qt::SizeFDiagCursor
+                        : axis == ResizeAxis::Width ? Qt::SizeHorCursor
+                                                    : Qt::SizeVerCursor;
+    viewport()->setCursor(cursor);
+  } else
+    viewport()->unsetCursor();
+
+  QTableView::mouseMoveEvent(event);
+}
+
+void ScreenSetupView::mouseReleaseEvent(QMouseEvent *event)
+{
+  if (m_resizeIndex.isValid()) {
+    m_resizeIndex = QPersistentModelIndex();
+    return;
+  }
+  QTableView::mouseReleaseEvent(event);
 }
 
 void ScreenSetupView::setTableSize()
@@ -69,11 +221,11 @@ void ScreenSetupView::resizeEvent(QResizeEvent *event)
 void ScreenSetupView::mouseDoubleClickEvent(QMouseEvent *event)
 {
   if (event->buttons() & Qt::LeftButton) {
-    int col = columnAt(event->pos().x());
-    int row = rowAt(event->pos().y());
+    // indexAt() resolves clicks inside a span to its top left cell
+    const auto index = indexAt(event->pos());
 
-    if (!model()->screen(col, row).isNull()) {
-      showScreenConfig(col, row);
+    if (index.isValid() && !model()->screen(index).isNull()) {
+      showScreenConfig(index.column(), index.row());
     }
   } else
     event->ignore();
@@ -103,7 +255,7 @@ void ScreenSetupView::dragMoveEvent(QDragMoveEvent *event)
       int row = rowAt(point.y());
 
       // a drop from outside is not allowed if there's a screen already there.
-      if (!model()->screen(col, row).isNull())
+      if (model()->m_Screens.screenIndexAt(col, row) != -1)
         event->ignore();
       else {
         event->acceptProposedAction();
@@ -111,6 +263,39 @@ void ScreenSetupView::dragMoveEvent(QDragMoveEvent *event)
     }
   } else
     event->ignore();
+}
+
+void ScreenSetupView::dropEvent(QDropEvent *event)
+{
+  if (!event->mimeData()->hasFormat(ScreenSetupModel::mimeType())) {
+    event->ignore();
+    return;
+  }
+
+  // Resolve the true cell under the cursor. The base QTableView drop path uses
+  // indexAt(), which collapses any point inside a span back to the span's
+  // anchor -- that makes a spanning screen impossible to nudge by a single cell
+  // or drop into a corner (the target always resolves to its current anchor).
+  // columnAt()/rowAt() are span-agnostic, so use them as the drop anchor.
+  const QPoint pos = event->position().toPoint();
+  const int col = columnAt(pos.x());
+  const int row = rowAt(pos.y());
+  if (col < 0 || row < 0) {
+    event->ignore();
+    return;
+  }
+
+  const bool internal = event->source() == this;
+  if (model()->dropMimeData(event->mimeData(), Qt::MoveAction, -1, -1, model()->index(row, col))) {
+    if (internal) {
+      event->setDropAction(Qt::MoveAction);
+      event->accept();
+    } else {
+      event->acceptProposedAction();
+    }
+  } else {
+    event->ignore();
+  }
 }
 
 // this is reimplemented from QAbstractItemView::startDrag()
@@ -131,17 +316,16 @@ void ScreenSetupView::startDrag(Qt::DropActions)
   pDrag->setMimeData(pData);
   pDrag->setHotSpot(QPoint(iconSize().width() / 2, iconSize().height() / 2));
 
+  model()->m_dropHandled = false;
   if (pDrag->exec(Qt::MoveAction, Qt::MoveAction) == Qt::MoveAction) {
     selectionModel()->clear();
 
-    // make sure to only delete the drag source if screens weren't swapped
-    // see ScreenSetupModel::dropMimeData
-    if (!model()->screen(indexes[0]).swapped())
+    // a grid drop moves the source itself (dropMimeData); a trash drop does
+    // not touch the model, so the source is removed here in that case
+    if (!model()->m_dropHandled) {
       model()->screen(indexes[0]) = Screen();
-    else
-      model()->screen(indexes[0]).setSwapped(false);
-
-    Q_EMIT model()->screensChanged();
+      Q_EMIT model()->screensChanged();
+    }
   }
 }
 

--- a/src/lib/gui/widgets/ScreenSetupView.h
+++ b/src/lib/gui/widgets/ScreenSetupView.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -14,6 +15,7 @@ class QWidget;
 class QMouseEvent;
 class QResizeEvent;
 class QDragEnterEvent;
+class QDropEvent;
 class ScreenSetupModel;
 
 class ScreenSetupView : public QTableView
@@ -26,18 +28,36 @@ public:
   ScreenSetupModel *model() const;
 
 private:
+  enum class ResizeAxis
+  {
+    Width,
+    Height,
+    Both
+  };
+
   void showScreenConfig(int col, int row);
+  void updateSpans();
+  QModelIndex resizeGripAt(const QPoint &pos, ResizeAxis &axis) const;
+  void resizeSpanTo(const QPoint &pos);
 
 protected:
   void mouseDoubleClickEvent(QMouseEvent *) override;
+  void mousePressEvent(QMouseEvent *) override;
+  void mouseMoveEvent(QMouseEvent *) override;
+  void mouseReleaseEvent(QMouseEvent *) override;
   void setTableSize();
   void resizeEvent(QResizeEvent *) override;
   void dragEnterEvent(QDragEnterEvent *event) override;
   void dragMoveEvent(QDragMoveEvent *event) override;
+  void dropEvent(QDropEvent *event) override;
   void startDrag(Qt::DropActions supportedActions) override;
   void initViewItemOption(QStyleOptionViewItem *option) const override;
   void scrollTo(const QModelIndex &, ScrollHint) override
   {
     // do nothing
   }
+
+private:
+  QPersistentModelIndex m_resizeIndex;
+  ResizeAxis m_resizeAxis = ResizeAxis::Width;
 };

--- a/src/unittests/gui/config/CMakeLists.txt
+++ b/src/unittests/gui/config/CMakeLists.txt
@@ -7,3 +7,10 @@ create_test(
   SOURCE ScreenTests.cpp
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
 )
+
+create_test(
+  NAME ScreenSetupModelTests
+  DEPENDS gui
+  SOURCE ScreenSetupModelTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
+)

--- a/src/unittests/gui/config/ScreenSetupModelTests.cpp
+++ b/src/unittests/gui/config/ScreenSetupModelTests.cpp
@@ -1,0 +1,177 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "ScreenSetupModelTests.h"
+
+#include "gui/ScreenSetupModel.h"
+#include "gui/config/ScreenList.h"
+
+#include <QMimeData>
+
+namespace {
+
+// exposes the protected drop entry point used by the view
+class TestModel : public ScreenSetupModel
+{
+public:
+  using ScreenSetupModel::dropMimeData;
+  using ScreenSetupModel::screen;
+  using ScreenSetupModel::ScreenSetupModel;
+};
+
+// mimics ScreenSetupView::dropEvent: build the drag payload and drop on the
+// TRUE target cell. The view resolves the cell with columnAt()/rowAt(), which
+// are span-agnostic, so the target is NOT collapsed to a covering screen's
+// anchor. Returns true if accepted.
+bool drag(TestModel &m, int srcCol, int srcRow, int dstCol, int dstRow)
+{
+  QByteArray payload;
+  QDataStream out(&payload, QIODevice::WriteOnly);
+  out << srcCol << srcRow << m.screen(srcCol, srcRow);
+  QMimeData mime;
+  mime.setData(ScreenSetupModel::mimeType(), payload);
+
+  return m.dropMimeData(&mime, Qt::MoveAction, -1, -1, m.index(dstRow, dstCol));
+}
+
+// every non-empty cell must be claimed by exactly one screen
+bool hasOverlap(const ScreenList &list, int cols)
+{
+  const int rows = static_cast<int>(list.size()) / cols;
+  for (int r = 0; r < rows; r++)
+    for (int c = 0; c < cols; c++) {
+      int claims = 0;
+      for (int i = 0; i < list.size(); i++) {
+        const auto &s = list[i];
+        if (s.isNull())
+          continue;
+        const int ac = i % cols, ar = i / cols;
+        if (c >= ac && c < ac + s.width() && r >= ar && r < ar + s.height())
+          claims++;
+      }
+      if (claims > 1)
+        return true;
+    }
+  return false;
+}
+
+} // namespace
+
+void ScreenSetupModelTests::moveKeepsLayoutConsistent()
+{
+  ScreenList list(5);
+  for (int i = 0; i < 15; i++)
+    list.append(Screen());
+  TestModel m(list, 5, 3);
+
+  Screen wide("wide");
+  wide.setWidth(3);
+  m.screen(1, 2) = wide; // anchor (1,2), covers cols 1..3
+  m.screen(0, 0) = Screen("solo");
+
+  // move the wide screen around; the layout must never overlap
+  QVERIFY(drag(m, 1, 2, 1, 1)); // up a row
+  QVERIFY(!hasOverlap(list, 5));
+  QVERIFY(drag(m, 1, 1, 2, 0)); // up and right
+  QVERIFY(!hasOverlap(list, 5));
+  QVERIFY(drag(m, 2, 0, 0, 2)); // back down to the left
+  QVERIFY(!hasOverlap(list, 5));
+
+  // the wide screen kept its span and is anchored where it was dropped
+  QCOMPARE(m.screen(0, 2).name(), QStringLiteral("wide"));
+  QCOMPARE(m.screen(0, 2).width(), 3);
+}
+
+void ScreenSetupModelTests::invalidSpanDropRejected()
+{
+  ScreenList list(5);
+  for (int i = 0; i < 15; i++)
+    list.append(Screen());
+  TestModel m(list, 5, 3);
+
+  Screen tall("tall");
+  tall.setHeight(2);
+  m.screen(4, 0) = tall; // anchor (4,0), covers rows 0..1
+  m.screen(0, 2) = Screen("solo");
+
+  // swapping solo onto the tall screen would push tall off the bottom row;
+  // the drop must be rejected and the layout left untouched
+  QVERIFY(!drag(m, 0, 2, 4, 1));
+  QVERIFY(!hasOverlap(list, 5));
+  QCOMPARE(m.screen(4, 0).name(), QStringLiteral("tall"));
+  QCOMPARE(m.screen(0, 2).name(), QStringLiteral("solo"));
+}
+
+void ScreenSetupModelTests::spanNudgesIntoOwnFootprint()
+{
+  ScreenList list(5);
+  for (int i = 0; i < 15; i++)
+    list.append(Screen());
+  TestModel m(list, 5, 3);
+
+  Screen wide("wide");
+  wide.setWidth(3);
+  m.screen(0, 0) = wide; // anchor (0,0), covers cols 0..2
+
+  // nudge one cell right: target (1,0) is INSIDE the screen's own span. The old
+  // span-collapsed drop resolved this back to the anchor and rejected it as a
+  // self-drop; the fix must let the screen shift by a single cell.
+  QVERIFY(drag(m, 0, 0, 1, 0));
+  QVERIFY(!hasOverlap(list, 5));
+  QVERIFY(m.screen(0, 0).isNull());
+  QCOMPARE(m.screen(1, 0).name(), QStringLiteral("wide"));
+  QCOMPARE(m.screen(1, 0).width(), 3); // span preserved, now covers cols 1..3
+
+  // shift into the right corner: anchor (2,0) covers cols 2..4
+  QVERIFY(drag(m, 1, 0, 2, 0));
+  QVERIFY(!hasOverlap(list, 5));
+  QCOMPARE(m.screen(2, 0).name(), QStringLiteral("wide"));
+
+  // one cell further would push cols 3..5 off the 5-wide grid -> rejected
+  QVERIFY(!drag(m, 2, 0, 3, 0));
+  QCOMPARE(m.screen(2, 0).name(), QStringLiteral("wide"));
+}
+
+void ScreenSetupModelTests::singleCellsSwap()
+{
+  ScreenList list(5);
+  for (int i = 0; i < 15; i++)
+    list.append(Screen());
+  TestModel m(list, 5, 3);
+
+  m.screen(0, 0) = Screen("a");
+  m.screen(1, 0) = Screen("b");
+
+  // dropping a onto an occupied cell swaps the two single-cell screens
+  QVERIFY(drag(m, 0, 0, 1, 0));
+  QVERIFY(!hasOverlap(list, 5));
+  QCOMPARE(m.screen(1, 0).name(), QStringLiteral("a"));
+  QCOMPARE(m.screen(0, 0).name(), QStringLiteral("b"));
+}
+
+void ScreenSetupModelTests::crossingSpansRejected()
+{
+  ScreenList list(5);
+  for (int i = 0; i < 15; i++)
+    list.append(Screen());
+  TestModel m(list, 5, 3);
+
+  Screen wide("wide");
+  wide.setWidth(2);
+  m.screen(0, 1) = wide;           // anchor (col0,row1), covers (0,1) and (1,1)
+  m.screen(1, 0) = Screen("tall"); // 1x1 at (col1,row0)
+
+  // growing "tall" down to height 2 makes it cover (1,0) and (1,1). (1,1) is a
+  // covered (non-anchor) cell of "wide" as well, so the two spans cross there.
+  // A wide screen and a tall screen overlapping like this must be rejected --
+  // each span only ever covers raw-empty cells, so the per-span "is this raw
+  // cell null" check misses it; validation has to be occupancy-based.
+  QVERIFY(!m.trySetSpan(1, 0, 1, 2));
+  QVERIFY(!hasOverlap(list, 5));
+  QCOMPARE(m.screen(1, 0).height(), 1); // unchanged
+}
+
+QTEST_MAIN(ScreenSetupModelTests)

--- a/src/unittests/gui/config/ScreenSetupModelTests.h
+++ b/src/unittests/gui/config/ScreenSetupModelTests.h
@@ -1,0 +1,21 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QTest>
+
+class ScreenSetupModelTests : public QObject
+{
+  Q_OBJECT
+private Q_SLOTS:
+  // Test are run in order top to bottom
+  void moveKeepsLayoutConsistent();
+  void invalidSpanDropRejected();
+  void spanNudgesIntoOwnFootprint();
+  void singleCellsSwap();
+  void crossingSpansRejected();
+};

--- a/src/unittests/gui/config/ScreenTests.cpp
+++ b/src/unittests/gui/config/ScreenTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2024 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -34,6 +35,31 @@ void ScreenTests::basicFunctionality()
   screen.saveSettings(Settings::proxy());
   screen.loadSettings(Settings::proxy());
   QCOMPARE("stub", screen.name());
+}
+
+void ScreenTests::span()
+{
+  Screen screen("stub");
+  QCOMPARE(screen.width(), 1);
+  QCOMPARE(screen.height(), 1);
+
+  // span is clamped to at least one cell
+  screen.setWidth(0);
+  screen.setHeight(0);
+  QCOMPARE(screen.width(), 1);
+  QCOMPARE(screen.height(), 1);
+
+  screen.setWidth(3);
+  screen.setHeight(2);
+  QCOMPARE(screen.width(), 3);
+  QCOMPARE(screen.height(), 2);
+  QVERIFY(!(screen == Screen("stub")));
+
+  screen.saveSettings(Settings::proxy());
+  Screen loaded;
+  loaded.loadSettings(Settings::proxy());
+  QCOMPARE(loaded.width(), 3);
+  QCOMPARE(loaded.height(), 2);
 }
 
 QTEST_MAIN(ScreenTests)

--- a/src/unittests/gui/config/ScreenTests.h
+++ b/src/unittests/gui/config/ScreenTests.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Mikhail Slyusarev <slyusarevmikhail@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -13,6 +14,7 @@ private Q_SLOTS:
   // Test are run in order top to bottom
   void initTestCase();
   void basicFunctionality();
+  void span();
 
 private:
   inline static const QString m_settingsPath = QStringLiteral("tmp/test");

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -907,8 +907,8 @@ Además, verifique que puede %1 el archivo de configuración del servidor: %2</t
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation type="unfinished">&lt;center&gt;Pantalla: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Haga doble clic para editar la configuración&lt;br&gt;Arrastre la pantalla a la papelera para eliminarla</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;Pantalla: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Haga doble clic para editar la configuración&lt;br&gt;Arrastre la pantalla a la papelera para eliminarla&lt;br&gt;Arrastre el borde derecho o inferior para abarcar más celdas</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -907,8 +907,8 @@ Inoltre, verifica di poter %1 il file di configurazione del server: %2</translat
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation>&lt;center&gt;Schermo: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Fai doppio clic per modificare le impostazioni&lt;br&gt;Trascina lo schermo nel cestino per rimuoverlo</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;Schermo: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Fai doppio clic per modificare le impostazioni&lt;br&gt;Trascina lo schermo nel cestino per rimuoverlo&lt;br&gt;Trascina il bordo destro o inferiore per estendersi su più celle</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -909,8 +909,8 @@ Additionally, check you are able to %1 the server config file: %2</source>
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation>&lt;center&gt;コンピューター: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;ダブルクリックで設定&lt;br&gt;ゴミ箱にドラッグして削除</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;コンピューター: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;ダブルクリックで設定&lt;br&gt;ゴミ箱にドラッグして削除&lt;br&gt;右端または下端をドラッグして複数のセルにまたがる</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -907,8 +907,8 @@ Additionally, check you are able to %1 the server config file: %2</source>
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation>&lt;center&gt;컴퓨터: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;더블 클릭하여 설정 편집&lt;br&gt;휴지통으로 드래그하여 삭제</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;컴퓨터: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;더블 클릭하여 설정 편집&lt;br&gt;휴지통으로 드래그하여 삭제&lt;br&gt;오른쪽 또는 아래쪽 가장자리를 드래그하여 여러 셀에 걸치기</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -907,8 +907,8 @@ Additionally, check you are able to %1 the server config file: %2</source>
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation>&lt;center&gt;Экран: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Двойной клик для настроек&lt;br&gt;Перетащите экран в корзину для удаления</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;Экран: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Двойной клик для настроек&lt;br&gt;Перетащите экран в корзину для удаления&lt;br&gt;Перетащите правый или нижний край, чтобы растянуть на несколько ячеек</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -909,8 +909,8 @@ Additionally, check you are able to %1 the server config file: %2</source>
 <context>
     <name>ScreenSetupModel</name>
     <message>
-        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it</source>
-        <translation>&lt;center&gt;屏幕：&lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;双击编辑设置&lt;br&gt;将屏幕拖到垃圾桶以移除</translation>
+        <source>&lt;center&gt;Screen: &lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;Double click to edit settings&lt;br&gt;Drag screen to the trashcan to remove it&lt;br&gt;Drag the right or bottom edge to span more cells</source>
+        <translation>&lt;center&gt;屏幕：&lt;b&gt;%1&lt;/b&gt;&lt;/center&gt;&lt;br&gt;双击编辑设置&lt;br&gt;将屏幕拖到垃圾桶以移除&lt;br&gt;拖动右边缘或下边缘以跨越更多单元格</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

### Problem

The server layout grid allows one neighbor per direction, so a physically large screen (e.g. an ultrawide spanning the width of three laptops below it, or a portrait monitor next to two stacked screens) can't be represented: moving the cursor toward it only ever reaches one of the screens.

### Solution

A screen can now be resized to span multiple grid cells by dragging its right or bottom edge, directly in the layout grid (no dialog). A screen spanning N cells sits next to several neighbors at once, and the generated config maps the overlap onto the link range syntax the server already supports:

```
section: links
    wide-desktop:
            down(0,33) = laptop-1
            down(33,67) = laptop-2
            down(67,100) = laptop-3
    laptop-2:
            right = laptop-3
            left = laptop-1
            up = wide-desktop(33,67)
```

No core/server changes needed — the parser and cursor position mapping (CellEdge intervals) handle ranged links already; only the GUI couldn't express them.

### Implementation notes

- The screen stays anchored in its top-left cell; covered cells stay empty in the ScreenList and screenIndexAt() resolves which screen covers a cell
- The grid renders spans with QTableView::setSpan; drag-resize handles appear on the right/bottom edges (cursor changes to a resize arrow)
- A resize that would push the span out of the grid or over an occupied cell is rejected; drops and new clients respect spans too
- Spans round-trip through settings and the drag-and-drop mime stream, and are clamped on load if the grid no longer fits them
- Width and height are symmetric — same handling, same link generation

### Screenshots

`wide-desktop` spans three columns, `tall-display` spans two rows:

<!-- drag span-grid.png in here -->

## AI tools used for this PR

Claude Code (Claude Fable 5, `claude-fable-5`) was used to implement the feature, write the unit test, and generate the screenshots. All changes were reviewed and tested manually.

## Fixed/related issues

None

## How has this been tested?

- New `ScreenTests::span()` unit test covering default values, clamping, equality, and settings round-trip for both width and height; full unit test suite passes
- Built and tested on Fedora 43, Qt 6.10.3, GNOME Wayland
- In daily use on a real 4-computer layout: a Linux server spanning 3 columns above three macOS clients
- Generated config verified against the core parser (ranged links such as `down(0,33)` / `up = name(33,67)` parse and route the cursor correctly)
