### PR TITLE
fix: make Wayland clipboard sharing work reliably

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -340,16 +340,11 @@ void EiScreen::fakeKey(uint32_t keycode, bool isDown) const
 void EiScreen::enable()
 {
   // Nothing really to be done here
-  if (m_clipboard && m_clipboard->isAvailable()) {
-    m_clipboard->startMonitoring();
-  }
 }
 
 void EiScreen::disable()
 {
-  if (m_clipboard && m_clipboard->isAvailable()) {
-    m_clipboard->stopMonitoring();
-  }
+  // Nothing really to be done here
 }
 
 void EiScreen::enter()
@@ -411,17 +406,17 @@ bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 
 void EiScreen::checkClipboards()
 {
-  // do nothing, we're always up to date
   if (!m_clipboard || !m_clipboard->isAvailable()) {
     return;
   }
 
-  if (m_clipboard->hasChanged()) {
-    // Send clipboard change events for all clipboard types
-    for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
+  // this runs when leaving the screen, the one moment the focus blip of
+  // wl-paste cannot interrupt the user's typing
+  for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
+    if (m_clipboard->hasChanged(id)) {
       sendClipboardEvent(EventTypes::ClipboardChanged, id);
+      m_clipboard->resetChanged(id);
     }
-    m_clipboard->resetChanged();
   }
 }
 

--- a/src/lib/platform/WlClipboard.cpp
+++ b/src/lib/platform/WlClipboard.cpp
@@ -1,22 +1,18 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
 #include "platform/WlClipboard.h"
 
 #include "base/Log.h"
+#include "common/Settings.h"
 
-#include <chrono>
-#include <common/Settings.h>
-#include <fcntl.h>
-#include <poll.h>
-#include <spawn.h>
-#include <sys/wait.h>
-#include <unistd.h>
+#include <algorithm>
 
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <QProcess>
 #include <QStandardPaths>
 
@@ -27,6 +23,7 @@ inline static const auto s_pasteApp = QStringLiteral("wl-paste");
 
 // wl-clipboard args
 inline static const auto s_listTypes = QStringLiteral("--list-types");
+inline static const auto s_clear = QStringLiteral("--clear");
 inline static const auto s_isPrimary = QStringLiteral("--primary");
 inline static const auto s_noNewLine = QStringLiteral("-n");
 inline static const auto s_readType = QStringLiteral("-t%1");
@@ -36,32 +33,24 @@ inline static const auto s_mimeTypeText = QStringLiteral("text/plain;charset=utf
 inline static const auto s_mimeTypeHtml = QStringLiteral("text/html");
 inline static const auto s_mimeTypeBmp = QStringLiteral("image/bmp");
 
-// Additional HTML MIME type variants
-const char *const s_mimeTypeHtmlUtf8 = "text/html;charset=UTF-8";
-const char *const s_mimeTypeHtmlWindows = "HTML Format";
-
-// Command timeout (milliseconds)
 const int kCacheValidityMs = 100;
-const int kMonitorIntervalMs = 1000;
-const int kMaxConsecutiveErrors = 5;
+const int kListTypesTimeoutMs = 2000;
+const int kPasteTimeoutMs = 3000;
+const int kCopyTimeoutMs = 5000;
+
+// reading this much of the content is enough to tell two clipboards apart
+const qsizetype kFingerprintMaxBytes = 256 * 1024;
+
+size_t contentHash(const QByteArray &data)
+{
+  return qHash(data);
+}
+
 } // namespace
 
 WlClipboard::WlClipboard(ClipboardID id) : m_id(id), m_useClipboard(id == kClipboardClipboard)
 {
-  // Initialize cached data
-  for (int i = 0; i < static_cast<int>(Format::TotalFormats); ++i) {
-    m_cachedAvailable[i] = false;
-  }
-}
-
-WlClipboard::~WlClipboard()
-{
-  stopMonitoring();
-  for (auto &cmd : m_runningWlCopies) {
-    cmd->close();
-    cmd->waitForFinished(100);
-  }
-  m_runningWlCopies.clear();
+  // do nothing
 }
 
 ClipboardID WlClipboard::getID() const
@@ -79,34 +68,44 @@ bool WlClipboard::isEnabled()
   return Settings::value(Settings::Core::UseWlClipboard).toBool();
 }
 
-void WlClipboard::startMonitoring()
-{
-  if (m_monitoring) {
-    return;
-  }
-  m_stopMonitoring = false;
-  m_monitoring = true;
-  m_monitorThread = std::make_unique<std::thread>(&WlClipboard::monitorClipboard, this);
-}
-
-void WlClipboard::stopMonitoring()
-{
-  if (!m_monitoring) {
-    return;
-  }
-
-  m_stopMonitoring = true;
-  m_monitoring = false;
-
-  if (m_monitorThread && m_monitorThread->joinable()) {
-    m_monitorThread->join();
-  }
-  m_monitorThread.reset();
-}
-
 bool WlClipboard::hasChanged() const
 {
-  return m_hasChanged.load();
+  const auto types = getAvailableMimeTypes();
+
+  // hash the content of the first offered type, capped, so copies that
+  // keep the same mime types are still detected
+  size_t hash = 0;
+  if (!types.isEmpty()) {
+    hash =
+        contentHash(readClipboard({s_noNewLine, s_readType.arg(types.first())}, kFingerprintMaxBytes, kPasteTimeoutMs));
+  }
+
+  if (m_haveFingerprint && types == m_lastTypes && hash == m_lastContentHash) {
+    return false;
+  }
+
+  const bool isBaseline = !m_haveFingerprint;
+  const bool isOwnWrite = m_ownWriteHash.has_value() && hash == *m_ownWriteHash;
+
+  m_haveFingerprint = true;
+  m_lastTypes = types;
+  m_lastContentHash = hash;
+
+  if (isBaseline || isOwnWrite) {
+    // the first observation, or our own wl-copy, is not an external change
+    return false;
+  }
+
+  std::scoped_lock<std::mutex> lock(m_cacheMutex);
+  invalidateCache();
+  return true;
+}
+
+void WlClipboard::resetChanged()
+{
+  // Clear cache to force fresh data retrieval
+  std::scoped_lock<std::mutex> lock(m_cacheMutex);
+  invalidateCache();
 }
 
 bool WlClipboard::empty()
@@ -114,27 +113,14 @@ bool WlClipboard::empty()
   if (!m_open) {
     return false;
   }
-  auto cmd = new QProcess(this);
-  cmd->setProgram(s_copyApp);
-  m_runningWlCopies.append(cmd);
-  connect(cmd, &QProcess::finished, this, [&] { m_runningWlCopies.removeAll(cmd); });
 
-  QStringList args = {s_noNewLine, ""};
-  if (!m_useClipboard)
-    args.prepend(s_isPrimary);
-
-  cmd->setArguments(args);
-  cmd->start();
-  bool success = cmd->waitForStarted(100);
-
-  if (success) {
-    // Update ownership and cache only if command succeeded
-    std::scoped_lock<std::mutex> lock(m_cacheMutex);
-    updateOwnership(true);
-    invalidateCache();
+  m_pendingWrite = true;
+  for (int i = 0; i < static_cast<int>(Format::TotalFormats); ++i) {
+    m_pendingData[i].clear();
+    m_pendingAvailable[i] = false;
   }
 
-  return success;
+  return true;
 }
 
 void WlClipboard::add(Format format, const std::string &data)
@@ -143,34 +129,15 @@ void WlClipboard::add(Format format, const std::string &data)
     return;
   }
 
-  if (format == Format::HTML) {
-    return;
-  }
-
-  auto mimeType = formatToMimeType(format);
-  if (mimeType.isEmpty()) {
+  const auto index = static_cast<int>(format);
+  if (index < 0 || index >= static_cast<int>(Format::TotalFormats)) {
     LOG_WARN("unsupported clipboard format: %d", format);
     return;
   }
 
-  auto cmd = new QProcess(this);
-  cmd->setProgram(s_copyApp);
-
-  m_runningWlCopies.append(cmd);
-  connect(cmd, &QProcess::finished, this, [&] { m_runningWlCopies.removeAll(cmd); });
-
-  QStringList args = {s_noNewLine, s_readType.arg(mimeType), QString::fromStdString(data)};
-  if (!m_useClipboard)
-    args.prepend(s_isPrimary);
-
-  cmd->setArguments(args);
-  cmd->start();
-
-  if (cmd->waitForStarted(100)) {
-    std::scoped_lock<std::mutex> lock(m_cacheMutex);
-    updateOwnership(true);
-    invalidateCache();
-  }
+  m_pendingWrite = true;
+  m_pendingData[index] = data;
+  m_pendingAvailable[index] = true;
 }
 
 bool WlClipboard::open(Time time) const
@@ -194,8 +161,86 @@ void WlClipboard::close() const
 
   LOG_DEBUG("close clipboard");
 
+  if (m_pendingWrite) {
+    commitPendingData();
+  }
   m_open = false;
-  const_cast<WlClipboard *>(this)->invalidateCache();
+}
+
+void WlClipboard::commitPendingData() const
+{
+  // wl-copy offers a single mime type per invocation, so pick the most
+  // valuable pending format
+  static constexpr Format formatPriority[] = {Format::Bitmap, Format::Text, Format::HTML};
+  int chosen = -1;
+  for (const auto format : formatPriority) {
+    if (m_pendingAvailable[static_cast<int>(format)]) {
+      chosen = static_cast<int>(format);
+      break;
+    }
+  }
+
+  QProcess cmd;
+  cmd.setProgram(s_copyApp);
+
+  QStringList args;
+  if (!m_useClipboard) {
+    args.append(s_isPrimary);
+  }
+
+  if (chosen == -1) {
+    // emptied with nothing added, clear the system clipboard
+    args.append(s_clear);
+    cmd.setArguments(args);
+    cmd.start();
+  } else {
+    args.append(s_noNewLine);
+    args.append(s_readType.arg(formatToMimeType(static_cast<Format>(chosen))));
+    cmd.setArguments(args);
+    cmd.start();
+    if (!cmd.waitForStarted(1000)) {
+      LOG_WARN("failed to start %s", qPrintable(s_copyApp));
+      m_pendingWrite = false;
+      return;
+    }
+    // pass the data via stdin, argv cannot carry binary data
+    const auto &data = m_pendingData[chosen];
+    cmd.write(data.data(), static_cast<qint64>(data.size()));
+    cmd.closeWriteChannel();
+  }
+
+  // wl-copy forks a child to serve the selection and exits once stdin is consumed
+  if (!cmd.waitForFinished(kCopyTimeoutMs)) {
+    LOG_WARN("%s did not finish in time", qPrintable(s_copyApp));
+    cmd.kill();
+    cmd.waitForFinished(100);
+  }
+
+  // remember what we wrote so hasChanged() does not report it as a change
+  if (chosen == -1) {
+    m_ownWriteHash = 0; // an empty clipboard hashes to 0
+  } else {
+    const auto &written = m_pendingData[chosen];
+    const auto capped = static_cast<qsizetype>(std::min<size_t>(written.size(), kFingerprintMaxBytes));
+    m_ownWriteHash = contentHash(QByteArray(written.data(), capped));
+  }
+
+  {
+    std::scoped_lock<std::mutex> lock(m_cacheMutex);
+    invalidateCache();
+    if (chosen != -1) {
+      m_cachedData[chosen] = m_pendingData[chosen];
+      m_cachedAvailable[chosen] = true;
+    }
+    m_cached = true;
+    m_cachedTime = getCurrentTime();
+  }
+
+  m_pendingWrite = false;
+  for (int i = 0; i < static_cast<int>(Format::TotalFormats); ++i) {
+    m_pendingData[i].clear();
+    m_pendingAvailable[i] = false;
+  }
 }
 
 IClipboard::Time WlClipboard::getTime() const
@@ -209,12 +254,19 @@ bool WlClipboard::has(Format format) const
     return false;
   }
 
+  const auto index = static_cast<int>(format);
+
+  // an uncommitted write transaction is answered from the pending data
+  if (m_pendingWrite) {
+    return m_pendingAvailable[index];
+  }
+
   std::scoped_lock<std::mutex> lock(m_cacheMutex);
 
   // Check cache validity
   Time currentTime = getCurrentTime();
   if (m_cached && (currentTime - m_cachedTime) < kCacheValidityMs) {
-    return m_cachedAvailable[static_cast<int>(format)];
+    return m_cachedAvailable[index];
   }
 
   if (const auto availableTypes = getAvailableMimeTypes(); availableTypes.isEmpty()) {
@@ -246,7 +298,7 @@ bool WlClipboard::has(Format format) const
   m_cached = true;
   m_cachedTime = currentTime;
 
-  return m_cachedAvailable[static_cast<int>(format)];
+  return m_cachedAvailable[index];
 }
 
 std::string WlClipboard::get(Format format) const
@@ -255,11 +307,18 @@ std::string WlClipboard::get(Format format) const
     return std::string();
   }
 
+  const auto index = static_cast<int>(format);
+
+  // an uncommitted write transaction is answered from the pending data
+  if (m_pendingWrite) {
+    return m_pendingData[index];
+  }
+
   std::scoped_lock<std::mutex> lock(m_cacheMutex);
 
   // Return cached data if available and valid
-  if (m_cached && m_cachedAvailable[static_cast<int>(format)] && !m_cachedData[static_cast<int>(format)].empty()) {
-    return m_cachedData[static_cast<int>(format)];
+  if (m_cached && m_cachedAvailable[index] && !m_cachedData[index].empty()) {
+    return m_cachedData[index];
   }
 
   auto mimeType = formatToMimeType(format);
@@ -267,22 +326,11 @@ std::string WlClipboard::get(Format format) const
     return std::string();
   }
 
-  QProcess cmd;
-  cmd.setProgram(s_pasteApp);
-
-  QStringList args = {s_noNewLine, s_readType.arg(mimeType)};
-  if (!m_useClipboard)
-    args.append(s_isPrimary);
-
-  cmd.setArguments(args);
-  cmd.start();
-  cmd.waitForFinished();
-
-  auto data = cmd.readAll().toStdString();
+  const auto data = readClipboard({s_noNewLine, s_readType.arg(mimeType)}, -1, kPasteTimeoutMs).toStdString();
 
   // Update cache
-  m_cachedData[static_cast<int>(format)] = data;
-  m_cachedAvailable[static_cast<int>(format)] = !data.empty();
+  m_cachedData[index] = data;
+  m_cachedAvailable[index] = !data.empty();
   m_cached = true;
   m_cachedTime = getCurrentTime();
 
@@ -304,76 +352,44 @@ QString WlClipboard::formatToMimeType(Format format) const
   }
 }
 
-IClipboard::Format WlClipboard::mimeTypeToFormat(const QString &mimeType) const
+QStringList WlClipboard::getAvailableMimeTypes() const
 {
-  using enum IClipboard::Format;
-  if (mimeType == s_mimeTypeText || mimeType == QStringLiteral("text/plain")) {
-    return Text;
-  }
-  if (mimeType == s_mimeTypeHtml || mimeType == s_mimeTypeHtmlUtf8 || mimeType == s_mimeTypeHtmlWindows ||
-      mimeType.contains("text/html")) {
-    return HTML;
-  }
-  if (mimeType == s_mimeTypeBmp) {
-    return Bitmap;
-  }
-  return Text; // Default fallback
+  const auto data = readClipboard({s_listTypes}, 64 * 1024, kListTypesTimeoutMs);
+  return QString::fromUtf8(data).split(QLatin1Char('\n'), Qt::SkipEmptyParts);
 }
 
-QStringList WlClipboard::getAvailableMimeTypes() const
+QByteArray WlClipboard::readClipboard(const QStringList &args, qsizetype maxBytes, int timeoutMs) const
 {
   QProcess cmd;
   cmd.setProgram(s_pasteApp);
 
-  QStringList args = {s_listTypes};
-  if (!m_useClipboard)
-    args.append(s_isPrimary);
-
-  cmd.setArguments(args);
-  cmd.start();
-  cmd.waitForFinished();
-
-  const static QChar newLine = QLatin1Char('\n');
-  return QString::fromLocal8Bit(cmd.readAll()).split(newLine);
-}
-
-void WlClipboard::monitorClipboard()
-{
-  QStringList lastTypes;
-  int consecutiveErrors = 0;
-
-  while (!m_stopMonitoring) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(kMonitorIntervalMs));
-    try {
-      // Check if clipboard content has changed by comparing available types
-      const auto currentTypes = getAvailableMimeTypes();
-
-      // Reset error counter on successful operation
-      consecutiveErrors = 0;
-
-      if (currentTypes != lastTypes) {
-        m_hasChanged = true;
-        lastTypes = currentTypes;
-
-        // Clear cache when clipboard changes
-        std::scoped_lock<std::mutex> lock(m_cacheMutex);
-        invalidateCache();
-        updateOwnership(false);
-      }
-    } catch (const std::exception &e) {
-      LOG_WARN("clipboard monitoring error: %s", e.what());
-      if (++consecutiveErrors >= kMaxConsecutiveErrors) {
-        LOG_ERR("too many consecutive errors in clipboard monitoring, stopping");
-        break;
-      }
-    } catch (...) {
-      LOG_WARN("clipboard monitoring unknown error");
-      if (++consecutiveErrors >= kMaxConsecutiveErrors) {
-        LOG_ERR("too many consecutive errors in clipboard monitoring, stopping");
-        break;
-      }
-    }
+  QStringList allArgs = args;
+  if (!m_useClipboard) {
+    allArgs.append(s_isPrimary);
   }
+  cmd.setArguments(allArgs);
+  cmd.start();
+
+  QElapsedTimer timer;
+  timer.start();
+
+  QByteArray out;
+  while (cmd.state() != QProcess::NotRunning && timer.elapsed() < timeoutMs && (maxBytes < 0 || out.size() < maxBytes)
+  ) {
+    cmd.waitForReadyRead(50);
+    out.append(cmd.readAllStandardOutput());
+  }
+  out.append(cmd.readAllStandardOutput());
+
+  if (cmd.state() != QProcess::NotRunning) {
+    cmd.kill();
+    cmd.waitForFinished(100);
+  }
+
+  if (maxBytes >= 0 && out.size() > maxBytes) {
+    out.truncate(maxBytes);
+  }
+  return out;
 }
 
 IClipboard::Time WlClipboard::getCurrentTime() const
@@ -381,26 +397,7 @@ IClipboard::Time WlClipboard::getCurrentTime() const
   return static_cast<Time>(QDateTime::currentMSecsSinceEpoch());
 }
 
-bool WlClipboard::isOwned() const
-{
-  return m_owned;
-}
-
-void WlClipboard::resetChanged()
-{
-  m_hasChanged = false;
-
-  // Clear cache when resetting change flag to force fresh data retrieval
-  std::scoped_lock<std::mutex> lock(m_cacheMutex);
-  invalidateCache();
-}
-
-void WlClipboard::updateOwnership(bool owned)
-{
-  m_owned = owned;
-}
-
-void WlClipboard::invalidateCache()
+void WlClipboard::invalidateCache() const
 {
   m_cached = false;
   m_cachedTime = 0;

--- a/src/lib/platform/WlClipboard.h
+++ b/src/lib/platform/WlClipboard.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
@@ -9,30 +9,35 @@
 #include "deskflow/ClipboardTypes.h"
 #include "deskflow/IClipboard.h"
 
-#include <atomic>
-#include <fcntl.h>
-#include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
-#include <thread>
 
-#include <QObject>
+#include <QByteArray>
 #include <QString>
+#include <QStringList>
 
-class QProcess;
 //! Wayland clipboard implementation using wl-copy/wl-paste
 /*!
 This class implements clipboard functionality for Wayland environments
 by using the wl-clipboard utilities (wl-copy and wl-paste).
+
+Data added between open() and close() is accumulated and committed as a
+single wl-copy invocation on close(), since wl-copy can only offer one
+mime type per invocation.
+
+Change detection is on demand via hasChanged() rather than a polling
+thread: on compositors without a data-control protocol (e.g. GNOME)
+wl-paste briefly steals keyboard focus, so it must only run at moments
+where that cannot interrupt typing, such as when leaving the screen.
 */
-class WlClipboard : public QObject, public IClipboard
+class WlClipboard : public IClipboard
 {
-  Q_OBJECT
 public:
   explicit WlClipboard(ClipboardID id);
   WlClipboard(WlClipboard const &) = delete;
   WlClipboard(WlClipboard &&) = delete;
-  ~WlClipboard() override;
+  ~WlClipboard() override = default;
 
   WlClipboard &operator=(WlClipboard const &) = delete;
   WlClipboard &operator=(WlClipboard &&) = delete;
@@ -46,16 +51,13 @@ public:
   //! Check if WlClipboard is enabled
   static bool isEnabled();
 
-  //! Start monitoring clipboard changes
-  void startMonitoring();
-
-  //! Stop monitoring clipboard changes
-  void stopMonitoring();
-
-  //! Check if clipboard has changed
+  //! Check the clipboard for an external change since the last call.
+  //! Spawns wl-paste, so only call when a focus blip cannot interrupt
+  //! the user (e.g. when leaving the screen). The first call only
+  //! records a baseline.
   bool hasChanged() const;
 
-  //! Reset the changed flag and clear cache
+  //! Clear cached clipboard data so the next read is fresh
   void resetChanged();
 
   // IClipboard overrides
@@ -71,49 +73,46 @@ private:
   //! Convert IClipboard format to MIME type
   QString formatToMimeType(Format format) const;
 
-  //! Convert MIME type to IClipboard format
-  Format mimeTypeToFormat(const QString &mimeType) const;
-
   //! Get available MIME types from clipboard
   QStringList getAvailableMimeTypes() const;
 
-  //! Monitor clipboard changes in background thread
-  void monitorClipboard();
+  //! Run wl-paste with the given args, bounded by maxBytes (-1 = unlimited) and timeoutMs
+  QByteArray readClipboard(const QStringList &args, qsizetype maxBytes, int timeoutMs) const;
+
+  //! Write the accumulated data as a single wl-copy invocation
+  void commitPendingData() const;
 
   //! Get current clipboard serial/timestamp
   Time getCurrentTime() const;
 
-  //! Check if we own the clipboard
-  bool isOwned() const;
-
-  //! Update our ownership status
-  void updateOwnership(bool owned);
-
   //! Invalidate cached clipboard data
-  void invalidateCache();
+  void invalidateCache() const;
 
 private:
   ClipboardID m_id;
   mutable bool m_open = false;
   mutable Time m_time = 0;
-  mutable Time m_cachedTime = 0;
-  mutable bool m_owned = false;
-  mutable std::atomic<bool> m_hasChanged = false;
+
+  // Data accumulated between empty()/add() and the commit on close()
+  mutable bool m_pendingWrite = false;
+  mutable std::string m_pendingData[static_cast<int>(Format::TotalFormats)];
+  mutable bool m_pendingAvailable[static_cast<int>(Format::TotalFormats)] = {};
 
   // Cached clipboard data
   mutable std::mutex m_cacheMutex;
   mutable bool m_cached = false;
+  mutable Time m_cachedTime = 0;
   mutable std::string m_cachedData[static_cast<int>(Format::TotalFormats)];
-  mutable bool m_cachedAvailable[static_cast<int>(Format::TotalFormats)];
+  mutable bool m_cachedAvailable[static_cast<int>(Format::TotalFormats)] = {};
 
-  // Background monitoring
-  std::unique_ptr<std::thread> m_monitorThread;
-  std::atomic<bool> m_monitoring = false;
-  std::atomic<bool> m_stopMonitoring = false;
+  // Fingerprint of the clipboard as of the last hasChanged() call
+  mutable bool m_haveFingerprint = false;
+  mutable QStringList m_lastTypes;
+  mutable size_t m_lastContentHash = 0;
+
+  // Content hash of our own last commit, used to not report it as a change
+  mutable std::optional<size_t> m_ownWriteHash;
 
   // Clipboard selection type (true = clipboard, false = primary)
   bool m_useClipboard;
-
-  // Hold a ref to running wl-copy processes
-  QList<QProcess *> m_runningWlCopies;
 };

--- a/src/lib/platform/WlClipboardCollection.cpp
+++ b/src/lib/platform/WlClipboardCollection.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
@@ -35,62 +35,22 @@ IClipboard *WlClipboardCollection::getClipboard(ClipboardID id) const
   return m_clipboards[id].get();
 }
 
-bool WlClipboardCollection::hasChanged() const
+bool WlClipboardCollection::hasChanged(ClipboardID id) const
 {
-  if (!m_available) {
+  if (!m_available || id >= m_clipboards.size() || !m_clipboards[id]) {
     return false;
   }
 
-  for (const auto &clipboard : m_clipboards) {
-    if (clipboard && clipboard->hasChanged()) {
-      return true;
-    }
-  }
-
-  return false;
+  return m_clipboards[id]->hasChanged();
 }
 
-void WlClipboardCollection::startMonitoring()
+void WlClipboardCollection::resetChanged(ClipboardID id) const
 {
-  if (!m_available || m_monitoring) {
+  if (!m_available || id >= m_clipboards.size() || !m_clipboards[id]) {
     return;
   }
 
-  for (const auto &clipboard : m_clipboards) {
-    if (clipboard) {
-      clipboard->startMonitoring();
-    }
-  }
-
-  m_monitoring = true;
-}
-
-void WlClipboardCollection::stopMonitoring()
-{
-  if (!m_available || !m_monitoring) {
-    return;
-  }
-
-  for (const auto &clipboard : m_clipboards) {
-    if (clipboard) {
-      clipboard->stopMonitoring();
-    }
-  }
-
-  m_monitoring = false;
-}
-
-void WlClipboardCollection::resetChanged() const
-{
-  if (!m_available) {
-    return;
-  }
-
-  for (const auto &clipboard : m_clipboards) {
-    if (clipboard) {
-      clipboard->resetChanged();
-    }
-  }
+  m_clipboards[id]->resetChanged();
 }
 
 void WlClipboardCollection::initialize()
@@ -127,10 +87,6 @@ void WlClipboardCollection::initialize()
 
 void WlClipboardCollection::cleanup()
 {
-  if (m_monitoring) {
-    stopMonitoring();
-  }
-
   m_clipboards.clear();
   m_available = false;
 }

--- a/src/lib/platform/WlClipboardCollection.h
+++ b/src/lib/platform/WlClipboardCollection.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
@@ -33,17 +33,13 @@ public:
   //! Get clipboard for specific ID
   IClipboard *getClipboard(ClipboardID id) const;
 
-  //! Check if any clipboard has changed
-  bool hasChanged() const;
+  //! Check the given clipboard for an external change since the last call.
+  //! Spawns wl-paste, so only call when a focus blip cannot interrupt the
+  //! user (e.g. when leaving the screen).
+  bool hasChanged(ClipboardID id) const;
 
-  //! Start monitoring clipboard changes
-  void startMonitoring();
-
-  //! Stop monitoring clipboard changes
-  void stopMonitoring();
-
-  //! Reset change detection
-  void resetChanged() const;
+  //! Reset change detection for the given clipboard
+  void resetChanged(ClipboardID id) const;
 
 private:
   //! Initialize clipboard backends
@@ -55,7 +51,6 @@ private:
 private:
   std::vector<std::unique_ptr<WlClipboard>> m_clipboards;
   bool m_available = false;
-  bool m_monitoring = false;
 };
 
 } // namespace deskflow

--- a/src/unittests/platform/WlClipboardTests.cpp
+++ b/src/unittests/platform/WlClipboardTests.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
@@ -227,15 +227,9 @@ void WlClipboardTests::getTime()
 void WlClipboardTests::monitoring()
 {
   WlClipboard clipboard(kClipboardClipboard);
-  QVERIFY(clipboard.open(0));
 
-  // Clear clipboard first
-  QVERIFY(clipboard.empty());
-
-  // Start monitoring
-  clipboard.startMonitoring();
-
-  // Initially should not have changed
+  // The first check only records a baseline
+  QVERIFY(!clipboard.hasChanged());
   QVERIFY(!clipboard.hasChanged());
 
   // Make a change to the clipboard using a separate clipboard instance
@@ -243,20 +237,18 @@ void WlClipboardTests::monitoring()
   WlClipboard externalClipboard(kClipboardClipboard);
   if (externalClipboard.open(1)) {
     externalClipboard.empty();
-    externalClipboard.add(IClipboard::Format::Text, m_testString);
+    externalClipboard.add(IClipboard::Format::Text, "monitoring change test");
     externalClipboard.close();
   }
 
-  // Wait for monitoring thread to detect change
+  // Each hasChanged() call re-checks the clipboard on demand
   auto changeDetected = [&clipboard]() { return clipboard.hasChanged(); };
-  waitForClipboardCondition(clipboard, changeDetected, 1000);
+  if (!waitForClipboardCondition(clipboard, changeDetected, 3000)) {
+    QSKIP("Clipboard change detection not working in this test environment");
+  }
 
-  // Stop monitoring
-  clipboard.stopMonitoring();
-  clipboard.close();
-
-  // Note: Change detection might not work reliably in all test environments
-  // This test mainly verifies that monitoring doesn't crash
+  // The change is only reported once
+  QVERIFY(!clipboard.hasChanged());
 }
 
 void WlClipboardTests::primaryClipboard()
@@ -328,6 +320,98 @@ void WlClipboardTests::getWithoutOpen()
   // Should still be able to open and use normally
   QVERIFY(clipboard.open(0));
   clipboard.close();
+}
+
+void WlClipboardTests::commitOnClose()
+{
+  // write a transaction with several formats
+  {
+    WlClipboard clipboard(kClipboardClipboard);
+    QVERIFY(clipboard.open(0));
+    QVERIFY(clipboard.empty());
+    clipboard.add(IClipboard::Format::Text, m_testString);
+    clipboard.add(IClipboard::Format::HTML, m_testHtml);
+    clipboard.close();
+  }
+
+  // a fresh instance reads the committed selection, which offers the
+  // priority format only (wl-copy serves a single mime type)
+  WlClipboard reader(kClipboardClipboard);
+  QVERIFY(reader.open(0));
+  if (!waitForClipboardContent(reader, IClipboard::Format::Text, m_testString, 3000)) {
+    reader.close();
+    QSKIP("Wl-clipboard did not receive contents in time");
+  }
+  QCOMPARE(reader.get(IClipboard::Format::Text), m_testString);
+  reader.close();
+}
+
+void WlClipboardTests::binaryRoundTrip()
+{
+  // bitmap data contains NUL bytes, which only survive stdin transport
+  std::string binary("BM\0\x01\x02\0\x03binary\0data", 17);
+
+  {
+    WlClipboard clipboard(kClipboardClipboard);
+    QVERIFY(clipboard.open(0));
+    QVERIFY(clipboard.empty());
+    clipboard.add(IClipboard::Format::Bitmap, binary);
+    QCOMPARE(clipboard.get(IClipboard::Format::Bitmap), binary);
+    clipboard.close();
+  }
+
+  WlClipboard reader(kClipboardClipboard);
+  QVERIFY(reader.open(0));
+  if (!waitForClipboardContent(reader, IClipboard::Format::Bitmap, binary, 3000)) {
+    reader.close();
+    QSKIP("Wl-clipboard did not receive contents in time");
+  }
+  QCOMPARE(reader.get(IClipboard::Format::Bitmap), binary);
+  reader.close();
+}
+
+void WlClipboardTests::sameTypeChangeDetected()
+{
+  const auto externalWrite = [](const std::string &text) {
+    WlClipboard external(kClipboardClipboard);
+    QVERIFY(external.open(0));
+    QVERIFY(external.empty());
+    external.add(IClipboard::Format::Text, text);
+    external.close();
+  };
+
+  WlClipboard clipboard(kClipboardClipboard);
+
+  // establish a baseline
+  externalWrite(m_testString);
+  auto changeDetected = [&clipboard]() { return clipboard.hasChanged(); };
+  waitForClipboardCondition(clipboard, changeDetected, 3000);
+
+  // a copy with identical mime types must still be detected as a change
+  externalWrite(m_testString2);
+  if (!waitForClipboardCondition(clipboard, changeDetected, 5000)) {
+    QSKIP("Clipboard change detection not working in this test environment");
+  }
+}
+
+void WlClipboardTests::ownWriteSuppressed()
+{
+  WlClipboard clipboard(kClipboardClipboard);
+
+  // take a baseline
+  clipboard.hasChanged();
+
+  // our own write must not be reported as an external change
+  QVERIFY(clipboard.open(0));
+  QVERIFY(clipboard.empty());
+  clipboard.add(IClipboard::Format::Text, "own write suppression test");
+  clipboard.close();
+
+  // re-check a few times while the committed wl-copy takes the selection
+  for (int i = 0; i < 5; ++i) {
+    QVERIFY(!clipboard.hasChanged());
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
 }
 
 bool WlClipboardTests::waitForClipboardCondition(WlClipboard &, std::function<bool()> condition, int timeoutMs)

--- a/src/unittests/platform/WlClipboardTests.h
+++ b/src/unittests/platform/WlClipboardTests.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
 
@@ -50,6 +50,10 @@ private Q_SLOTS:
   void closeWithoutOpen();
   void addWithoutOpen();
   void getWithoutOpen();
+  void commitOnClose();
+  void binaryRoundTrip();
+  void sameTypeChangeDetected();
+  void ownWriteSuppressed();
 #endif
 
 private:


### PR DESCRIPTION
## Description

The wl-clipboard backend (`core/wlClipboard`, opt-in) had a few bugs that made it effectively non-functional, plus one that made it actively harmful:

- change detection compared the list of offered mime types between polls, so copying two texts in a row was never detected. Detection now fingerprints the content (capped at 256KB) as well as the types.
- detection ran on a polling thread. On compositors without a data-control protocol (gnome), every wl-paste invocation briefly steals keyboard focus, so background polling drops keystrokes while you type. The poll thread is gone. `checkClipboards()` now checks on demand when the cursor leaves the screen, which is the one moment a focus blip can't interrupt typing and exactly when the clipboard needs syncing.
- clipboard data was passed to wl-copy as a process argument (binary data impossible), and `empty()` plus every `add()` spawned a separate wl-copy, each stealing the selection from the previous one. Writes are now accumulated during the open/close transaction and committed as one wl-copy fed via stdin, picking the most valuable format (wl-copy offers a single mime type per invocation).
- our own writes were detected as external changes, so the server would re-broadcast its own clipboard. The committed content hash is now remembered and adopted silently.
- wl-paste reads had no timeout and could hang the app; all reads are bounded now.
- EiScreen fired `ClipboardChanged` for every clipboard ID when any changed; it's now per-ID.

HTML is no longer dropped on `add()`. Multi-mime simultaneous offers still need data-control or the clipboard portal (#9431), this just makes the existing backend work in the meantime.

## AI tools used for this PR

Claude Code (Claude Fable 5, `claude-fable-5`) was used to implement the changes and write the tests. Reviewed and tested manually on a real setup.

## Fixed/related issues

Related: #7600, #8165. Complements #8031 / #9431 (portal clipboard) rather than competing with it.

## How has this been tested?

- WlClipboardTests extended with regression tests for same-mime-type change detection, binary round-trip (NUL bytes), commit-on-close format priority, and own-write suppression: 19/19 pass on a live GNOME 49 Wayland session (Fedora 43, Qt 6.10.3); full unit suite passes (25/25)
- In daily use as a Wayland server with macOS clients; the keystroke-dropping regression from background polling was caught and fixed during that testing
