### PR TITLE
Move Default Lock to screen state to new settings

### DIFF
--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -328,7 +328,7 @@ void ServerConfigDialog::setSwitchDelay(int delay)
   onChange();
 }
 
-void ServerConfigDialog::toggleDefaultLockToScreenState(bool state)
+void ServerConfigDialog::toggleDefaultLockToComputerState(bool state)
 {
   if (m_defaultLockToComputerState == state)
     return;
@@ -442,7 +442,7 @@ void ServerConfigDialog::loadFromConfig()
   ui->sbSwitchCornerSize->setValue(serverConfig().switchCornerSize());
 
   m_defaultLockToComputerState = Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
-  ui->cbDefaultLockToScreenState->setChecked(m_defaultLockToComputerState);
+  ui->cbDefaultLockToComputerState->setChecked(m_defaultLockToComputerState);
 
   m_disableLockToComputer = Settings::value(Settings::Server::DisableLockToComputer).toBool();
   ui->cbDisableLockToComputer->setChecked(m_disableLockToComputer);
@@ -524,7 +524,7 @@ void ServerConfigDialog::initConnections()
   connect(ui->cbCornerBottomLeft, &QCheckBox::toggled, this, &ServerConfigDialog::toggleCornerBottomLeft);
   connect(ui->cbCornerBottomRight, &QCheckBox::toggled, this, &ServerConfigDialog::toggleCornerBottomRight);
   connect(
-      ui->cbDefaultLockToScreenState, &QCheckBox::toggled, this, &ServerConfigDialog::toggleDefaultLockToScreenState
+      ui->cbDefaultLockToComputerState, &QCheckBox::toggled, this, &ServerConfigDialog::toggleDefaultLockToComputerState
   );
   connect(ui->cbDisableLockToComputer, &QCheckBox::toggled, this, &ServerConfigDialog::toggleLockToComputer);
   connect(&m_screenSetupModel, &ScreenSetupModel::screensChanged, this, &ServerConfigDialog::onChange);

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -60,7 +60,7 @@ protected:
   void toggleSwitchDelay(bool enable);
   void setSwitchDelay(int delay);
 
-  void toggleDefaultLockToScreenState(bool state);
+  void toggleDefaultLockToComputerState(bool state);
   void toggleLockToComputer(bool disabled);
   void toggleWin32Foreground(bool enabled);
 

--- a/src/lib/gui/dialogs/ServerConfigDialog.ui
+++ b/src/lib/gui/dialogs/ServerConfigDialog.ui
@@ -435,7 +435,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="cbDefaultLockToScreenState">
+           <widget class="QCheckBox" name="cbDefaultLockToComputerState">
             <property name="text">
              <string>Enable lock to computer at startup</string>
             </property>


### PR DESCRIPTION

## Description
<!--- Describe what your changes do -->
 -  rename `cbDefaultLockToScreenState` -> `cbDefaultLockToComputerState`
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Working towards unified settings file 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
local run 