### PR TITLE
fix: handle top-down DIB (negative biHeight) in Windows clipboard bitmap converter

### DIFF
--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -72,6 +72,13 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   BITMAPINFOHEADER info;
   LONG w = bitmap->bmiHeader.biWidth;
   LONG h = bitmap->bmiHeader.biHeight;
+  // A negative biHeight denotes a top-down DIB (origin at the upper-left). This is legal
+  // per the BITMAPINFOHEADER spec and is produced by e.g. macOS and some screenshot tools.
+  // The pixel buffer always contains abs(biHeight) rows. Using the signed height in the byte
+  // count below makes the product negative, which then wraps to an enormous size_t in
+  // std::string::append() and throws std::length_error ("string too long"), aborting
+  // deskflow-core (0xc0000409).
+  const LONG absHeight = (h < 0) ? -h : h;
   info.biSize = sizeof(BITMAPINFOHEADER);
   info.biWidth = w;
   info.biHeight = h;
@@ -85,6 +92,12 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   info.biClrImportant = 0;
   HDC dc = GetDC(nullptr);
   HBITMAP dst = CreateDIBSection(dc, (BITMAPINFO *)&info, DIB_RGB_COLORS, &raw, nullptr, 0);
+  if (dst == nullptr || raw == nullptr) {
+    LOG_WARN("failed to allocate destination bitmap for clipboard image");
+    ReleaseDC(nullptr, dc);
+    GlobalUnlock(data);
+    return std::string();
+  }
 
   // find the start of the pixel data
   const char *srcBits = (const char *)bitmap + bitmap->bmiHeader.biSize;
@@ -103,14 +116,14 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   // copy source image to destination image
   HDC dstDC = CreateCompatibleDC(dc);
   HGDIOBJ oldBitmap = SelectObject(dstDC, dst);
-  SetDIBitsToDevice(dstDC, 0, 0, w, h, 0, 0, 0, h, srcBits, bitmap, DIB_RGB_COLORS);
+  SetDIBitsToDevice(dstDC, 0, 0, w, absHeight, 0, 0, 0, absHeight, srcBits, bitmap, DIB_RGB_COLORS);
   SelectObject(dstDC, oldBitmap);
   DeleteDC(dstDC);
   GdiFlush();
 
   // extract data
   std::string image((const char *)&info, info.biSize);
-  image.append((const char *)raw, 4 * w * h);
+  image.append((const char *)raw, static_cast<size_t>(4) * static_cast<size_t>(w) * static_cast<size_t>(absHeight));
 
   // clean up GDI
   DeleteObject(dst);


### PR DESCRIPTION
## Description

`MSWindowsClipboardBitmapConverter::toIClipboard()` sized the destination pixel buffer with `4 * w * h`. When the source clipboard image is a **top-down DIB** — i.e. `biHeight` is **negative**, which is legal per the `BITMAPINFOHEADER` spec and is what macOS/Retina clipboards and several Windows screenshot tools produce — the signed product is negative and wraps to a huge `size_t` in `std::string::append(ptr, count)`. That exceeds `max_size()` and throws `std::length_error("string too long")`. The throw is unhandled on the clipboard worker thread, so `deskflow-core` fail-fasts (Windows exception `0xc0000409`).

**Symptom:** on a Windows server, moving the cursor to a client screen while an **image** is on the Windows clipboard crashes/restarts `deskflow-core`, and keeps doing so for as long as that image stays on the clipboard (copying plain text clears it). Observed bitmaps all had negative heights — e.g. `3186x-1560`, and `268x-58` / `2256x-308` in the reports collected under #7329. The 24/32-bit "canonical form" fast-path above is skipped for these because they are `BI_BITFIELDS` (`convert image from: depth=32 comp=3`), not `BI_RGB`, so they take the conversion path.

This change:
- computes `absHeight = abs(biHeight)` and uses it (with `size_t` arithmetic) for the `append` length — the actual crash fix;
- passes a non-negative height / scan-line count to `SetDIBitsToDevice` (a negative count is invalid);
- null-checks `CreateDIBSection` before dereferencing `raw`.

## Disclosure of AI use

This patch — both the root-cause analysis and the code — was produced with **Claude (Anthropic's Claude Code)**. A human filed #9869 and is coordinating, and (per the offer below) will help test.

## Related Issue

fixes: #9869

## How Has This Been Tested?

**Not yet runtime-tested.** I don't have a Windows + Qt6 + MSVC build environment, so `deskflow-core` could not be compiled/run on my side — which is why this is a **draft** (@nbolton kindly offered to test on #9869). The change is confined to one function, uses an existing log macro (`LOG_WARN`, `base/Log.h`), and is reasoned from the crash and the GDI/DIB semantics rather than observed in a build.

The **buffer-size calculation is the critical fix** (it's the throw site). The thing most worth confirming once built is that **top-down images still come through correctly oriented**, not merely that the crash is gone. Happy to adjust based on your testing.
