### PR TITLE
fix: release EIS emulation grab when idle so client screens can sleep

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -88,6 +88,8 @@ EiScreen::~EiScreen()
   m_events->adoptBuffer(nullptr);
   m_events->removeHandler(EventTypes::System, m_events->getSystemTarget());
 
+  cancelIdleEmulationTimer();
+
   cleanupEi();
 
   delete m_keyState;
@@ -294,6 +296,7 @@ void EiScreen::fakeMouseButton(ButtonID button, bool press)
     break;
   }
 
+  ensureEmulating();
   ei_device_button_button(m_eiPointer, code, press);
   ei_device_frame(m_eiPointer, ei_now(m_ei));
 }
@@ -310,6 +313,7 @@ void EiScreen::fakeMouseMove(int32_t x, int32_t y)
   if (!m_eiAbs)
     return;
 
+  ensureEmulating();
   ei_device_pointer_motion_absolute(m_eiAbs, x, y);
   ei_device_frame(m_eiAbs, ei_now(m_ei));
 }
@@ -319,6 +323,7 @@ void EiScreen::fakeMouseRelativeMove(int32_t dx, int32_t dy) const
   if (!m_eiPointer)
     return;
 
+  ensureEmulating();
   ei_device_pointer_motion(m_eiPointer, dx, dy);
   ei_device_frame(m_eiPointer, ei_now(m_ei));
 }
@@ -332,6 +337,7 @@ void EiScreen::fakeMouseWheel(ScrollDelta delta) const
   // libei and deskflow seem to use opposite directions, so we have
   // to send EI the opposite of the value received if we want to remain
   // compatible with other platforms (including X11).
+  ensureEmulating();
   ei_device_scroll_discrete(m_eiPointer, -delta.x, -delta.y);
   ei_device_frame(m_eiPointer, ei_now(m_ei));
 }
@@ -343,6 +349,7 @@ void EiScreen::fakeKey(uint32_t keycode, bool isDown) const
 
   auto xkbKeycode = keycode + 8;
   m_keyState->updateXkbState(xkbKeycode, isDown);
+  ensureEmulating();
   ei_device_keyboard_key(m_eiKeyboard, keycode, isDown);
   ei_device_frame(m_eiKeyboard, ei_now(m_ei));
 }
@@ -361,22 +368,62 @@ void EiScreen::disable()
   // Socket-based clipboard is passive (no monitoring needed)
 }
 
+void EiScreen::cancelIdleEmulationTimer() const
+{
+  if (m_idleEmulationTimer) {
+    m_events->removeHandler(EventTypes::Timer, m_idleEmulationTimer);
+    m_events->deleteTimer(m_idleEmulationTimer);
+    m_idleEmulationTimer = nullptr;
+  }
+}
+
+void EiScreen::ensureEmulating() const
+{
+  if (m_isPrimary || !m_isOnScreen)
+    return;
+
+  if (!m_isEmulating) {
+    ++m_sequenceNumber;
+    if (m_eiPointer)
+      ei_device_start_emulating(m_eiPointer, m_sequenceNumber);
+    if (m_eiKeyboard)
+      ei_device_start_emulating(m_eiKeyboard, m_sequenceNumber);
+    if (m_eiAbs)
+      ei_device_start_emulating(m_eiAbs, m_sequenceNumber);
+    m_isEmulating = true;
+  }
+
+  cancelIdleEmulationTimer();
+  if (Settings::value(Settings::Core::PreventSleep).toBool())
+    return;
+
+  m_idleEmulationTimer = m_events->newOneShotTimer(s_idleEmulationTimeout, nullptr);
+  m_events->addHandler(EventTypes::Timer, m_idleEmulationTimer, [this](const auto &) { stopEmulating(); });
+}
+
+void EiScreen::stopEmulating() const
+{
+  cancelIdleEmulationTimer();
+  if (!m_isEmulating)
+    return;
+  if (m_eiPointer)
+    ei_device_stop_emulating(m_eiPointer);
+  if (m_eiKeyboard)
+    ei_device_stop_emulating(m_eiKeyboard);
+  if (m_eiAbs)
+    ei_device_stop_emulating(m_eiAbs);
+  m_isEmulating = false;
+}
+
 void EiScreen::enter()
 {
   m_isOnScreen = true;
-  if (!m_isPrimary) {
-    ++m_sequenceNumber;
-    if (m_eiPointer) {
-      ei_device_start_emulating(m_eiPointer, m_sequenceNumber);
-    }
-    if (m_eiKeyboard) {
-      ei_device_start_emulating(m_eiKeyboard, m_sequenceNumber);
-    }
-    if (m_eiAbs) {
-      ei_device_start_emulating(m_eiAbs, m_sequenceNumber);
-      fakeMouseMove(m_cursorX, m_cursorY);
-    }
-  } else {
+  if (!m_isPrimary && m_eiAbs) {
+    // Emulation is started lazily by ensureEmulating() on the first injected
+    // input and released again after a short idle, so this screen can DPMS-sleep
+    // while the cursor sits here with no relayed activity.
+    fakeMouseMove(m_cursorX, m_cursorY);
+  } else if (m_isPrimary) {
     LOG_DEBUG("releasing input capture at x=%i y=%i", m_cursorX, m_cursorY);
     m_portalInputCapture->release(m_cursorX, m_cursorY);
   }
@@ -390,15 +437,7 @@ bool EiScreen::canLeave()
 void EiScreen::leave()
 {
   if (!m_isPrimary) {
-    if (m_eiPointer) {
-      ei_device_stop_emulating(m_eiPointer);
-    }
-    if (m_eiKeyboard) {
-      ei_device_stop_emulating(m_eiKeyboard);
-    }
-    if (m_eiAbs) {
-      ei_device_stop_emulating(m_eiAbs);
-    }
+    stopEmulating();
   }
 
   m_isOnScreen = false;
@@ -577,12 +616,24 @@ void EiScreen::removeDevice(struct ei_device *device)
 {
   LOG_DEBUG("removing device %s", ei_device_get_name(device));
 
-  if (device == m_eiPointer)
+  bool wasTracked = false;
+  if (device == m_eiPointer) {
     m_eiPointer = ei_device_unref(m_eiPointer);
-  if (device == m_eiKeyboard)
+    wasTracked = true;
+  }
+  if (device == m_eiKeyboard) {
     m_eiKeyboard = ei_device_unref(m_eiKeyboard);
-  if (device == m_eiAbs)
+    wasTracked = true;
+  }
+  if (device == m_eiAbs) {
     m_eiAbs = ei_device_unref(m_eiAbs);
+    wasTracked = true;
+  }
+
+  if (wasTracked) {
+    m_isEmulating = false;
+    cancelIdleEmulationTimer();
+  }
 
   for (auto it = m_eiDevices.begin(); it != m_eiDevices.end(); it++) {
     if (*it == device) {
@@ -894,11 +945,13 @@ void EiScreen::handleSystemEvent(const Event &)
       break;
     case EI_EVENT_DEVICE_PAUSED:
       LOG_DEBUG("device %s is paused", ei_device_get_name(device));
+      m_isEmulating = false;
+      cancelIdleEmulationTimer();
       break;
     case EI_EVENT_DEVICE_RESUMED:
       LOG_DEBUG("device %s is resumed", ei_device_get_name(device));
       if (!m_isPrimary && m_isOnScreen) {
-        ei_device_start_emulating(device, ++m_sequenceNumber);
+        ensureEmulating();
       }
       break;
     case EI_EVENT_KEYBOARD_MODIFIERS:

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -22,6 +22,8 @@ struct ei_event;
 struct ei_seat;
 struct ei_device;
 
+class EventQueueTimer;
+
 namespace deskflow {
 
 class EiKeyState;
@@ -122,6 +124,9 @@ private:
 
   void handleConnectedToEisEvent(const Event &event);
   void handlePortalSessionClosed();
+  void ensureEmulating() const;
+  void stopEmulating() const;
+  void cancelIdleEmulationTimer() const;
 
   static void handleEiLogEvent(ei *ei, const ei_log_priority priority, const char *message, ei_log_context *)
   {
@@ -151,7 +156,15 @@ private:
   ei_device *m_eiKeyboard = nullptr;
   ei_device *m_eiAbs = nullptr;
 
-  std::uint32_t m_sequenceNumber = 0;
+  mutable std::uint32_t m_sequenceNumber = 0;
+
+  // Lazily-started EIS emulation: only grab while relayed input is actually
+  // flowing, and release after a short idle so the compositor can DPMS-sleep
+  // this screen even while the deskflow cursor logically sits on it.
+  mutable bool m_isEmulating = false;
+  mutable EventQueueTimer *m_idleEmulationTimer = nullptr;
+  // Chosen empirically on one machine in 2026-06; not derived from any protocol constant.
+  static constexpr double s_idleEmulationTimeout = 4.0;
 
   std::uint32_t m_activeSides = 0;
   std::uint32_t m_x = 0;


### PR DESCRIPTION
## Description

On the Wayland/libei backend, a deskflow **client** (secondary screen) keeps its
input devices in the EIS *emulating* state for the entire time the cursor is on
that screen: `EiScreen::enter()` calls `ei_device_start_emulating()` and the grab
is only released in `leave()`.

While that grab is held, the compositor will not power the output off via DPMS.
The practical effect on a client is that the screen can **never go to sleep**
(nor be blanked by an idle-lock/screensaver) as long as the deskflow cursor sits
on it, even when no input is actually flowing and the machine is otherwise idle.
Notably the grab does **not** reset the compositor's idle timer, so an idle
DPMS-off is still *requested* on schedule and then immediately aborted/reverted.

This change makes the emulation grab follow *actual input* rather than *cursor
presence*:

- `enter()` no longer eagerly `start_emulating()`s; it positions the cursor via
  `fakeMouseMove()`, which starts emulation on demand.
- A new `ensureEmulating()` starts emulation on the first injected event and
  (re)arms a short one-shot idle timer (`IEventQueue::newOneShotTimer`).
- A new `stopEmulating()` releases the grab when the idle timer fires, or on
  `leave()`.

After `s_idleEmulationTimeout` (4 s) with no relayed input, the grab is released,
so the compositor is free to power the screen off; the next injected event
re-grabs and wakes it. Screens that are actively being used are unaffected (the
grab simply stays alive while events keep arriving). Only `EiScreen.cpp/.h` are
touched; the primary/server path is unchanged.

Open question for maintainers: `s_idleEmulationTimeout` is a hard-coded 4 s. Happy
to make it a setting if preferred.
Moreover, if this behavior of...not allowing DPMS while the mouse/input is active on the client is a feature, not a bug, then so be it, but it ends up not allowing DPMS at all in my instance, so happy to refactor this as a configurable user-facing option if other users would PREFER this behavior.

As far as I can tell, since I have "prevent this computer from going to sleep" disabled, this wouldn't necessarily be expected behavior.

## AI tools used for this PR

Claude (model: Claude Opus 4.8) was used throughout: to diagnose the root cause
(comparing `ei_device_start/stop_emulating` lifetime against the compositor's
DPMS behaviour), to design and write the patch, and to drive the runtime
validation below. All changes were reviewed and tested by me on real hardware.

## Fixed/related issues

Loosely related to #9121 (but I think this is its own behavior bug).

## How has this been tested?

Built from this branch (`cmake -B build -G Ninja && cmake --build build`) and run
as the live client, validated on real hardware:

- Hardware/stack: AMD RX 9070 XT (RDNA4, amdgpu), MSI MPG 274U over DisplayPort,
  KWin Wayland / Plasma 6.7, openSUSE Tumbleweed; deskflow client connected to a
  remote server.
- Method: with the deskflow cursor confirmed parked on the client screen (via the
  `entering screen` log, no `leaving screen` during the test), requested a
  DPMS-off and watched the amdgpu driver's `link_set_dpms_off` / `link_set_dpms_on`
  trace (`drm.debug=0x16`).
- Stock binary: DPMS-off is aborted (no completed `link_set_dpms_off`; the panel
  flashes dark for ~0.5 s and comes back).
- Patched binary: after the 4 s idle-release fires, DPMS-off **completes and holds**
  (`link_set_dpms_off` with no following `link_set_dpms_on`); the panel stays off
  until input arrives, then re-grabs and wakes. Confirmed both in the kernel trace
  and visually (held dark ~10 s until the screen was turned back on).
- Active use sanity check: moving the mouse / typing on the client immediately
  re-grabs and behaves as before.
