### PR TITLE
feat(server): switch away from the input method (IME) when leaving a screen

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -119,6 +119,7 @@ public:
     inline static const auto RelativeMouseMoves = QStringLiteral("server/relativeMouseMoves");
     inline static const auto SwitchDelay = QStringLiteral("server/switchDelay");
     inline static const auto SwitchDoubleTap = QStringLiteral("server/switchDoubleTap");
+    inline static const auto SwitchToAsciiOnLeave = QStringLiteral("server/switchToAsciiOnLeave");
     inline static const auto Win32KeepForeground = QStringLiteral("server/win32KeepForeground");
     inline static const auto XdpRestoreToken = QStringLiteral("server/xdpRestoreToken");
   };
@@ -308,6 +309,7 @@ private:
     , Settings::Server::RelativeMouseMoves
     , Settings::Server::SwitchDelay
     , Settings::Server::SwitchDoubleTap
+    , Settings::Server::SwitchToAsciiOnLeave
     , Settings::Server::Win32KeepForeground
     , Settings::Server::XdpRestoreToken
   };
@@ -335,6 +337,7 @@ private:
     , Settings::Server::EnableSwitchDoubleTap
     , Settings::Server::ExternalConfig
     , Settings::Server::RelativeMouseMoves
+    , Settings::Server::SwitchToAsciiOnLeave
   };
 
   // When checking the default values this list contains the ones that default to true.

--- a/src/lib/deskflow/IPlatformScreen.h
+++ b/src/lib/deskflow/IPlatformScreen.h
@@ -135,6 +135,30 @@ public:
   */
   virtual std::string getSecureInputApp() const = 0;
 
+  //! Remember the current input source and switch to an ASCII-capable one
+  /*!
+  Called when leaving a primary screen so that an active input method
+  (e.g. Korean, Japanese or Chinese) on the server does not swallow
+  keystrokes that are meant for a client. The previous input source is
+  remembered so it can be restored by restoreInputSource(). The default
+  implementation does nothing; platforms that support input source
+  switching may override it.
+  */
+  virtual void switchToAsciiInputSource()
+  {
+    // do nothing
+  }
+
+  //! Restore the input source remembered by switchToAsciiInputSource()
+  /*!
+  Called when returning to a primary screen. The default implementation
+  does nothing.
+  */
+  virtual void restoreInputSource()
+  {
+    // do nothing
+  }
+
   //@}
   //! @name accessors
   //@{

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -145,6 +145,9 @@ void Screen::enter(KeyModifierMask toggleMask)
   m_screen->enter();
   if (m_isPrimary) {
     enterPrimary();
+    if (Settings::value(Settings::Server::SwitchToAsciiOnLeave).toBool()) {
+      m_screen->restoreInputSource();
+    }
   } else {
     enterSecondary(toggleMask);
   }
@@ -171,6 +174,9 @@ bool Screen::leave()
 
   if (m_isPrimary) {
     leavePrimary();
+    if (Settings::value(Settings::Server::SwitchToAsciiOnLeave).toBool()) {
+      m_screen->switchToAsciiInputSource();
+    }
   } else {
     leaveSecondary();
   }

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -139,6 +139,7 @@ void SettingsDialog::initConnections() const
   connect(ui->lineTlsCertPath, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbRunEnterCommand, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->cbRunExitCommand, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
+  connect(ui->cbSwitchToAsciiOnLeave, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->lineCommandEnter, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->lineCommandExit, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
 }
@@ -246,6 +247,7 @@ void SettingsDialog::accept()
   Settings::setValue(Settings::Core::EnableExitCommand, ui->cbRunExitCommand->isChecked());
   Settings::setValue(Settings::Core::ScreenEnterCommand, ui->lineCommandEnter->text());
   Settings::setValue(Settings::Core::ScreenExitCommand, ui->lineCommandExit->text());
+  Settings::setValue(Settings::Server::SwitchToAsciiOnLeave, ui->cbSwitchToAsciiOnLeave->isChecked());
 
   Settings::ProcessMode mode;
   if (ui->groupService->isChecked())
@@ -274,6 +276,7 @@ void SettingsDialog::loadFromConfig()
   ui->cbRunExitCommand->setChecked(Settings::value(Settings::Core::EnableExitCommand).toBool());
   ui->lineCommandEnter->setText(Settings::value(Settings::Core::ScreenEnterCommand).toString());
   ui->lineCommandExit->setText(Settings::value(Settings::Core::ScreenExitCommand).toString());
+  ui->cbSwitchToAsciiOnLeave->setChecked(Settings::value(Settings::Server::SwitchToAsciiOnLeave).toBool());
 
   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
   ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);
@@ -443,6 +446,7 @@ bool SettingsDialog::isModified() const
       (ui->cbRunExitCommand->isChecked() != Settings::value(Settings::Core::EnableExitCommand).toBool()) ||
       (ui->lineCommandEnter->text() != Settings::value(Settings::Core::ScreenEnterCommand).toString()) ||
       (ui->lineCommandExit->text() != Settings::value(Settings::Core::ScreenExitCommand).toString()) ||
+      (ui->cbSwitchToAsciiOnLeave->isChecked() != Settings::value(Settings::Server::SwitchToAsciiOnLeave).toBool()) ||
       (I18N::nativeTo639Name(ui->comboLanguage->currentText()) != Settings::value(Settings::Core::Language).toString());
 
   if (!ignoreInterface)
@@ -479,6 +483,7 @@ bool SettingsDialog::isDefault() const
       (ui->lineCommandExit->text() == Settings::defaultValue(Settings::Core::ScreenExitCommand).toString()) &&
       (ui->cbRunEnterCommand->isChecked() == Settings::defaultValue(Settings::Core::EnableEnterCommand).toBool()) &&
       (ui->cbRunExitCommand->isChecked() == Settings::defaultValue(Settings::Core::EnableExitCommand).toBool()) &&
+      (ui->cbSwitchToAsciiOnLeave->isChecked() == Settings::defaultValue(Settings::Server::SwitchToAsciiOnLeave).toBool()) &&
       (ui->comboLanguage->currentText() == "English")
   );
 }
@@ -500,6 +505,7 @@ void SettingsDialog::resetToDefault()
   ui->cbRunExitCommand->setChecked(Settings::defaultValue(Settings::Core::EnableExitCommand).toBool());
   ui->lineCommandEnter->setText(Settings::defaultValue(Settings::Core::ScreenEnterCommand).toString());
   ui->lineCommandExit->setText(Settings::defaultValue(Settings::Core::ScreenExitCommand).toString());
+  ui->cbSwitchToAsciiOnLeave->setChecked(Settings::defaultValue(Settings::Server::SwitchToAsciiOnLeave).toBool());
 
   const auto autoHide = Settings::defaultValue(Settings::Gui::Autohide).toBool();
   ui->rbCloseToTray->setChecked(autoHide);

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -841,6 +841,16 @@
          <item row="1" column="1">
           <widget class="QLineEdit" name="lineCommandExit"/>
          </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbSwitchToAsciiOnLeave">
+           <property name="toolTip">
+            <string>When this computer is the server, switch its keyboard to a plain ASCII layout (e.g. ABC) when control moves to another computer, and restore the previous input source when control returns. Helps when an input method (Korean, Japanese, Chinese) would otherwise swallow keystrokes meant for the client.</string>
+           </property>
+           <property name="text">
+            <string>Switch away from input method (IME) when leaving (restore on return)</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -93,6 +93,8 @@ public:
   void setSequenceNumber(uint32_t) override;
   bool isPrimary() const override;
   std::string getSecureInputApp() const override;
+  void switchToAsciiInputSource() override;
+  void restoreInputSource() override;
 
   void waitForCarbonLoop() const;
 
@@ -219,6 +221,10 @@ private:
 
   // true if screen is being used as a primary screen, false otherwise
   bool m_isPrimary;
+
+  // input source id remembered by switchToAsciiInputSource() so it can be
+  // restored by restoreInputSource(); empty when nothing is remembered
+  std::string m_savedInputSourceId;
 
   // true if mouse has entered the screen
   bool m_isOnScreen;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -35,6 +35,7 @@
 
 #include <AppKit/NSEvent.h>
 #include <AvailabilityMacros.h>
+#include <Carbon/Carbon.h>
 #include <IOKit/hidsystem/event_status_driver.h>
 #include <dispatch/dispatch.h>
 #include <libproc.h>
@@ -804,6 +805,61 @@ void OSXScreen::leave()
 
   // now off screen
   m_isOnScreen = false;
+}
+
+void OSXScreen::switchToAsciiInputSource()
+{
+  // Remember the current keyboard input source so it can be restored when we
+  // return to this screen.
+  m_savedInputSourceId.clear();
+  if (TISInputSourceRef current = TISCopyCurrentKeyboardInputSource()) {
+    if (void *property = TISGetInputSourceProperty(current, kTISPropertyInputSourceID)) {
+      auto sourceId = static_cast<CFStringRef>(property);
+      char buffer[256];
+      if (CFStringGetCString(sourceId, buffer, sizeof(buffer), kCFStringEncodingUTF8)) {
+        m_savedInputSourceId = buffer;
+      }
+    }
+    CFRelease(current);
+  }
+
+  // Switch to an ASCII-capable layout (e.g. ABC / U.S.) so that an active input
+  // method on this server (e.g. Korean, Japanese, Chinese) does not consume
+  // keystrokes that are meant for a client.
+  if (TISInputSourceRef ascii = TISCopyCurrentASCIICapableKeyboardInputSource()) {
+    LOG_DEBUG("switching to ascii input source on leave (was: %s)", m_savedInputSourceId.c_str());
+    TISSelectInputSource(ascii);
+    CFRelease(ascii);
+  }
+}
+
+void OSXScreen::restoreInputSource()
+{
+  if (m_savedInputSourceId.empty()) {
+    return;
+  }
+
+  CFStringRef sourceId =
+      CFStringCreateWithCString(kCFAllocatorDefault, m_savedInputSourceId.c_str(), kCFStringEncodingUTF8);
+  if (sourceId != nullptr) {
+    const void *keys[] = {kTISPropertyInputSourceID};
+    const void *values[] = {sourceId};
+    if (CFDictionaryRef filter = CFDictionaryCreate(
+            kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks
+        )) {
+      if (CFArrayRef list = TISCreateInputSourceList(filter, false)) {
+        if (CFArrayGetCount(list) > 0) {
+          LOG_DEBUG("restoring input source on enter: %s", m_savedInputSourceId.c_str());
+          TISSelectInputSource((TISInputSourceRef)CFArrayGetValueAtIndex(list, 0));
+        }
+        CFRelease(list);
+      }
+      CFRelease(filter);
+    }
+    CFRelease(sourceId);
+  }
+
+  m_savedInputSourceId.clear();
 }
 
 bool OSXScreen::setClipboard(ClipboardID, const IClipboard *src)


### PR DESCRIPTION
## Description

When the server's keyboard is set to an input method (IME) such as Korean, Japanese or Chinese, the active IME composition swallows keystrokes that are meant for a client. The result is that after switching to a client screen, typing does nothing until you manually switch the server's keyboard back to a plain/ASCII layout. This is a long-standing pain point for CJK users.

This PR adds an **opt-in** server option (off by default): when control leaves the primary screen, the server remembers its current keyboard input source and switches to an ASCII-capable layout; when control returns, the previous input source is restored.

Implementation notes:
- The hook lives in the cross-platform `Screen::enter()` / `Screen::leave()` (only when this screen is the primary), gated by the new setting.
- Two new methods are added to `IPlatformScreen` with **no-op default implementations**, so other platforms are unaffected.
- **macOS** implements them using the Text Input Source (TIS) API (`TISCopyCurrentASCIICapableKeyboardInputSource` so the user's real Latin layout — ABC, US, German, etc. — is chosen, not hardcoded English).
- A checkbox is added to the **Advanced** settings page, next to the existing "Run command on enter/exit" options.
- Windows/Linux are intentionally no-op for now; the hook is in place so they can be implemented later (e.g. via the IMM API on Windows).

## AI tools used for this PR

Claude (Anthropic, **Opus 4.8**) was used to explore the codebase, write the implementation, and assist with debugging. A human author reviewed the full diff, built it locally, installed and ran the resulting build, and verified the behavior described below.

## Fixed/related issues

Related: #8575, #7200, #7611

(This is an opt-in, macOS-first mitigation; it does not fully resolve these cross-platform issues, so it is listed as related rather than `fixes:`.)

## How has this been tested?

- Built locally on **macOS (Apple Silicon, arm64), Qt 6.11.1**, Release.
- Ran the server build and verified with the Korean 2-Set input method active:
  - On leaving the primary screen the input source switches to the ASCII-capable layout, so keystrokes reach the client.
  - On returning to the primary screen the previous (Korean) input source is restored.
- With the option **off** (default), behavior is unchanged.
- Existing unit tests build/run; the only failure observed was the pre-existing, environment-dependent flaky `OSXKeyStateTests::fakePollShift` (unrelated to this change — it passes on re-run and touches code this PR does not modify).
- Windows/Linux were not runtime-tested (no-op there); relying on CI for cross-platform build verification.