### PR TITLE
Protect Clipboards with mutexes

### DIFF
--- a/src/lib/deskflow/Clipboard.cpp
+++ b/src/lib/deskflow/Clipboard.cpp
@@ -21,6 +21,7 @@ Clipboard::Clipboard()
 
 bool Clipboard::empty()
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot empty clipboard, not open");
     return false;
@@ -43,6 +44,7 @@ bool Clipboard::empty()
 
 void Clipboard::add(Format format, const std::string &data)
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot add to clipboard, not open");
     return;
@@ -60,6 +62,7 @@ void Clipboard::add(Format format, const std::string &data)
 
 bool Clipboard::open(Time time) const
 {
+  std::scoped_lock lock{m_mutex};
   if (m_open) {
     LOG_DEBUG("skipping clipboard open, already open");
     return true;
@@ -73,6 +76,7 @@ bool Clipboard::open(Time time) const
 
 void Clipboard::close() const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("clipboard is not open");
   }
@@ -86,6 +90,7 @@ Clipboard::Time Clipboard::getTime() const
 
 bool Clipboard::has(Format format) const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot check for clipboard format, not open");
     return false;
@@ -95,6 +100,7 @@ bool Clipboard::has(Format format) const
 
 std::string Clipboard::get(Format format) const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot get clipboard format, not open");
     return "";

--- a/src/lib/deskflow/Clipboard.h
+++ b/src/lib/deskflow/Clipboard.h
@@ -9,6 +9,8 @@
 
 #include "deskflow/IClipboard.h"
 
+#include <mutex>
+
 //! Memory buffer clipboard
 /*!
 This class implements a clipboard that stores data in memory.
@@ -53,6 +55,7 @@ public:
 
 private:
   mutable bool m_open = false;
+  mutable std::mutex m_mutex;
   mutable Time m_time;
   bool m_owner = false;
   Time m_timeOwned;

--- a/src/lib/platform/EiClipboard.cpp
+++ b/src/lib/platform/EiClipboard.cpp
@@ -18,6 +18,7 @@ EiClipboard::EiClipboard(ClipboardID id) : m_id(id)
 
 bool EiClipboard::empty()
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot empty clipboard, not open");
     return false;
@@ -40,6 +41,7 @@ bool EiClipboard::empty()
 
 void EiClipboard::add(Format format, const std::string &data)
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot add to clipboard, not open");
     return;
@@ -57,6 +59,7 @@ void EiClipboard::add(Format format, const std::string &data)
 
 bool EiClipboard::open(Time time) const
 {
+  std::scoped_lock lock{m_mutex};
   if (m_open) {
     LOG_DEBUG("skipping clipboard open, already open");
     return true;
@@ -70,6 +73,7 @@ bool EiClipboard::open(Time time) const
 
 void EiClipboard::close() const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("clipboard is not open");
   }
@@ -83,6 +87,7 @@ EiClipboard::Time EiClipboard::getTime() const
 
 bool EiClipboard::has(Format format) const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot check for clipboard format, not open");
     return false;
@@ -92,6 +97,7 @@ bool EiClipboard::has(Format format) const
 
 std::string EiClipboard::get(Format format) const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_open) {
     LOG_WARN("cannot get clipboard format, not open");
     return "";

--- a/src/lib/platform/EiClipboard.h
+++ b/src/lib/platform/EiClipboard.h
@@ -8,6 +8,7 @@
 
 #include "deskflow/ClipboardTypes.h"
 #include "deskflow/IClipboard.h"
+#include <mutex>
 
 namespace deskflow {
 
@@ -43,6 +44,7 @@ private:
   ClipboardID m_id;
   mutable bool m_open = false;
   mutable Time m_time = 0;
+  mutable std::mutex m_mutex;
   bool m_owner = false;
   Time m_timeOwned = 0;
   bool m_added[static_cast<int>(Format::TotalFormats)] = {false, false, false};

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -125,6 +125,7 @@ bool MSWindowsClipboard::open(Time time) const
 
   for (int i = 0; i < kMaxRetries; ++i) {
     if (OpenClipboard(m_window)) {
+      std::scoped_lock lock{m_mutex};
       m_time = time;
       return true;
     }
@@ -147,6 +148,7 @@ void MSWindowsClipboard::close() const
 
 IClipboard::Time MSWindowsClipboard::getTime() const
 {
+  std::scoped_lock lock{m_mutex};
   return m_time;
 }
 

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -10,6 +10,7 @@
 
 #include "deskflow/IClipboard.h"
 
+#include <mutex>
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
@@ -68,6 +69,7 @@ private:
   using ConverterList = std::vector<IMSWindowsClipboardConverter *>;
 
   HWND m_window;
+  mutable std::mutex m_mutex;
   mutable Time m_time;
   ConverterList m_converters;
   static UINT s_ownershipFormat;

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -231,6 +231,7 @@ Atom XWindowsClipboard::getSelection() const
 
 bool XWindowsClipboard::empty()
 {
+  std::scoped_lock lock{m_mutex};
   assert(m_open);
 
   LOG_DEBUG("empty clipboard %d", m_id);
@@ -277,6 +278,7 @@ void XWindowsClipboard::add(Format format, const std::string &data)
 
 bool XWindowsClipboard::open(Time time) const
 {
+  std::scoped_lock lock{m_mutex};
   if (m_open) {
     LOG_WARN("failed to open clipboard: already opened");
     return false;
@@ -318,6 +320,7 @@ void XWindowsClipboard::close() const
 
   LOG_DEBUG("close clipboard %d", m_id);
 
+  std::scoped_lock lock{m_mutex};
   // unlock clipboard
   if (m_motif) {
     motifUnlockClipboard();
@@ -330,6 +333,7 @@ void XWindowsClipboard::close() const
 IClipboard::Time XWindowsClipboard::getTime() const
 {
   checkCache();
+  std::scoped_lock lock{m_mutex};
   return m_timeOwned;
 }
 
@@ -382,6 +386,7 @@ IXWindowsClipboardConverter *XWindowsClipboard::getConverter(Atom target, bool o
 
 void XWindowsClipboard::checkCache() const
 {
+  std::scoped_lock lock{m_mutex};
   if (!m_checkCache) {
     return;
   }
@@ -413,6 +418,7 @@ void XWindowsClipboard::clearCache() const
 
 void XWindowsClipboard::doClearCache()
 {
+  std::scoped_lock lock{m_mutex};
   m_checkCache = false;
   m_cached = false;
   for (int32_t index = 0; index < static_cast<int>(Format::TotalFormats); ++index) {
@@ -432,6 +438,7 @@ void XWindowsClipboard::fillCache() const
 
 void XWindowsClipboard::doFillCache()
 {
+  std::scoped_lock lock{m_mutex};
   if (m_motif) {
     motifFillCache();
   } else {
@@ -517,6 +524,7 @@ bool XWindowsClipboard::icccmGetSelection(Atom target, Atom *actualTarget, std::
   assert(actualTarget != nullptr);
   assert(data != nullptr);
 
+  std::scoped_lock lock{m_mutex};
   // request data conversion
   if (CICCCMGetClipboard getter(m_window, m_time, m_atomData);
       !getter.readClipboard(m_display, m_selection, target, actualTarget, data)) {
@@ -977,6 +985,7 @@ bool XWindowsClipboard::sendReply(Reply *reply)
     }
 
     if (!reply->m_replied) {
+      std::scoped_lock lock{m_mutex};
       sendNotify(reply->m_requestor, m_selection, reply->m_target, None, reply->m_time);
 
       // don't wait for any reply (because we're not expecting one)
@@ -1002,6 +1011,7 @@ bool XWindowsClipboard::sendReply(Reply *reply)
 
   // nothing to log
   if (CLOG->getFilter() < LogLevel::Level::Verbose) {
+    std::scoped_lock lock{m_mutex};
     sendNotify(
         reply->m_requestor, m_selection, reply->m_target, reply->m_property, static_cast<unsigned int>(reply->m_time)
     );
@@ -1050,7 +1060,7 @@ bool XWindowsClipboard::sendReply(Reply *reply)
   if (props != nullptr) {
     XFree(props);
   }
-
+  std::scoped_lock lck{m_mutex};
   sendNotify(reply->m_requestor, m_selection, reply->m_target, reply->m_property, reply->m_time);
 
   // wait for delete notify
@@ -1092,6 +1102,7 @@ bool XWindowsClipboard::wasOwnedAtTime(::Time time) const
 {
   // not owned if we've never owned the selection
   checkCache();
+  std::scoped_lock lock{m_mutex};
   if (m_timeOwned == 0) {
     return false;
   }
@@ -1147,6 +1158,7 @@ Atom XWindowsClipboard::getTimestampData(std::string &data, int *format) const
   assert(format != nullptr);
 
   checkCache();
+  std::scoped_lock lock{m_mutex};
   XWindowsUtil::appendTimeData(data, m_timeOwned);
   *format = 32;
   return m_atomInteger;

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -15,6 +15,7 @@
 
 #include <list>
 #include <map>
+#include <mutex>
 #include <vector>
 
 #include <X11/Xlib.h>
@@ -286,6 +287,7 @@ private:
   Window m_window;
   ClipboardID m_id;
   Atom m_selection;
+  mutable std::mutex m_mutex;
   mutable bool m_open = false;
   mutable Time m_time = 0;
   bool m_owner = false;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
   We have several mutable vars in the clipboards but no mutex to guard them. This adds the mutex to all clipboard classes other than the OSX one that does not appear to have any mutable vars
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Sonar has flagged these as reliability issues 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Tested wayland <-> wayland clipboard. 