### PR TITLE
move clipboard settings to Deskflow.conf

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -143,6 +143,7 @@ This section contains options used when in server mode it will begin with `[serv
 |:-------------------|:-----------------:|:-----------|
 | defaultLockToComputerState| `true` or `false` | When this is true the cursor is locked to the new computer when switching (default: false)|
 | disableLockToComputer| `true` or `false` | If false pressing scroll lock will toggle your cursor to be locked to current computer. (default: false) |
+| enableClipboard    | `true` or `false` | When `true` the clipboard will be shared with all clients If set to ''true'' then clipboard shared and the ''clipboardSharingSize'' setting will be used. If set to false, then clipboard sharing will be disabled and the the ''clipboardSharingSize'' setting will be ignored.|
 | enableHeartbeat    | `true` or `false` | Send a heartbeat to connected clients; this has been replaced by internal keep alive (default: false)|
 | enableSwitchDelay  | `true` or `false` | Switching will be delayed by the set value (default: false)|
 | enableSwitchDoubleTap  | `true` or `false` | Enables the doubletap to switch method (default: false)|
@@ -167,7 +168,6 @@ block of a server config file as seen below. This section is used by the GUI to 
 
 ```
 [internalConfig]
-clipboardSharing=true
 clipboardSharingSize=@Variant(\0\0\0\x84\0\0\0\0\0\0<\0)
 hotkeys\1\actions\1\activeOnRelease=false
 hotkeys\1\actions\1\hasScreens=true
@@ -402,7 +402,6 @@ end
 |switchCorners | none top-left top-right bottom-left bottom-right left right top bottom all | Deskflow won't switch computers when the mouse reaches the edge of the computer if it's in a listed corner. The size of all corners is given by the `switchCornerSize` option. The first name in the list is one of the above names and defines the initial set of corners. Subsequent names are prefixed with + or - to add the corner to or remove the corner from the set, respectively. For example: `all -left +top-left` starts will all corners, removes the left corners (top and bottom) then adds the top-left back in, resulting in the top-left, bottom-left and bottom-right corners.|
 |switchCornerSize | integer (N) | Sets the size of all corners in pixels. The cursor must be within `N` pixels of the corner to be considered to be in the corner.|
 |screenSaverSync| `true` or `false`| ''Note: Removed in v1.14.1'' If set to ''false'' then Deskflow won't synchronize screen savers. Client screen savers will start according to their individual configurations. The server screen saver won't start if there is input, even if that input is directed toward a client computer.|
-|clipboardSharing| `true` or `false`|If set to ''true'' then clipboard sharing will be enabled and the ''clipboardSharingSize'' setting will be used. If set to false, then clipboard sharing will be disabled and the the ''clipboardSharingSize'' setting will be ignored.|
 |clipboardSharingSize| integer (N)| Deskflow will send a maximum of `N` kilobytes of clipboard data to another computer when the mouse transitions to that computer.|
 |keystroke(key) | actions | Binds the ''key'' combination key to the given ''actions''. ''key'' is an optional list of modifiers (''shift'', ''control'', ''alt'', ''meta'' or ''super'') optionally followed by a character or a key name, all separated by + (plus signs). You must have either modifiers or a character/key name or both. See below for `valid key names` and `actions`. Keyboard hot keys are handled while the cursor any computer. Separate actions can be assigned to press and release.|
 |mousebutton(button) | actions| Binds the modifier and mouse button combination ''button'' to the given ''actions''. ''button'' is an optional list of modifiers (''shift'', ''control'', ''alt'', ''meta'' or ''super'') followed by a button number. The primary button (the left button for right handed users) is button 1, the middle button is 2, etc. Actions can be found below. Mouse button actions are not handled while the cursor is on the server. You cannot use these to perform an action while on the server. Separate actions can be assigned to press and release.|

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -141,6 +141,7 @@ This section contains options used when in server mode it will begin with `[serv
 
 |Option              |    Valid Values   |Description|
 |:-------------------|:-----------------:|:-----------|
+| clipboardSize      | int > 0           | Deskflow will send a maximum of `N` megabytes of clipboard data to another computer when the mouse transitions to that computer.|
 | defaultLockToComputerState| `true` or `false` | When this is true the cursor is locked to the new computer when switching (default: false)|
 | disableLockToComputer| `true` or `false` | If false pressing scroll lock will toggle your cursor to be locked to current computer. (default: false) |
 | enableClipboard    | `true` or `false` | When `true` the clipboard will be shared with all clients If set to ''true'' then clipboard shared and the ''clipboardSharingSize'' setting will be used. If set to false, then clipboard sharing will be disabled and the the ''clipboardSharingSize'' setting will be ignored.|
@@ -168,7 +169,6 @@ block of a server config file as seen below. This section is used by the GUI to 
 
 ```
 [internalConfig]
-clipboardSharingSize=@Variant(\0\0\0\x84\0\0\0\0\0\0<\0)
 hotkeys\1\actions\1\activeOnRelease=false
 hotkeys\1\actions\1\hasScreens=true
 hotkeys\1\actions\1\keys\1\key=83
@@ -402,7 +402,6 @@ end
 |switchCorners | none top-left top-right bottom-left bottom-right left right top bottom all | Deskflow won't switch computers when the mouse reaches the edge of the computer if it's in a listed corner. The size of all corners is given by the `switchCornerSize` option. The first name in the list is one of the above names and defines the initial set of corners. Subsequent names are prefixed with + or - to add the corner to or remove the corner from the set, respectively. For example: `all -left +top-left` starts will all corners, removes the left corners (top and bottom) then adds the top-left back in, resulting in the top-left, bottom-left and bottom-right corners.|
 |switchCornerSize | integer (N) | Sets the size of all corners in pixels. The cursor must be within `N` pixels of the corner to be considered to be in the corner.|
 |screenSaverSync| `true` or `false`| ''Note: Removed in v1.14.1'' If set to ''false'' then Deskflow won't synchronize screen savers. Client screen savers will start according to their individual configurations. The server screen saver won't start if there is input, even if that input is directed toward a client computer.|
-|clipboardSharingSize| integer (N)| Deskflow will send a maximum of `N` kilobytes of clipboard data to another computer when the mouse transitions to that computer.|
 |keystroke(key) | actions | Binds the ''key'' combination key to the given ''actions''. ''key'' is an optional list of modifiers (''shift'', ''control'', ''alt'', ''meta'' or ''super'') optionally followed by a character or a key name, all separated by + (plus signs). You must have either modifiers or a character/key name or both. See below for `valid key names` and `actions`. Keyboard hot keys are handled while the cursor any computer. Separate actions can be assigned to press and release.|
 |mousebutton(button) | actions| Binds the modifier and mouse button combination ''button'' to the given ''actions''. ''button'' is an optional list of modifiers (''shift'', ''control'', ''alt'', ''meta'' or ''super'') followed by a button number. The primary button (the left button for right handed users) is button 1, the middle button is 2, etc. Actions can be found below. Mouse button actions are not handled while the cursor is on the server. You cannot use these to perform an action while on the server. Separate actions can be assigned to press and release.|
 

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -222,6 +222,9 @@ QVariant Settings::defaultValue(const QString &key)
   if (key == Server::SwitchDelay || key == Server::SwitchDoubleTap)
     return 250;
 
+  if (key == Server::ClipboardSize)
+    return 3; // 3 MiB
+
   return QVariant();
 }
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -105,6 +105,7 @@ public:
   {
     inline static const auto DefaultLockToComputerState = QStringLiteral("server/defaultLockToComputerState");
     inline static const auto DisableLockToComputer = QStringLiteral("server/disableLockToComputer");
+    inline static const auto EnableClipboard = QStringLiteral("server/enableClipboard");
     inline static const auto EnableHeatbeat = QStringLiteral("server/enableHeatbeat");
     inline static const auto EnableSwitchDelay = QStringLiteral("server/enableSwitchDelay");
     inline static const auto EnableSwitchDoubleTap = QStringLiteral("server/enableSwitchDoubleTap");
@@ -253,6 +254,7 @@ private:
     , Settings::Security::TlsEnabled
     , Settings::Server::DefaultLockToComputerState
     , Settings::Server::DisableLockToComputer
+    , Settings::Server::EnableClipboard
     , Settings::Server::EnableHeatbeat
     , Settings::Server::EnableSwitchDelay
     , Settings::Server::EnableSwitchDoubleTap
@@ -304,6 +306,7 @@ private:
     , Settings::Gui::SymbolicTrayIcon
     , Settings::Security::TlsEnabled
     , Settings::Security::CheckPeers
+    , Settings::Server::EnableClipboard
     , Settings::Server::Win32KeepForeground
   };
 
@@ -319,6 +322,7 @@ private:
   inline static const QStringList m_oldServerConfigKeys = {
       QStringLiteral("internalConfig/defaultLockToScreenState")
     , QStringLiteral("internalConfig/disableLockToScreen")
+    , QStringLiteral("internalConfig/clipboardSharing")
     , QStringLiteral("internalConfig/hasHeartbeat")
     , QStringLiteral("internalConfig/hasSwitchDelay")
     , QStringLiteral("internalConfig/hasSwitchDoubleTap")

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -103,6 +103,7 @@ public:
   };
   struct Server
   {
+    inline static const auto ClipboardSize = QStringLiteral("server/clipboardSize");
     inline static const auto DefaultLockToComputerState = QStringLiteral("server/defaultLockToComputerState");
     inline static const auto DisableLockToComputer = QStringLiteral("server/disableLockToComputer");
     inline static const auto EnableClipboard = QStringLiteral("server/enableClipboard");
@@ -252,6 +253,7 @@ private:
     , Settings::Security::CheckPeers
     , Settings::Security::KeySize
     , Settings::Security::TlsEnabled
+    , Settings::Server::ClipboardSize
     , Settings::Server::DefaultLockToComputerState
     , Settings::Server::DisableLockToComputer
     , Settings::Server::EnableClipboard
@@ -323,6 +325,7 @@ private:
       QStringLiteral("internalConfig/defaultLockToScreenState")
     , QStringLiteral("internalConfig/disableLockToScreen")
     , QStringLiteral("internalConfig/clipboardSharing")
+    , QStringLiteral("internalConfig/clipboardSharingSize")
     , QStringLiteral("internalConfig/hasHeartbeat")
     , QStringLiteral("internalConfig/hasSwitchDelay")
     , QStringLiteral("internalConfig/hasSwitchDoubleTap")

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -55,8 +55,7 @@ bool ServerConfig::operator==(const ServerConfig &sc) const
   return m_Screens == sc.m_Screens &&                   //
          m_SwitchCornerSize == sc.m_SwitchCornerSize && //
          m_SwitchCorners == sc.m_SwitchCorners &&       //
-         m_Hotkeys == sc.m_Hotkeys &&                   //
-         m_ClipboardSharingSize == sc.m_ClipboardSharingSize;
+         m_Hotkeys == sc.m_Hotkeys;                     //
 }
 
 void ServerConfig::save(QFile &file) const
@@ -89,8 +88,6 @@ void ServerConfig::commit()
   settings().remove("");
 
   settings().setValue("switchCornerSize", switchCornerSize());
-  settings().setValue("clipboardSharingSize", QVariant::fromValue(clipboardSharingSize()));
-
   writeSettings(settings(), switchCorners(), "switchCorner");
 
   settings().beginWriteArray("screens");
@@ -129,10 +126,6 @@ void ServerConfig::recall()
   setupScreens();
 
   setSwitchCornerSize(settings().value("switchCornerSize").toInt());
-  setClipboardSharingSize(
-      settings().value("clipboardSharingSize", (int)ServerConfig::defaultClipboardSharingSize()).toULongLong()
-  );
-
   readSettings(settings(), switchCorners(), "switchCorner", false, static_cast<int>(NumSwitchCorners));
 
   int numScreens = settings().beginReadArray("screens");
@@ -213,8 +206,6 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   outStream << "end" << Qt::endl << Qt::endl;
 
   outStream << "section: options" << Qt::endl;
-  outStream << "\t"
-            << "clipboardSharingSize = " << config.clipboardSharingSize() << Qt::endl;
   outStream << "\t"
             << "switchCorners = none ";
   for (int i = 0; i < config.switchCorners().size(); i++)
@@ -346,23 +337,6 @@ bool ServerConfig::fixNoServer(const QString &name, int &index)
   }
 
   return fixed;
-}
-
-size_t ServerConfig::defaultClipboardSharingSize()
-{
-  return 3 * 1024; // 3 MiB
-}
-
-size_t ServerConfig::setClipboardSharingSize(size_t size)
-{
-  if (size) {
-    size += 512; // Round up to the nearest megabyte
-    size /= 1024;
-    size *= 1024;
-  }
-  using std::swap;
-  swap(size, m_ClipboardSharingSize);
-  return size;
 }
 
 QSettingsProxy &ServerConfig::settings()

--- a/src/lib/gui/config/ServerConfig.cpp
+++ b/src/lib/gui/config/ServerConfig.cpp
@@ -56,7 +56,6 @@ bool ServerConfig::operator==(const ServerConfig &sc) const
          m_SwitchCornerSize == sc.m_SwitchCornerSize && //
          m_SwitchCorners == sc.m_SwitchCorners &&       //
          m_Hotkeys == sc.m_Hotkeys &&                   //
-         m_ClipboardSharing == sc.m_ClipboardSharing && //
          m_ClipboardSharingSize == sc.m_ClipboardSharingSize;
 }
 
@@ -90,7 +89,6 @@ void ServerConfig::commit()
   settings().remove("");
 
   settings().setValue("switchCornerSize", switchCornerSize());
-  settings().setValue("clipboardSharing", clipboardSharing());
   settings().setValue("clipboardSharingSize", QVariant::fromValue(clipboardSharingSize()));
 
   writeSettings(settings(), switchCorners(), "switchCorner");
@@ -134,7 +132,6 @@ void ServerConfig::recall()
   setClipboardSharingSize(
       settings().value("clipboardSharingSize", (int)ServerConfig::defaultClipboardSharingSize()).toULongLong()
   );
-  setClipboardSharing(settings().value("clipboardSharing", true).toBool());
 
   readSettings(settings(), switchCorners(), "switchCorner", false, static_cast<int>(NumSwitchCorners));
 
@@ -216,8 +213,6 @@ QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config)
   outStream << "end" << Qt::endl << Qt::endl;
 
   outStream << "section: options" << Qt::endl;
-  outStream << "\t"
-            << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << Qt::endl;
   outStream << "\t"
             << "clipboardSharingSize = " << config.clipboardSharingSize() << Qt::endl;
   outStream << "\t"
@@ -364,9 +359,6 @@ size_t ServerConfig::setClipboardSharingSize(size_t size)
     size += 512; // Round up to the nearest megabyte
     size /= 1024;
     size *= 1024;
-    setClipboardSharing(true);
-  } else {
-    setClipboardSharing(false);
   }
   using std::swap;
   swap(size, m_ClipboardSharingSize);

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -56,10 +56,6 @@ public:
   {
     return m_Hotkeys;
   }
-  bool clipboardSharing() const
-  {
-    return m_ClipboardSharing;
-  }
   size_t clipboardSharingSize() const
   {
     return m_ClipboardSharingSize;
@@ -102,10 +98,6 @@ private:
   {
     m_SwitchCornerSize = val;
   }
-  void setClipboardSharing(bool on)
-  {
-    m_ClipboardSharing = on;
-  }
   void setConfigFile(const QString &configFile) const;
   void setUseExternalConfig(bool useExternalConfig) const;
   size_t setClipboardSharingSize(size_t size);
@@ -123,7 +115,6 @@ private:
 
 private:
   int m_SwitchCornerSize = 0;
-  bool m_ClipboardSharing = true;
   QList<bool> m_SwitchCorners;
   HotkeyList m_Hotkeys;
 

--- a/src/lib/gui/config/ServerConfig.h
+++ b/src/lib/gui/config/ServerConfig.h
@@ -56,11 +56,6 @@ public:
   {
     return m_Hotkeys;
   }
-  size_t clipboardSharingSize() const
-  {
-    return m_ClipboardSharingSize;
-  }
-  static size_t defaultClipboardSharingSize();
 
   bool save(const QString &fileName) const;
   bool screenExists(const QString &screenName) const;
@@ -100,7 +95,6 @@ private:
   }
   void setConfigFile(const QString &configFile) const;
   void setUseExternalConfig(bool useExternalConfig) const;
-  size_t setClipboardSharingSize(size_t size);
   QList<bool> &switchCorners()
   {
     return m_SwitchCorners;
@@ -121,7 +115,6 @@ private:
   ScreenList m_Screens;
   int m_columns;
   int m_rows;
-  size_t m_ClipboardSharingSize = defaultClipboardSharingSize();
 };
 
 QTextStream &operator<<(QTextStream &outStream, const ServerConfig &config);

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -76,6 +76,7 @@ void ServerConfigDialog::accept()
   // original one, which is a reference to the one in MainWindow.
   setOriginalServerConfig(serverConfig());
   Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(m_protocol));
+  Settings::setValue(Settings::Server::EnableClipboard, m_enableClipboard);
   Settings::setValue(Settings::Server::EnableHeatbeat, m_enableHeartbeat);
   Settings::setValue(Settings::Server::Heartbeat, m_heartbeatRate);
   Settings::setValue(Settings::Server::EnableSwitchDelay, m_enableSwitchDelay);
@@ -217,12 +218,16 @@ void ServerConfigDialog::removeAction()
 
 void ServerConfigDialog::toggleClipboard(bool enabled)
 {
+  if (m_enableClipboard == enabled)
+    return;
+
+  m_enableClipboard = enabled;
+
   ui->sbClipboardSizeLimit->setEnabled(enabled);
   if (enabled && !ui->sbClipboardSizeLimit->value()) {
     auto size = static_cast<int>((ServerConfig::defaultClipboardSharingSize() + 512) / 1024);
     ui->sbClipboardSizeLimit->setValue(size ? size : 1);
   }
-  serverConfig().setClipboardSharing(enabled);
   onChange();
 }
 
@@ -368,7 +373,6 @@ void ServerConfigDialog::toggleExternalConfig(bool checked)
   ui->widgetExternalConfigControls->setEnabled(checked);
   ui->tabWidget->setTabEnabled(0, !checked);
   ui->tabWidget->setTabEnabled(1, !checked);
-  ui->cbEnableClipboard->setEnabled(!checked);
   ui->label_7->setEnabled(checked ? !checked : ui->cbEnableClipboard->isChecked());
   ui->sbClipboardSizeLimit->setEnabled(checked ? !checked : ui->cbEnableClipboard->isChecked());
   ui->groupCorners->setEnabled(!checked);
@@ -447,11 +451,12 @@ void ServerConfigDialog::loadFromConfig()
   m_disableLockToComputer = Settings::value(Settings::Server::DisableLockToComputer).toBool();
   ui->cbDisableLockToComputer->setChecked(m_disableLockToComputer);
 
-  ui->cbEnableClipboard->setChecked(serverConfig().clipboardSharing());
+  m_enableClipboard = Settings::value(Settings::Server::EnableClipboard).toBool();
+  ui->cbEnableClipboard->setChecked(m_enableClipboard);
+  ui->sbClipboardSizeLimit->setEnabled(m_enableClipboard);
 
   auto clipboardSharingSizeM = static_cast<int>(serverConfig().clipboardSharingSize() / 1024);
   ui->sbClipboardSizeLimit->setValue(clipboardSharingSizeM);
-  ui->sbClipboardSizeLimit->setEnabled(serverConfig().clipboardSharing());
 
   ui->listHotkeys->clear();
   for (const Hotkey &hotkey : std::as_const(serverConfig().hotkeys()))
@@ -550,6 +555,7 @@ void ServerConfigDialog::onChange()
       m_originalServerConfigIsExternal == serverConfig().useExternalConfig() &&
       m_originalServerConfigUsesExternalFile == serverConfig().configFile() &&
       m_protocol == Settings::networkProtocol() &&
+      m_enableClipboard == Settings::value(Settings::Server::EnableClipboard).toBool() &&
       m_enableHeartbeat == Settings::value(Settings::Server::EnableHeatbeat).toBool() &&
       m_heartbeatRate == Settings::value(Settings::Server::Heartbeat).toInt() &&
       m_enableSwitchDelay == Settings::value(Settings::Server::EnableSwitchDelay).toBool() &&

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -77,6 +77,7 @@ void ServerConfigDialog::accept()
   setOriginalServerConfig(serverConfig());
   Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(m_protocol));
   Settings::setValue(Settings::Server::EnableClipboard, m_enableClipboard);
+  Settings::setValue(Settings::Server::ClipboardSize, m_clipboardSize);
   Settings::setValue(Settings::Server::EnableHeatbeat, m_enableHeartbeat);
   Settings::setValue(Settings::Server::Heartbeat, m_heartbeatRate);
   Settings::setValue(Settings::Server::EnableSwitchDelay, m_enableSwitchDelay);
@@ -225,15 +226,18 @@ void ServerConfigDialog::toggleClipboard(bool enabled)
 
   ui->sbClipboardSizeLimit->setEnabled(enabled);
   if (enabled && !ui->sbClipboardSizeLimit->value()) {
-    auto size = static_cast<int>((ServerConfig::defaultClipboardSharingSize() + 512) / 1024);
-    ui->sbClipboardSizeLimit->setValue(size ? size : 1);
+    m_clipboardSize = Settings::defaultValue(Settings::Server::ClipboardSize).toUInt();
+    ui->sbClipboardSizeLimit->setValue(m_clipboardSize ? m_clipboardSize : 1);
   }
   onChange();
 }
 
 void ServerConfigDialog::setClipboardLimit(int limit)
 {
-  serverConfig().setClipboardSharingSize(limit * 1024);
+  if (m_clipboardSize == limit)
+    return;
+
+  m_clipboardSize = limit;
   onChange();
 }
 
@@ -373,8 +377,6 @@ void ServerConfigDialog::toggleExternalConfig(bool checked)
   ui->widgetExternalConfigControls->setEnabled(checked);
   ui->tabWidget->setTabEnabled(0, !checked);
   ui->tabWidget->setTabEnabled(1, !checked);
-  ui->label_7->setEnabled(checked ? !checked : ui->cbEnableClipboard->isChecked());
-  ui->sbClipboardSizeLimit->setEnabled(checked ? !checked : ui->cbEnableClipboard->isChecked());
   ui->groupCorners->setEnabled(!checked);
   serverConfig().setUseExternalConfig(checked);
   onChange();
@@ -455,8 +457,8 @@ void ServerConfigDialog::loadFromConfig()
   ui->cbEnableClipboard->setChecked(m_enableClipboard);
   ui->sbClipboardSizeLimit->setEnabled(m_enableClipboard);
 
-  auto clipboardSharingSizeM = static_cast<int>(serverConfig().clipboardSharingSize() / 1024);
-  ui->sbClipboardSizeLimit->setValue(clipboardSharingSizeM);
+  m_clipboardSize = Settings::value(Settings::Server::ClipboardSize).toUInt();
+  ui->sbClipboardSizeLimit->setValue(m_clipboardSize);
 
   ui->listHotkeys->clear();
   for (const Hotkey &hotkey : std::as_const(serverConfig().hotkeys()))
@@ -556,6 +558,7 @@ void ServerConfigDialog::onChange()
       m_originalServerConfigUsesExternalFile == serverConfig().configFile() &&
       m_protocol == Settings::networkProtocol() &&
       m_enableClipboard == Settings::value(Settings::Server::EnableClipboard).toBool() &&
+      m_clipboardSize == Settings::value(Settings::Server::ClipboardSize).toUInt() &&
       m_enableHeartbeat == Settings::value(Settings::Server::EnableHeatbeat).toBool() &&
       m_heartbeatRate == Settings::value(Settings::Server::Heartbeat).toInt() &&
       m_enableSwitchDelay == Settings::value(Settings::Server::EnableSwitchDelay).toBool() &&

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -109,6 +109,7 @@ private:
   int m_heartbeatRate;
   int m_switchDelay;
   int m_switchDoubleTap;
+  uint m_clipboardSize;
   bool m_relativeMouseMoves;
   bool m_enableSwitchDelay;
   bool m_enableSwitchDoubleTap;

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -104,6 +104,7 @@ private:
   int m_rows;
   ServerConfig &m_originalServerConfig;
   NetworkProtocol m_protocol;
+  bool m_enableClipboard;
   bool m_enableHeartbeat;
   int m_heartbeatRate;
   int m_switchDelay;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -656,8 +656,6 @@ void Config::readSectionOptions(ConfigReadContext &s)
       addOption("", kOptionScreenSwitchNeedsControl, s.parseBoolean(value));
     } else if (name == "switchNeedsAlt") {
       addOption("", kOptionScreenSwitchNeedsAlt, s.parseBoolean(value));
-    } else if (name == "clipboardSharingSize") {
-      addOption("", kOptionClipboardSharingSize, s.parseInt(value));
     } else {
       handled = false;
     }
@@ -723,6 +721,7 @@ void Config::readSectionOptions(ConfigReadContext &s)
   addOption("", kOptionRelativeMouseMoves, Settings::value(Settings::Server::RelativeMouseMoves).toInt());
   addOption("", kOptionWin32KeepForeground, Settings::value(Settings::Server::Win32KeepForeground).toInt());
   addOption("", kOptionClipboardSharing, Settings::value(Settings::Server::EnableClipboard).toBool());
+  addOption("", kOptionClipboardSharingSize, Settings::value(Settings::Server::ClipboardSize).toUInt() * 1024);
 
   throw ServerConfigReadException(s, "unexpected end of options section");
 }

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -656,8 +656,6 @@ void Config::readSectionOptions(ConfigReadContext &s)
       addOption("", kOptionScreenSwitchNeedsControl, s.parseBoolean(value));
     } else if (name == "switchNeedsAlt") {
       addOption("", kOptionScreenSwitchNeedsAlt, s.parseBoolean(value));
-    } else if (name == "clipboardSharing") {
-      addOption("", kOptionClipboardSharing, s.parseBoolean(value));
     } else if (name == "clipboardSharingSize") {
       addOption("", kOptionClipboardSharingSize, s.parseInt(value));
     } else {
@@ -724,6 +722,7 @@ void Config::readSectionOptions(ConfigReadContext &s)
   addOption("", kOptionDisableLockToScreen, Settings::value(Settings::Server::DisableLockToComputer).toInt());
   addOption("", kOptionRelativeMouseMoves, Settings::value(Settings::Server::RelativeMouseMoves).toInt());
   addOption("", kOptionWin32KeepForeground, Settings::value(Settings::Server::Win32KeepForeground).toInt());
+  addOption("", kOptionClipboardSharing, Settings::value(Settings::Server::EnableClipboard).toBool());
 
   throw ServerConfigReadException(s, "unexpected end of options section");
 }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -477,6 +477,7 @@ private:
   IEventQueue *m_events;
   inline static const QStringList m_oldNames = {
       QStringLiteral("clipboardSharing"),
+      QStringLiteral("clipboardSharingSize"),
       QStringLiteral("protocol"),
       QStringLiteral("heartbeat"),
       QStringLiteral("switchDelay"),

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -476,6 +476,7 @@ private:
   bool m_hasLockToScreenAction = false;
   IEventQueue *m_events;
   inline static const QStringList m_oldNames = {
+      QStringLiteral("clipboardSharing"),
       QStringLiteral("protocol"),
       QStringLiteral("heartbeat"),
       QStringLiteral("switchDelay"),


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Move `clipboardSharing` -> `enableClipboard` in general settings
 - Move `clipboardSharingSize` -> `clipboardSize` in general settings
 - Save only the MB size of the clipboard apply the transform when settings the option.
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Moving towards a single config file
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local smoke test