### PR TITLE
fix: do add existing aliases to the alias list correctly remove items on save

### DIFF
--- a/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
@@ -85,6 +85,8 @@ void ScreenSettingsDialog::accept()
 
   m_screen->setName(ui->lineNameEdit->text());
 
+  m_screen->aliases().clear();
+
   for (int i = 0; i < ui->listAliases->count(); i++) {
     QString alias(ui->listAliases->item(i)->text());
     if (alias == ui->lineNameEdit->text()) {
@@ -95,7 +97,8 @@ void ScreenSettingsDialog::accept()
       );
       return;
     }
-    m_screen->addAlias(alias);
+    if (!m_screen->aliases().contains(alias))
+      m_screen->addAlias(alias);
   }
 
   m_screen->setModifier(Shift, ui->comboShift->currentIndex());


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
  - Don't add existing aliases to the alias list
  - Clear the alias list before saving to avoid stale entries
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None 

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
 Fix an issue where when you have an alias and enter the screen settings screen the aliases are duplicated into the alias settings causing the server to be unable to run 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally