### PR TITLE
upgrade server options section  setting to new format

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -96,13 +96,18 @@ Settings::Settings(QObject *parent) : QObject(parent)
 
 void Settings::upgradeSettings()
 {
-
   if (const auto logValue = m_settings->value(Settings::Log::Level).toString();
       !LogLevel::logLevelOptions().contains(logValue, Qt::CaseInsensitive))
     m_settings->setValue(Settings::Log::Level, defaultValue(Settings::Log::Level));
 
   for (const auto [oldKey, newKey] : m_upgradedMap.asKeyValueRange()) {
-    if (m_settings->contains(oldKey) && !m_settings->contains(newKey)) {
+    if (m_settings->contains(newKey) || !m_settings->contains(oldKey))
+      continue;
+    if (oldKey == InternalConfig::Protocol) {
+      m_settings->setValue(newKey, networkProtocolToOption(NetworkProtocol(m_settings->value(oldKey).toInt())));
+    } else if (oldKey == InternalConfig::ClipboardSharingSize) {
+      m_settings->setValue(newKey, m_settings->value(oldKey).toUInt() / 1024);
+    } else {
       m_settings->setValue(newKey, m_settings->value(oldKey));
     }
   }
@@ -118,9 +123,8 @@ void Settings::cleanSettings()
       continue;
     if (const auto group = key.mid(0, key.indexOf('/')); !m_validKeys.contains(key) && m_validGroup.contains(group))
       m_settings->remove(key);
-    if (!m_settings->value(key).canConvert<QStringList>() && m_settings->value(key).toString().isEmpty()) {
+    if (!m_settings->value(key).canConvert<QStringList>() && m_settings->value(key).toString().isEmpty())
       m_settings->remove(key);
-    }
   }
 }
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -128,6 +128,27 @@ public:
     inline static const auto Aliases = QStringLiteral("screen_%1/aliases");
   };
 
+  // Track Removed keys to make upgrading config easier
+  // REMOVE FOR 2.0
+  struct InternalConfig
+  {
+    inline static const auto NumRows = QStringLiteral("internalConfig/numRows");
+    inline static const auto NumColumns = QStringLiteral("internalConfig/numColumns");
+    inline static const auto ClipboardSharing = QStringLiteral("internalConfig/clipboardSharing");
+    inline static const auto Heatbeat = QStringLiteral("internalConfig/heartbeat");
+    inline static const auto SwitchDelay = QStringLiteral("internalConfig/switchDelay");
+    inline static const auto HasHeartbeat = QStringLiteral("internalConfig/hasHeartbeat");
+    inline static const auto HasSwitchDelay = QStringLiteral("internalConfig/hasSwitchDelay");
+    inline static const auto HasSwitchDoubleTap = QStringLiteral("internalConfig/hasSwitchDoubleTap");
+    inline static const auto DefaultLockToScreenState = QStringLiteral("internalConfig/defaultLockToScreenState");
+    inline static const auto DisableLockToScreen = QStringLiteral("internalConfig/disableLockToScreen");
+    inline static const auto SwitchDoubleTapDelay = QStringLiteral("internalConfig/switchDoubleTap");
+    inline static const auto Win32KeepForeground = QStringLiteral("internalConfig/win32KeepForeground");
+    inline static const auto RelativeMouseMoves = QStringLiteral("internalConfig/relativeMouseMoves");
+    inline static const auto Protocol = QStringLiteral("internalConfig/protocol");
+    inline static const auto ClipboardSharingSize = QStringLiteral("internalConfig/clipboardSharingSize");
+  };
+
   // Enums types used in settings
   // The use of enum classes is not use for these
   // enum classes are more specific when used with QVariant
@@ -336,26 +357,42 @@ private:
   // Contains settings keys to be upgraded.
   inline static const QMap<QString, QString> m_upgradedMap = {
     /*             OLD KEY                        NEW KEY          */
-    {QStringLiteral("core/screenName"), Settings::Core::ComputerName}
+      {Core::ScreenName, Core::ComputerName}
+    , {InternalConfig::NumColumns, Server::GridWidth}
+    , {InternalConfig::NumRows, Server::GridHeight}
+    , {InternalConfig::Heatbeat, Server::Heartbeat}
+    , {InternalConfig::SwitchDelay, Server::SwitchDelay}
+    , {InternalConfig::HasHeartbeat, Server::EnableHeatbeat}
+    , {InternalConfig::HasSwitchDelay, Server::EnableSwitchDelay}
+    , {InternalConfig::HasSwitchDoubleTap, Server::EnableSwitchDoubleTap}
+    , {InternalConfig::ClipboardSharing, Server::EnableClipboard}
+    , {InternalConfig::DisableLockToScreen, Server::DisableLockToComputer}
+    , {InternalConfig::DefaultLockToScreenState, Server::DefaultLockToComputerState}
+    , {InternalConfig::SwitchDoubleTapDelay, Server::SwitchDoubleTap}
+    , {InternalConfig::Win32KeepForeground, Server::Win32KeepForeground}
+    , {InternalConfig::RelativeMouseMoves, Server::RelativeMouseMoves}
+    , {InternalConfig::Protocol, Server::Protocol}
+    , {InternalConfig::ClipboardSharingSize, Server::ClipboardSize}
   };
-  // Contains settings removed from server-configuration file
+
+// Contains settings removed from server-configuration file
   inline static const QStringList m_oldServerConfigKeys = {
-      QStringLiteral("internalConfig/defaultLockToScreenState")
-    , QStringLiteral("internalConfig/disableLockToScreen")
-    , QStringLiteral("internalConfig/clipboardSharing")
-    , QStringLiteral("internalConfig/clipboardSharingSize")
-    , QStringLiteral("internalConfig/hasHeartbeat")
-    , QStringLiteral("internalConfig/hasSwitchDelay")
-    , QStringLiteral("internalConfig/hasSwitchDoubleTap")
-    , QStringLiteral("internalConfig/heartbeat")
-    , QStringLiteral("internalConfig/protocol")
-    , QStringLiteral("internalConfig/numColumns")
-    , QStringLiteral("internalConfig/numRows")
-    , QStringLiteral("internalConfig/relativeMouseMoves")
+      InternalConfig::DefaultLockToScreenState
+    , InternalConfig::DisableLockToScreen
+    , InternalConfig::ClipboardSharing
+    , InternalConfig::ClipboardSharingSize
+    , InternalConfig::HasHeartbeat
+    , InternalConfig::HasSwitchDelay
+    , InternalConfig::HasSwitchDoubleTap
+    , InternalConfig::Heatbeat
+    , InternalConfig::NumColumns
+    , InternalConfig::NumRows
+    , InternalConfig::RelativeMouseMoves
+    , InternalConfig::SwitchDelay
+    , InternalConfig::SwitchDoubleTapDelay
+    , InternalConfig::Win32KeepForeground
+    , InternalConfig::Protocol
     , QStringLiteral("internalConfig/switchCorner")
-    , QStringLiteral("internalConfig/switchDelay")
-    , QStringLiteral("internalConfig/switchDoubleTap")
-    , QStringLiteral("internalConfig/win32KeepForeground")
   };
   // clang-format on
 };


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Provides upgrade for almost all the settings moved to the Deskflow.conf . The only one currently not moved over are the aliases. 
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Upgrades from 1.26.0 should keep their settings where possible. 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local test with settings from1.26.0 -> now 