### PR TITLE
fix(gui): avoid QSystemTrayIcon crash on macOS 27

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -59,7 +59,9 @@ using namespace deskflow::gui;
 MainWindow::MainWindow()
     : ui{std::make_unique<Ui::MainWindow>()},
       m_coreProcess(m_serverConfig),
+#ifndef Q_OS_MACOS
       m_trayIcon{new QSystemTrayIcon(this)},
+#endif
       m_guiDupeChecker{new QLocalServer(this)},
       m_daemonIpcClient{new ipc::DaemonIpcClient(this)},
       m_logDock{new LogDock(this)},
@@ -160,6 +162,10 @@ MainWindow::MainWindow()
 }
 MainWindow::~MainWindow()
 {
+#ifdef Q_OS_MACOS
+  cleanupMacOSStatusItem();
+#endif
+
   // Stop network monitoring
   if (m_networkMonitor) {
     m_networkMonitor->stopMonitoring();
@@ -264,9 +270,9 @@ void MainWindow::connectSlots()
   connect(m_actionRestartCore, &QAction::triggered, this, &MainWindow::resetCore);
   connect(m_actionStopCore, &QAction::triggered, this, &MainWindow::stopCore);
 
-  // Mac os tray will only show a menu
-  if (!deskflow::platform::isMac())
-    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
+#ifndef Q_OS_MACOS
+  connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
+#endif
 
   connect(&m_coreProcess, &CoreProcess::connectedClientsChanged, this, &MainWindow::serverClientsChanged);
   connect(&m_coreProcess, &CoreProcess::unrecognisedClient, this, &MainWindow::handleUnrecognisedClient);
@@ -366,12 +372,14 @@ void MainWindow::serverConfigSaving()
   m_serverConfig.commit();
 }
 
+#ifndef Q_OS_MACOS
 void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
 {
   if (reason != QSystemTrayIcon::Trigger)
     return;
   isVisible() ? hide() : showAndActivate();
 }
+#endif
 
 void MainWindow::coreProcessError(CoreProcess::Error error)
 {
@@ -428,7 +436,9 @@ void MainWindow::clearSettings()
   disconnect(&m_coreProcess, nullptr, this, nullptr);
   disconnect(&m_versionChecker, nullptr, this, nullptr);
   disconnect(m_guiDupeChecker, nullptr, this, nullptr);
+#ifndef Q_OS_MACOS
   disconnect(m_trayIcon, nullptr, this, nullptr);
+#endif
   disconnect(m_logDock->toggleViewAction(), nullptr, this, nullptr);
 
   m_coreProcess.stop();
@@ -689,10 +699,16 @@ void MainWindow::setupTrayIcon()
   );
   trayMenu->insertSeparator(m_actionMinimize);
   trayMenu->insertSeparator(m_actionTrayQuit);
+#ifdef Q_OS_MACOS
+  setupMacOSStatusItem(trayMenu);
+#else
   m_trayIcon->setContextMenu(trayMenu);
+#endif
 
   setTrayIcon();
+#ifndef Q_OS_MACOS
   m_trayIcon->show();
+#endif
 }
 
 void MainWindow::applyConfig()
@@ -732,13 +748,22 @@ void MainWindow::saveSettings() const
 void MainWindow::setTrayIcon()
 {
   static const auto fallbackPath = QStringLiteral(":/icons/%1-%2/apps/64/%3");
+#ifdef Q_OS_MACOS
+  const auto applyTrayIcon = [](const QIcon &icon) {
+    setMacOSStatusItemIcon(icon);
+  };
+#else
+  const auto applyTrayIcon = [this](const QIcon &icon) {
+    m_trayIcon->setIcon(icon);
+  };
+#endif
 
   QString themeIcon = kRevFqdnName;
   if (!Settings::value(Settings::Gui::SymbolicTrayIcon).toBool()) {
     if (deskflow::platform::isMac())
-      m_trayIcon->setIcon(QIcon::fromTheme(themeIcon));
+      applyTrayIcon(QIcon::fromTheme(themeIcon));
     else
-      m_trayIcon->setIcon(QIcon(fallbackPath.arg(kAppId, QStringLiteral("dark"), themeIcon)));
+      applyTrayIcon(QIcon(fallbackPath.arg(kAppId, QStringLiteral("dark"), themeIcon)));
     return;
   }
 
@@ -751,13 +776,13 @@ void MainWindow::setTrayIcon()
     );
     const QString theme = settings.value(QStringLiteral("SystemUsesLightTheme"), 1).toBool() ? QStringLiteral("light")
                                                                                              : QStringLiteral("dark");
-    m_trayIcon->setIcon(QIcon(fallbackPath.arg(kAppId, theme, themeIcon)));
+    applyTrayIcon(QIcon(fallbackPath.arg(kAppId, theme, themeIcon)));
     return;
   }
 
   auto icon = QIcon::fromTheme(themeIcon, QIcon(fallbackPath.arg(kAppId, iconMode(), themeIcon)));
   icon.setIsMask(true);
-  m_trayIcon->setIcon(icon);
+  applyTrayIcon(icon);
 }
 
 void MainWindow::handleLogLine(const QString &line)

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -12,7 +12,6 @@
 #include <QMainWindow>
 #include <QProcess>
 #include <QRegularExpression>
-#include <QSystemTrayIcon>
 
 #include "VersionChecker.h"
 #include "config/ServerConfig.h"
@@ -22,6 +21,8 @@
 
 #ifdef Q_OS_MACOS
 #include "gui/OSXHelpers.h"
+#else
+#include <QSystemTrayIcon>
 #endif
 
 class QAction;
@@ -90,7 +91,9 @@ private:
   void coreConnectionStateChanged(ConnectionState state);
   void coreProcessStateChanged(ProcessState state);
 
+#ifndef Q_OS_MACOS
   void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
+#endif
   void serverConnectionConfigureClient(const QString &clientName);
 
   void clearSettings();
@@ -175,7 +178,9 @@ private:
   QSize m_expandedSize = QSize();
   QStringList m_checkedClients;
   QStringList m_checkedServers;
+#ifndef Q_OS_MACOS
   QSystemTrayIcon *m_trayIcon = nullptr;
+#endif
   QLocalServer *m_guiDupeChecker = nullptr;
   deskflow::gui::ipc::DaemonIpcClient *m_daemonIpcClient = nullptr;
 

--- a/src/lib/gui/OSXHelpers.h
+++ b/src/lib/gui/OSXHelpers.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2015 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -8,9 +9,15 @@
 
 #include <QString>
 
+class QIcon;
+class QMenu;
+
 void requestOSXNotificationPermission();
 bool isOSXDevelopmentBuild();
 bool showOSXNotification(const QString &title, const QString &body);
 bool isOSXInterfaceStyleDark();
 void forceAppActive();
 void macOSNativeHide();
+void setupMacOSStatusItem(QMenu *menu);
+void setMacOSStatusItemIcon(const QIcon &icon);
+void cleanupMacOSStatusItem();

--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2015 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -16,8 +17,211 @@
 
 #import <QtGlobal>
 
+#include <QAction>
+#include <QIcon>
+#include <QImage>
+#include <QMenu>
+#include <QPixmap>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace {
+QString statusItemTitle(const QString &text)
+{
+  QString title;
+  title.reserve(text.size());
+
+  for (auto i = 0; i < text.size(); ++i) {
+    if (text.at(i) != u'&') {
+      title.append(text.at(i));
+      continue;
+    }
+
+    if ((i + 1) < text.size() && text.at(i + 1) == u'&') {
+      title.append(u'&');
+      ++i;
+    }
+  }
+
+  return title;
+}
+} // namespace
+
+@interface DeskflowStatusItemActionTarget : NSObject {
+  QAction *m_action;
+}
+- (instancetype)initWithAction:(QAction *)action;
+- (void)trigger:(id)sender;
+@end
+
+@implementation DeskflowStatusItemActionTarget
+
+- (instancetype)initWithAction:(QAction *)action
+{
+  self = [super init];
+  if (self != nil) {
+    m_action = action;
+  }
+  return self;
+}
+
+- (void)trigger:(id)sender
+{
+  Q_UNUSED(sender);
+  if (m_action != nullptr && m_action->isEnabled()) {
+    m_action->trigger();
+  }
+}
+
+@end
+
+@interface DeskflowStatusItemController : NSObject <NSMenuDelegate> {
+  NSStatusItem *m_statusItem;
+  NSMenu *m_menu;
+  QMenu *m_qtMenu;
+  NSMutableArray *m_targets;
+}
+- (void)setQtMenu:(QMenu *)menu;
+- (void)setIcon:(const QIcon &)icon;
+- (void)cleanup;
+@end
+
+@implementation DeskflowStatusItemController
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self != nil) {
+    m_statusItem = [[[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength] retain];
+    m_menu = [[NSMenu alloc] initWithTitle:@"Deskflow"];
+    [m_menu setDelegate:self];
+    [m_statusItem setMenu:m_menu];
+    [m_statusItem button].imagePosition = NSImageOnly;
+    [m_statusItem button].toolTip = @"Deskflow";
+    m_targets = [[NSMutableArray alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  [self cleanup];
+  [super dealloc];
+}
+
+- (void)setQtMenu:(QMenu *)menu
+{
+  m_qtMenu = menu;
+}
+
+- (void)clearMenu
+{
+  [m_targets removeAllObjects];
+  [m_menu removeAllItems];
+}
+
+- (void)addActions:(const QList<QAction *> &)actions toMenu:(NSMenu *)menu
+{
+  for (auto *action : actions) {
+    if (action == nullptr || !action->isVisible()) {
+      continue;
+    }
+
+    if (action->isSeparator()) {
+      [menu addItem:[NSMenuItem separatorItem]];
+      continue;
+    }
+
+    auto *target = [[DeskflowStatusItemActionTarget alloc] initWithAction:action];
+    [m_targets addObject:target];
+    [target release];
+
+    auto *item = [[NSMenuItem alloc] initWithTitle:statusItemTitle(action->text()).toNSString()
+                                           action:@selector(trigger:)
+                                    keyEquivalent:@""];
+    [item setTarget:target];
+    [item setEnabled:action->isEnabled()];
+
+    if (action->isCheckable()) {
+      [item setState:action->isChecked() ? NSControlStateValueOn : NSControlStateValueOff];
+    }
+
+    if (auto *subMenu = action->menu(); subMenu != nullptr) {
+      auto *nativeSubMenu = [[NSMenu alloc] initWithTitle:statusItemTitle(subMenu->title()).toNSString()];
+      [self addActions:subMenu->actions() toMenu:nativeSubMenu];
+      [item setSubmenu:nativeSubMenu];
+      [nativeSubMenu release];
+    }
+
+    [menu addItem:item];
+    [item release];
+  }
+}
+
+- (void)menuWillOpen:(NSMenu *)menu
+{
+  Q_UNUSED(menu);
+  [self clearMenu];
+  if (m_qtMenu != nullptr) {
+    [self addActions:m_qtMenu->actions() toMenu:m_menu];
+  }
+}
+
+- (void)setIcon:(const QIcon &)icon
+{
+  if (m_statusItem == nil || icon.isNull()) {
+    return;
+  }
+
+  auto pixmap = icon.pixmap(QSize(22, 22));
+  if (pixmap.isNull()) {
+    return;
+  }
+
+  const auto image = pixmap.toImage();
+  CGImageRef cgImage = image.toCGImage();
+  if (cgImage == nullptr) {
+    return;
+  }
+
+  const auto scale = pixmap.devicePixelRatio();
+  auto *statusImage = [[NSImage alloc] initWithCGImage:cgImage
+                                                 size:NSMakeSize(pixmap.width() / scale, pixmap.height() / scale)];
+  [statusImage setTemplate:icon.isMask()];
+  [[m_statusItem button] setImage:statusImage];
+  [statusImage release];
+  CGImageRelease(cgImage);
+}
+
+- (void)cleanup
+{
+  if (m_statusItem != nil) {
+    [m_statusItem setMenu:nil];
+    [[NSStatusBar systemStatusBar] removeStatusItem:m_statusItem];
+    [m_statusItem release];
+    m_statusItem = nil;
+  }
+
+  [m_targets release];
+  m_targets = nil;
+
+  [m_menu release];
+  m_menu = nil;
+  m_qtMenu = nullptr;
+}
+
+@end
+
+static DeskflowStatusItemController *s_statusItemController = nil;
+
+static DeskflowStatusItemController *statusItemController()
+{
+  if (s_statusItemController == nil) {
+    s_statusItemController = [[DeskflowStatusItemController alloc] init];
+  }
+  return s_statusItemController;
+}
 
 void requestOSXNotificationPermission()
 {
@@ -106,4 +310,21 @@ void macOSNativeHide()
 {
   [NSApp hide:nil];
   [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+void setupMacOSStatusItem(QMenu *menu)
+{
+  [statusItemController() setQtMenu:menu];
+}
+
+void setMacOSStatusItemIcon(const QIcon &icon)
+{
+  [statusItemController() setIcon:icon];
+}
+
+void cleanupMacOSStatusItem()
+{
+  [s_statusItemController cleanup];
+  [s_statusItemController release];
+  s_statusItemController = nil;
 }

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -106,6 +106,7 @@ private:
   bool updateScreenShape();
   bool updateScreenShape(const CGDirectDisplayID, const CGDisplayChangeSummaryFlags);
   void postMouseEvent(CGPoint &) const;
+  void activateWindowAtCursor(CGPoint) const;
 
   // convenience function to send events
   void sendEvent(EventTypes type, void * = nullptr) const;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -34,6 +34,7 @@
 #include "platform/OSXScreenSaver.h"
 
 #include <AppKit/NSEvent.h>
+#include <AppKit/NSRunningApplication.h>
 #include <AvailabilityMacros.h>
 #include <IOKit/hidsystem/event_status_driver.h>
 #include <dispatch/dispatch.h>
@@ -60,6 +61,15 @@ enum
 };
 
 static const double kCarbonLoopWaitTimeout = 10.0;
+
+static AXUIElementRef copyWindowElement(AXUIElementRef element)
+{
+  CFTypeRef window = nullptr;
+  if (AXUIElementCopyAttributeValue(element, kAXWindowAttribute, &window) == kAXErrorSuccess && window != nullptr) {
+    return (AXUIElementRef)window;
+  }
+  return nullptr;
+}
 
 int getSecureInputEventPID();
 std::string getProcessName(int pid);
@@ -491,6 +501,66 @@ void OSXScreen::postMouseEvent(CGPoint &pos) const
   CFRelease(event);
 }
 
+void OSXScreen::activateWindowAtCursor(CGPoint pos) const
+{
+  if (!AXIsProcessTrusted()) {
+    return;
+  }
+
+  AXUIElementRef system = AXUIElementCreateSystemWide();
+  if (system == nullptr) {
+    return;
+  }
+
+  AXUIElementRef element = nullptr;
+  AXError error =
+      AXUIElementCopyElementAtPosition(system, static_cast<float>(pos.x), static_cast<float>(pos.y), &element);
+  CFRelease(system);
+  if (error != kAXErrorSuccess || element == nullptr) {
+    return;
+  }
+
+  AXUIElementRef window = copyWindowElement(element);
+  if (window == nullptr) {
+    CFRelease(element);
+    return;
+  }
+
+  pid_t pid = 0;
+  if (AXUIElementGetPid(element, &pid) != kAXErrorSuccess) {
+    AXUIElementGetPid(window, &pid);
+  }
+
+  AXUIElementRef app = nullptr;
+  if (pid > 0) {
+    app = AXUIElementCreateApplication(pid);
+  }
+
+  AXUIElementSetAttributeValue(window, kAXMainAttribute, kCFBooleanTrue);
+  AXUIElementPerformAction(window, kAXRaiseAction);
+
+  if (app != nullptr) {
+    AXUIElementSetAttributeValue(app, kAXFrontmostAttribute, kCFBooleanTrue);
+    AXUIElementSetAttributeValue(app, kAXFocusedWindowAttribute, window);
+  }
+
+  if (pid > 0) {
+    @autoreleasepool {
+      NSRunningApplication *runningApp = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+      if (runningApp != nil && ![runningApp isActive]) {
+        [runningApp unhide];
+        [runningApp activateWithOptions:0];
+      }
+    }
+  }
+
+  if (app != nullptr) {
+    CFRelease(app);
+  }
+  CFRelease(window);
+  CFRelease(element);
+}
+
 void OSXScreen::fakeMouseButton(ButtonID id, bool press)
 {
   // Buttons are indexed from one, but the button down array is indexed from zero
@@ -544,6 +614,11 @@ void OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
   MouseButtonEventMapType thisButtonMap = MouseButtonEventMap[index];
   CGEventType type = thisButtonMap[state];
+
+  if (press) {
+    // Some macOS versions no longer promote inactive windows for synthetic HID clicks.
+    activateWindowAtCursor(pos);
+  }
 
   CGEventRef event = CGEventCreateMouseEvent(nullptr, type, pos, static_cast<CGMouseButton>(index));
 


### PR DESCRIPTION
## Description
Fixes the macOS 27 beta crash when opening the Deskflow menu bar item by using a native macOS status item instead of Qt's QSystemTrayIcon on macOS.

## AI tools used for this PR
Codex/GPT-5 helped investigate the crash, draft the patch, and run local build/test commands. I reviewed and tested the change.

## Fixed/related issues
fixes: #9835

## How has this been tested?
Built locally on macOS 27 beta. Launched Deskflow, clicked the menu bar item, verified the menu opened, and quit from the menu without a crash.

Closes #9835 