### PR TITLE
Remove undocumented hold modifiers to switch code

### DIFF
--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -628,12 +628,6 @@ void Config::readSectionOptions(ConfigReadContext &s)
       } catch (SocketAddressException &e) {
         throw ServerConfigReadException(s, std::string("invalid address argument ") + e.what());
       }
-    } else if (name == "switchNeedsShift") {
-      addOption("", kOptionScreenSwitchNeedsShift, s.parseBoolean(value));
-    } else if (name == "switchNeedsControl") {
-      addOption("", kOptionScreenSwitchNeedsControl, s.parseBoolean(value));
-    } else if (name == "switchNeedsAlt") {
-      addOption("", kOptionScreenSwitchNeedsAlt, s.parseBoolean(value));
     } else {
       handled = false;
     }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -460,6 +460,7 @@ private:
       QStringLiteral("clipboardSharingSize"),
       QStringLiteral("switchCornerSize"),
       QStringLiteral("switchCorners"),
+      QStringLiteral("switchNeeds"),
       QStringLiteral("protocol"),
       QStringLiteral("heartbeat"),
       QStringLiteral("switchDelay"),

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -841,16 +841,6 @@ bool Server::isSwitchOkay(
     stopSwitch();
   }
 
-  // check for optional needed modifiers
-  if (KeyModifierMask mods = this->m_primaryClient->getToggleMask();
-      !preventSwitch && ((this->m_switchNeedsShift && ((mods & KeyModifierShift) != KeyModifierShift)) ||
-                         (this->m_switchNeedsControl && ((mods & KeyModifierControl) != KeyModifierControl)) ||
-                         (this->m_switchNeedsAlt && ((mods & KeyModifierAlt) != KeyModifierAlt)))) {
-    LOG_VERBOSE("need modifiers to switch");
-    preventSwitch = true;
-    stopSwitch();
-  }
-
   return !preventSwitch;
 }
 
@@ -1076,10 +1066,6 @@ void Server::processOptions()
     return;
   }
 
-  m_switchNeedsShift = false;   // it seems if i don't add these
-  m_switchNeedsControl = false; // lines, the 'reload config' option
-  m_switchNeedsAlt = false;     // doesnt' work correct.
-
   bool newRelativeMoves = m_relativeMoves;
   for (auto [optionId, optionValue] : *options) {
     const OptionID id = optionId;
@@ -1096,12 +1082,6 @@ void Server::processOptions()
         m_switchTwoTapDelay = 0.0;
       }
       stopSwitchTwoTap();
-    } else if (id == kOptionScreenSwitchNeedsControl) {
-      m_switchNeedsControl = (value != 0);
-    } else if (id == kOptionScreenSwitchNeedsShift) {
-      m_switchNeedsShift = (value != 0);
-    } else if (id == kOptionScreenSwitchNeedsAlt) {
-      m_switchNeedsAlt = (value != 0);
     } else if (id == kOptionRelativeMouseMoves) {
       newRelativeMoves = (value != 0);
     } else if (id == kOptionDefaultLockToScreenState) {

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -454,11 +454,6 @@ private:
   bool m_switchTwoTapEngaged = false;
   bool m_switchTwoTapArmed = false;
 
-  // modifiers needed before switching
-  bool m_switchNeedsShift = false;
-  bool m_switchNeedsControl = false;
-  bool m_switchNeedsAlt = false;
-
   // relative mouse move option
   bool m_relativeMoves = false;
 


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Removes undocumented switchNeeds[Shift|Alt|Control]
 Based on poll results from https://github.com/deskflow/deskflow/discussions/9863
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Removed unused options from the options sections
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally run smoke test