### PR TITLE
fix(macos): stop pollActiveGroup crashing off the main queue

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -13,6 +13,8 @@
 
 #include <Carbon/Carbon.h>
 #include <IOKit/hidsystem/IOHIDLib.h>
+#include <dispatch/dispatch.h>
+#include <pthread.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -431,8 +433,10 @@ KeyModifierMask OSXKeyState::pollActiveModifiers() const
   return outMask;
 }
 
-int32_t OSXKeyState::pollActiveGroup() const
+int32_t OSXKeyState::updateActiveGroupCache()
 {
+  // MUST run on the main dispatch queue: macOS 14+ asserts the main queue
+  // inside the Text Input Source APIs.
   AutoTISInputSourceRef keyboardLayout(nullptr, CFRelease);
   CFDataRef id = nullptr;
   {
@@ -442,14 +446,27 @@ int32_t OSXKeyState::pollActiveGroup() const
       id = (CFDataRef)TISGetInputSourceProperty(keyboardLayout.get(), kTISPropertyInputSourceID);
   }
 
-  GroupMap::const_iterator i = m_groupMap.find(id);
-  if (i != m_groupMap.end()) {
-    return i->second;
+  int32_t group = 0;
+  if (GroupMap::const_iterator i = m_groupMap.find(id); i != m_groupMap.end()) {
+    group = i->second;
   }
+  m_activeGroupCache.store(group, std::memory_order_relaxed);
+  return group;
+}
 
-  LOG_WARN("can't get the active group, use the first group instead");
-
-  return 0;
+int32_t OSXKeyState::pollActiveGroup() const
+{
+  // The TIS calls in updateActiveGroupCache() assert the main dispatch queue
+  // (macOS 14+); deskflow injects keys (fakeKeyDown -> pollActiveGroup) on its
+  // event thread, where calling them crashes via _dispatch_assert_queue_fail.
+  // On the main thread refresh synchronously; off it, kick a non-blocking
+  // refresh and return the last cached group (no blocking -> no deadlock).
+  if (pthread_main_np() != 0) {
+    return const_cast<OSXKeyState *>(this)->updateActiveGroupCache();
+  }
+  auto *self = const_cast<OSXKeyState *>(this);
+  dispatch_async(dispatch_get_main_queue(), ^{ self->updateActiveGroupCache(); });
+  return m_activeGroupCache.load(std::memory_order_relaxed);
 }
 
 void OSXKeyState::pollPressedKeys(KeyButtonSet &pressedKeys) const

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -12,6 +12,7 @@
 
 #include <Carbon/Carbon.h>
 
+#include <atomic>
 #include <map>
 #include <vector>
 
@@ -153,10 +154,20 @@ private:
   using GroupMap = std::map<CFDataRef, int32_t>;
   using VirtualKeyMap = std::map<uint32_t, KeyID>;
 
+  // Refresh m_activeGroupCache from the current TIS keyboard layout. MUST run
+  // on the main dispatch queue -- macOS 14+ asserts the main queue inside the
+  // Text Input Source APIs, so calling them off the deskflow event thread
+  // crashes via _dispatch_assert_queue_fail.
+  int32_t updateActiveGroupCache();
+
   VirtualKeyMap m_virtualKeyMap;
   mutable uint32_t m_deadKeyState;
   AutoCFArray m_groups{nullptr, CFRelease};
   GroupMap m_groupMap;
+  // Last keyboard group resolved on the main queue. pollActiveGroup() reads
+  // this off the event thread (where the TIS calls would crash) and kicks an
+  // async refresh; on the main thread it refreshes synchronously.
+  mutable std::atomic<int32_t> m_activeGroupCache{0};
   bool m_shiftPressed;
   bool m_controlPressed;
   bool m_altPressed;


### PR DESCRIPTION
## Summary
- Dispatch `pollActiveGroup` work onto the main queue on macOS to avoid crashes when called from background threads.

## Test plan
- [ ] macOS CI green
- [ ] Manual: multi-monitor KVM switch without crash