### PR TITLE
Fix Windows start up warnings

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -70,11 +70,6 @@ App *createApp(const CoreArgParser &parser, EventQueue &events, const QString &p
 int main(int argc, char **argv)
 {
 #if defined(Q_OS_WIN)
-  {
-    // HACK to make sure settings gets the correct qApp path
-    QCoreApplication m(argc, argv);
-  }
-
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
@@ -126,9 +121,8 @@ int main(int argc, char **argv)
   const auto processName = QFileInfo(argv[0]).fileName();
 
   App *coreApp = createApp(parser, events, processName);
-
-  QApplication app(argc, argv);
   QApplication::setApplicationName(QStringLiteral("%1 Core").arg(kAppName));
+  QApplication app(argc, argv);
 
   const auto ipcServer = new deskflow::core::ipc::CoreIpcServer(&app); // NOSONAR - Qt managed
   QObject::connect(

--- a/src/apps/deskflow-core/deskflow-core.exe.manifest
+++ b/src/apps/deskflow-core/deskflow-core.exe.manifest
@@ -8,10 +8,4 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-    </windowsSettings>
-  </application>
 </assembly>

--- a/src/apps/deskflow-daemon/deskflow-daemon.cpp
+++ b/src/apps/deskflow-daemon/deskflow-daemon.cpp
@@ -39,6 +39,9 @@ int main(int argc, char **argv)
   ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
+  QCoreApplication::setApplicationName(QStringLiteral("%1 Daemon").arg(kAppName));
+  QCoreApplication app(argc, argv);
+
   Arch arch;
   arch.init();
 
@@ -47,9 +50,6 @@ int main(int argc, char **argv)
 
   // Daemon deliberately does not have a parent, as it will be moved to a new thread.
   DaemonApp daemon(events);
-
-  QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationName(QStringLiteral("%1 Daemon").arg(kAppName));
 
   QCommandLineParser parser;
   parser.addHelpOption();


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Fix the two warnings on windows seen at start up 
 - make the QApplication as early as possible in deskflow daemon 
 - remove the settings of dpi scale in deskflow-core manifest (this is now the default that Qt apps use)
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #9861 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Tested in win vm 