### PR TITLE
feat: remember previously used server addresses

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -42,6 +42,7 @@ public:
     inline static const auto XScrollScale = QStringLiteral("client/xScrollScale");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
+    inline static const auto ServerAddressHistory = QStringLiteral("client/serverAddressHistory");
     inline static const auto XdpRestoreToken = QStringLiteral("client/xdpRestoreToken");
   };
   struct Core
@@ -210,6 +211,7 @@ private:
     , Settings::Client::InvertXScroll
     , Settings::Client::LanguageSync
     , Settings::Client::RemoteHost
+    , Settings::Client::ServerAddressHistory
     , Settings::Client::YScrollScale
     , Settings::Client::XScrollScale
     , Settings::Client::XdpRestoreToken

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -31,10 +31,12 @@
 #include "net/FingerprintDatabase.h"
 #include "widgets/StatusBar.h"
 
+#include <QAbstractItemView>
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QKeyEvent>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QMenu>
@@ -283,8 +285,9 @@ void MainWindow::connectSlots()
 
   connect(ui->btnRestartCore, &QPushButton::clicked, this, &MainWindow::resetCore);
 
-  connect(ui->lineHostname, &QLineEdit::returnPressed, ui->btnRestartCore, &QPushButton::click);
-  connect(ui->lineHostname, &QLineEdit::textChanged, this, &MainWindow::remoteHostChanged);
+  connect(ui->comboHostname->lineEdit(), &QLineEdit::returnPressed, ui->btnRestartCore, &QPushButton::click);
+  connect(ui->comboHostname, &QComboBox::editTextChanged, this, &MainWindow::remoteHostChanged);
+  connect(ui->btnRemoveHostname, &QPushButton::clicked, this, &MainWindow::removeHostname);
 
   connect(ui->btnSaveServerConfig, &QPushButton::clicked, this, &MainWindow::saveServerConfig);
   connect(ui->btnConfigureServer, &QPushButton::clicked, this, [this] { showConfigureServer(""); });
@@ -401,6 +404,8 @@ void MainWindow::startCore()
   if (m_coreProcess.mode() == CoreMode::Server && Settings::value(Settings::Core::Interface).toString().isEmpty()) {
     m_serverStartIPs = NetworkMonitor::validAddresses();
     m_serverStartSuggestedIP = m_serverStartIPs.isEmpty() ? "" : m_serverStartIPs.first();
+  } else if (m_coreProcess.mode() == CoreMode::Client) {
+    saveServerAddressHistory(ui->comboHostname->currentText());
   }
 
   m_actionStartCore->setVisible(false);
@@ -649,7 +654,7 @@ void MainWindow::open()
   }
 
   if (Settings::value(Settings::Gui::AutoStartCore).toBool()) {
-    if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
+    if (ui->rbModeClient->isChecked() && ui->comboHostname->currentText().isEmpty())
       return;
     startCore();
   }
@@ -703,8 +708,9 @@ void MainWindow::applyConfig()
     setWindowTitle(kAppName);
   }
 
+  loadServerAddressHistory();
   if (const auto host = Settings::value(Settings::Client::RemoteHost).toString(); !host.isEmpty())
-    ui->lineHostname->setText(host);
+    ui->comboHostname->setCurrentText(host);
 
   updateLocalFingerprint();
   setTrayIcon();
@@ -724,8 +730,8 @@ void MainWindow::saveSettings() const
   } else if (ui->rbModeServer->isChecked()) {
     Settings::setValue(Settings::Core::CoreMode, Settings::CoreMode::Server);
   }
-  if (!ui->lineHostname->text().isEmpty())
-    Settings::setValue(Settings::Client::RemoteHost, ui->lineHostname->text());
+  if (!ui->comboHostname->currentText().isEmpty())
+    Settings::setValue(Settings::Client::RemoteHost, ui->comboHostname->currentText());
   Settings::save();
 }
 
@@ -1024,6 +1030,37 @@ void MainWindow::changeEvent(QEvent *e)
   }
 }
 
+void MainWindow::removeHostname()
+{
+  const QString itemToRemove = ui->comboHostname->currentText();
+  if (itemToRemove.isEmpty() || ui->comboHostname->count() == 0) {
+    return;
+  }
+
+  QStringList history = Settings::value(Settings::Client::ServerAddressHistory).toStringList();
+  for (int i = 0; i < history.size(); ++i) {
+    if (history[i].compare(itemToRemove, Qt::CaseInsensitive) == 0) {
+      history.removeAt(i);
+      break;
+    }
+  }
+
+  Settings::setValue(Settings::Client::ServerAddressHistory, history);
+
+  const int index = ui->comboHostname->findText(itemToRemove);
+  if (index >= 0) {
+    ui->comboHostname->removeItem(index);
+  }
+
+  if (ui->comboHostname->currentText() == itemToRemove) {
+    ui->comboHostname->setCurrentText(QString());
+  }
+
+  if (ui->comboHostname->count() == 0) {
+    ui->btnRemoveHostname->setEnabled(false);
+  }
+}
+
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
   if (obj != ui->lineEditName || event->type() != QEvent::KeyPress)
@@ -1284,5 +1321,45 @@ bool MainWindow::canRunCore() const
   const auto mode = m_coreProcess.mode();
   const bool isServer = mode == Settings::CoreMode::Server;
   const bool isClient = mode == Settings::CoreMode::Client;
-  return ((isServer || isClient) && (isClient && !ui->lineHostname->text().isEmpty()) || isServer);
+  return ((isServer || isClient) && (isClient && !ui->comboHostname->currentText().isEmpty()) || isServer);
+}
+
+void MainWindow::loadServerAddressHistory()
+{
+  const auto history = Settings::value(Settings::Client::ServerAddressHistory).toStringList();
+  ui->comboHostname->clear();
+  ui->comboHostname->addItems(history);
+  ui->btnRemoveHostname->setEnabled(ui->comboHostname->count() > 0);
+}
+
+void MainWindow::saveServerAddressHistory(const QString &address)
+{
+  QString normalized = address.trimmed().toLower();
+  if (normalized.isEmpty())
+    return;
+
+  QStringList history = Settings::value(Settings::Client::ServerAddressHistory).toStringList();
+
+  // Remove existing entry to move it to the top (case-insensitive check)
+  for (int i = 0; i < history.size(); ++i) {
+    if (history[i].compare(normalized, Qt::CaseInsensitive) == 0) {
+      history.removeAt(i);
+      break;
+    }
+  }
+
+  history.prepend(normalized);
+
+  while (history.size() > 10) {
+    history.removeLast();
+  }
+
+  Settings::setValue(Settings::Client::ServerAddressHistory, history);
+
+  // Reload combo box while preserving current text
+  const QString current = ui->comboHostname->currentText();
+  ui->comboHostname->clear();
+  ui->comboHostname->addItems(history);
+  ui->comboHostname->setCurrentText(current);
+  ui->btnRemoveHostname->setEnabled(ui->comboHostname->count() > 0);
 }

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -126,6 +126,8 @@ private:
   void handleLogLine(const QString &line);
   void updateLocalFingerprint();
   void updateScreenName();
+  void loadServerAddressHistory();
+  void saveServerAddressHistory(const QString &address);
   void saveSettings() const;
   void showConfigureServer(const QString &message);
   void showConfigureClient();
@@ -139,6 +141,7 @@ private:
   void daemonIpcClientConnectionFailed();
   void toggleCanRunCore(bool enableButtons);
   void remoteHostChanged(const QString &newRemoteHost);
+  void removeHostname();
   void updateIpLabel(const QStringList &addresses);
   void updateTimeoutDelay(int newDelay);
 

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -399,7 +399,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineHostname">
+              <widget class="QComboBox" name="comboHostname">
                <property name="minimumSize">
                 <size>
                  <width>0</width>
@@ -408,6 +408,40 @@
                </property>
                <property name="toolTip">
                 <string>&lt;html&gt;Hostname or IP address of the server computer.&lt;br/&gt;May contain a comma seperated list.&lt;/html&gt;</string>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+               <property name="insertPolicy">
+                <enum>QComboBox::NoInsert</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnRemoveHostname">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>Remove saved hostname</string>
+               </property>
+               <property name="text">
+                <string>Remove</string>
                </property>
               </widget>
              </item>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -594,6 +594,14 @@ Además, verifique que puede %1 el archivo de configuración del servidor: %2</t
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -594,6 +594,14 @@ Inoltre, verifica di poter %1 il file di configurazione del server: %2</translat
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -594,6 +594,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -594,6 +594,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -594,6 +594,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -594,6 +594,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove saved hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewScreenWidget</name>


### PR DESCRIPTION
## Description

Implemented support for remembering previously used server addresses in client mode using an editable `QComboBox`.

* Replaced server address input with an editable dropdown
* Persisted recent server address history using `QSettings`
* Limited history to 10 entries
* Prevented duplicates and moved reused addresses to the top

## AI tools used for this PR

None

## Fixed/related issues

fixes: #8114

## How has this been tested?

Tested locally on Windows by:

* Adding new server addresses
* Restarting the app to verify persistence
* Checking duplicate handling and history ordering
* Verifying history limit of 10 entries
