### PR TITLE
refactor: replace use of insert for std::maps with try_emplace

### DIFF
--- a/src/lib/deskflow/KeyState.cpp
+++ b/src/lib/deskflow/KeyState.cpp
@@ -1100,10 +1100,10 @@ void KeyState::updateModifierKeyState(
   deskflow::KeyMap::ButtonToKeyMap oldKeys;
   deskflow::KeyMap::ButtonToKeyMap newKeys;
   for (const auto &[modifier, keyItem] : oldModifiers) {
-    oldKeys.insert(std::make_pair(keyItem.m_button, &keyItem));
+    oldKeys.try_emplace(keyItem.m_button, &keyItem);
   }
   for (const auto &[modifier, keyItem] : newModifiers) {
-    newKeys.insert(std::make_pair(keyItem.m_button, &keyItem));
+    newKeys.try_emplace(keyItem.m_button, &keyItem);
   }
 
   // get the modifier buttons that were pressed or released

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -80,7 +80,7 @@ void SocketMultiplexer::addSocket(ISocket *socket, ISocketMultiplexerJob *job)
     // serviceThread().
     JobCursor j = m_socketJobs.insert(m_socketJobs.end(), job);
     m_update = true;
-    m_socketJobMap.insert(std::make_pair(socket, j));
+    m_socketJobMap.try_emplace(socket, j);
   } else {
     if (JobCursor j = i->second; *j != job) {
       delete *j;

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -806,7 +806,7 @@ MSWindowsDesks::Desk *MSWindowsDesks::addDesk(const std::wstring &name, HDESK hd
   desk->m_targetID = GetCurrentThreadId();
   desk->m_thread = new Thread(new TMethodJob<MSWindowsDesks>(this, &MSWindowsDesks::deskThread, desk));
   waitForDesk();
-  m_desks.insert(std::make_pair(name, desk));
+  m_desks.try_emplace(name, desk);
   return desk;
 }
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -595,7 +595,7 @@ uint32_t MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
   }
 
   if (!err) {
-    m_hotKeys.insert(std::make_pair(id, HotKeyItem(vk, modifiers)));
+    m_hotKeys.try_emplace(id, HotKeyItem(vk, modifiers));
     m_hotKeyToIDMap[HotKeyItem(vk, modifiers)] = id;
   } else {
     m_oldHotKeyIDs.push_back(id);

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -358,7 +358,7 @@ uint32_t OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     return 0;
   }
 
-  m_hotKeys.insert(std::make_pair(id, HotKeyItem(ref, macKey, macMask)));
+  m_hotKeys.try_emplace(id, HotKeyItem(ref, macKey, macMask));
 
   LOG_DEBUG(
       "registered hotkey %s (id=%04x mask=%04x) as id=%d", deskflow::KeyMap::formatKey(key, mask).c_str(), key, mask, id

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -701,7 +701,7 @@ void XWindowsClipboard::motifFillCache()
     }
 
     // save it
-    motifFormats.insert(std::make_pair(motifFormat.m_type, data));
+    motifFormats.try_emplace(motifFormat.m_type, data);
   }
 
   // try each converter in order (because they're in order of

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -398,7 +398,7 @@ void XWindowsKeyState::updateKeysymMap(deskflow::KeyMap &keyMap)
   for (unsigned int i = 0; i < 8; ++i) {
     const KeyCode *buttons = modifiers->modifiermap + i * modifiers->max_keypermod;
     for (int j = 0; j < modifiers->max_keypermod; ++j) {
-      modifierButtons.insert(std::make_pair(buttons[j], i));
+      modifierButtons.try_emplace(buttons[j], i);
     }
   }
   XFreeModifiermap(modifiers);
@@ -722,7 +722,7 @@ void XWindowsKeyState::updateKeysymMapXKB(deskflow::KeyMap &keyMap)
 
             // save modifier
             m_modifierFromX[8 * group + j] |= (1u << modifierBit);
-            m_modifierToX.insert(std::make_pair(1u << modifierBit, 1u << j));
+            m_modifierToX.try_emplace(1u << modifierBit, 1u << j);
           }
         }
 

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -431,7 +431,7 @@ void XWindowsScreenSaver::addWatchXScreenSaver(Window window)
     }
     if (!error) {
       // if successful then add the window to our list
-      m_watchWindows.insert(std::make_pair(window, attr.your_event_mask));
+      m_watchWindows.try_emplace(window, attr.your_event_mask);
     }
   }
 }

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -41,10 +41,10 @@ bool Config::addScreen(const std::string &name)
   }
 
   // add cell
-  m_map.insert(std::make_pair(name, Cell()));
+  m_map.try_emplace(name, Cell());
 
   // add name
-  m_nameToCanonicalName.insert(std::make_pair(name, name));
+  m_nameToCanonicalName.try_emplace(name, name);
 
   return true;
 }
@@ -67,11 +67,11 @@ bool Config::renameScreen(const std::string &oldName, const std::string &newName
   // update cell
   Cell tmpCell = index->second;
   m_map.erase(index);
-  m_map.insert(std::make_pair(newName, tmpCell));
+  m_map.try_emplace(newName, tmpCell);
 
   // update name
   m_nameToCanonicalName.erase(oldCanonical);
-  m_nameToCanonicalName.insert(std::make_pair(newName, newName));
+  m_nameToCanonicalName.try_emplace(newName, newName);
 
   // update connections
   Name oldNameObj(this, oldName);
@@ -138,7 +138,7 @@ bool Config::addAlias(const std::string &canonical, const std::string &alias)
   }
 
   // insert alias
-  m_nameToCanonicalName.insert(std::make_pair(alias, canonical));
+  m_nameToCanonicalName.try_emplace(alias, canonical);
 
   return true;
 }
@@ -1442,7 +1442,7 @@ bool Config::Cell::add(const CellEdge &src, const CellEdge &dst)
   }
 
   m_neighbors.erase(src);
-  m_neighbors.insert(std::make_pair(src, dst));
+  m_neighbors.try_emplace(src, dst);
   return true;
 }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1907,7 +1907,7 @@ bool Server::addClient(BaseClientProxy *client)
 
   // add to list
   m_clientSet.insert(client);
-  m_clients.insert(std::make_pair(name, client));
+  m_clients.try_emplace(name, client);
 
   // initialize client data
   int32_t x;
@@ -1970,7 +1970,7 @@ void Server::closeClient(BaseClientProxy *client, const char *msg)
   // move client to closing list
   removeClient(client);
 
-  m_oldClients.insert(std::make_pair(client, timer));
+  m_oldClients.try_emplace(client, timer);
 
   // if this client is the active screen then we have to
   // jump off of it


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Replace uses of `std::map<>::insert` with `std::map<>::try_emplace` as recommended by modern C++ standards.
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None , maybe some sonar issues ? 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally tested with a clean build and connection to a client. 