### PR TITLE
fix: [CVE-2026-63409] Check options array is always an even size

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -301,6 +301,11 @@ void Client::resetOptions()
 
 void Client::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   for (auto index = options.begin(); index != options.end(); ++index) {
     const OptionID id = *index;
     if (id == kOptionClipboardSharing) {

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -773,6 +773,11 @@ void ServerProxy::setOptions()
   ProtocolUtil::readf(m_stream, kMsgDSetOptions + 4, &options);
   LOG_VERBOSE("recv set options size=%d", options.size());
 
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   // forward
   m_client->setOptions(options);
 

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -281,6 +281,11 @@ void Screen::resetOptions()
 
 void Screen::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   // update options
   for (uint32_t i = 0, n = (uint32_t)options.size(); i < n; i += 2) {
     if (options[i] == kOptionHalfDuplexCapsLock) {

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -400,6 +400,10 @@ void XWindowsScreen::resetOptions()
 
 void XWindowsScreen::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
   for (uint32_t i = 0, n = options.size(); i < n; i += 2) {
     if (options[i] == kOptionXTestXineramaUnaware) {
       m_xtestIsXineramaUnaware = (options[i + 1] != 0);

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -350,6 +350,11 @@ void ClientProxy1_0::resetOptions()
 void ClientProxy1_0::setOptions(const OptionsList &options)
 {
   LOG_VERBOSE("send set options to \"%s\" size=%d", getName().c_str(), options.size());
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, not sending");
+    return;
+  }
+
   ProtocolUtil::writef(getStream(), kMsgDSetOptions, &options);
 
   // check options


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Check the options arrays are always even  log an error and ignore send options if its not (maybe this should be fatal??)
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Prevent overflow if processing non even size an option array with an odd size
fixes: https://github.com/deskflow/deskflow/security/advisories/GHSA-gmvh-3c73-m5gg
fixes: CVE-2026-63409 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Smoke test 