### PR TITLE
feat: remember previously used server addresses (#8114)

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -42,6 +42,7 @@ public:
     inline static const auto XScrollScale = QStringLiteral("client/xScrollScale");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
+    inline static const auto RecentRemoteHosts = QStringLiteral("client/recentRemoteHosts");
     inline static const auto XdpRestoreToken = QStringLiteral("client/xdpRestoreToken");
   };
   struct Core
@@ -249,6 +250,7 @@ private:
     , Settings::Client::InvertXScroll
     , Settings::Client::LanguageSync
     , Settings::Client::RemoteHost
+    , Settings::Client::RecentRemoteHosts
     , Settings::Client::YScrollScale
     , Settings::Client::XScrollScale
     , Settings::Client::XdpRestoreToken

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -45,6 +45,7 @@
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
+#include <QComboBox>
 #include <QScreen>
 #include <QScrollBar>
 
@@ -283,8 +284,9 @@ void MainWindow::connectSlots()
 
   connect(ui->btnRestartCore, &QPushButton::clicked, this, &MainWindow::resetCore);
 
-  connect(ui->lineHostname, &QLineEdit::returnPressed, ui->btnRestartCore, &QPushButton::click);
-  connect(ui->lineHostname, &QLineEdit::textChanged, this, &MainWindow::remoteHostChanged);
+  ui->cbHostname->setValidator(new QRegularExpressionValidator(m_nameRegEx, this));
+  connect(ui->cbHostname->lineEdit(), &QLineEdit::returnPressed, ui->btnRestartCore, &QPushButton::click);
+  connect(ui->cbHostname, &QComboBox::editTextChanged, this, &MainWindow::remoteHostChanged);
 
   connect(ui->btnSaveServerConfig, &QPushButton::clicked, this, &MainWindow::saveServerConfig);
   connect(ui->btnConfigureServer, &QPushButton::clicked, this, [this] { showConfigureServer(""); });
@@ -653,7 +655,7 @@ void MainWindow::open()
   }
 
   if (Settings::value(Settings::Gui::AutoStartCore).toBool()) {
-    if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
+    if (ui->rbModeClient->isChecked() && ui->cbHostname->currentText().isEmpty())
       return;
     startCore();
   }
@@ -707,8 +709,12 @@ void MainWindow::applyConfig()
     setWindowTitle(kAppName);
   }
 
+  const auto recentHosts = Settings::value(Settings::Client::RecentRemoteHosts).toStringList();
+  ui->cbHostname->clear();
+  ui->cbHostname->addItems(recentHosts);
+
   if (const auto host = Settings::value(Settings::Client::RemoteHost).toString(); !host.isEmpty())
-    ui->lineHostname->setText(host);
+    ui->cbHostname->setCurrentText(host);
 
   updateFingerprintButton();
   setTrayIcon();
@@ -728,8 +734,9 @@ void MainWindow::saveSettings() const
   } else if (ui->rbModeServer->isChecked()) {
     Settings::setValue(Settings::Core::CoreMode, Settings::CoreMode::Server);
   }
-  if (!ui->lineHostname->text().isEmpty())
-    Settings::setValue(Settings::Client::RemoteHost, ui->lineHostname->text());
+  if (!ui->cbHostname->currentText().isEmpty()) {
+    Settings::setValue(Settings::Client::RemoteHost, ui->cbHostname->currentText());
+  }
   Settings::save();
 }
 
@@ -990,8 +997,28 @@ void MainWindow::coreConnectionStateChanged(ConnectionState state)
   // when the correct TLS version string is detected.
   if (state != ConnectionState::Connected) {
     secureSocket(false);
-  } else if (isVisible()) {
-    showFirstConnectedMessage();
+  } else {
+    if (m_coreProcess.mode() == CoreMode::Client) {
+      if (const auto host = ui->cbHostname->currentText(); !host.isEmpty()) {
+        QStringList recentHosts = Settings::value(Settings::Client::RecentRemoteHosts).toStringList();
+        if (recentHosts.isEmpty() || recentHosts.first() != host) {
+          recentHosts.removeAll(host);
+          recentHosts.prepend(host);
+          while (recentHosts.size() > 10) {
+            recentHosts.removeLast();
+          }
+          Settings::setValue(Settings::Client::RecentRemoteHosts, recentHosts);
+          ui->cbHostname->blockSignals(true);
+          ui->cbHostname->clear();
+          ui->cbHostname->addItems(recentHosts);
+          ui->cbHostname->setCurrentText(host);
+          ui->cbHostname->blockSignals(false);
+        }
+      }
+    }
+    if (isVisible()) {
+      showFirstConnectedMessage();
+    }
   }
 }
 
@@ -1089,8 +1116,11 @@ void MainWindow::showConfigureServer(const QString &message)
 void MainWindow::showConfigureClient()
 {
   ClientConfigDialog dialog(this);
-  if ((dialog.exec() == QDialog::Accepted) && m_coreProcess.isStarted()) {
-    m_coreProcess.restart();
+  if (dialog.exec() == QDialog::Accepted) {
+    applyConfig();
+    if (m_coreProcess.isStarted()) {
+      m_coreProcess.restart();
+    }
   }
 }
 
@@ -1287,5 +1317,5 @@ bool MainWindow::canRunCore() const
   const auto mode = m_coreProcess.mode();
   const bool isServer = mode == Settings::CoreMode::Server;
   const bool isClient = mode == Settings::CoreMode::Client;
-  return ((isServer || isClient) && (isClient && !ui->lineHostname->text().isEmpty()) || isServer);
+  return ((isServer || isClient) && (isClient && !ui->cbHostname->currentText().isEmpty()) || isServer);
 }

--- a/src/lib/gui/MainWindow.ui
+++ b/src/lib/gui/MainWindow.ui
@@ -399,7 +399,13 @@
               </widget>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineHostname">
+              <widget class="QComboBox" name="cbHostname">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="minimumSize">
                 <size>
                  <width>0</width>
@@ -408,6 +414,9 @@
                </property>
                <property name="toolTip">
                 <string>&lt;html&gt;Hostname or IP address of the server computer.&lt;br/&gt;May contain a comma seperated list.&lt;/html&gt;</string>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
                </property>
               </widget>
              </item>

--- a/src/lib/gui/dialogs/ClientConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ClientConfigDialog.cpp
@@ -55,6 +55,7 @@ void ClientConfigDialog::initConnections() const
   connect(
       ui->cbDynamicConnectTime, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons
   );
+  connect(ui->btnClearServerHistory, &QPushButton::clicked, this, &ClientConfigDialog::clearServerHistory);
   connect(ui->cbLanguageSync, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->cbYScrollInvert, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->sbYScrollScale, &QDoubleSpinBox::valueChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
@@ -121,4 +122,14 @@ void ClientConfigDialog::save()
   Settings::setValue(Settings::Client::InvertXScroll, ui->cbXScrollInvert->isChecked());
   Settings::setValue(Settings::Client::XScrollScale, ui->sbXScrollScale->value());
   QDialog::accept();
+}
+
+void ClientConfigDialog::clearServerHistory()
+{
+  QString currentHost = Settings::value(Settings::Client::RemoteHost).toString();
+  QStringList recentHosts;
+  if (!currentHost.isEmpty()) {
+    recentHosts.append(currentHost);
+  }
+  Settings::setValue(Settings::Client::RecentRemoteHosts, recentHosts);
 }

--- a/src/lib/gui/dialogs/ClientConfigDialog.h
+++ b/src/lib/gui/dialogs/ClientConfigDialog.h
@@ -72,5 +72,7 @@ private:
    */
   void save();
 
+  void clearServerHistory();
+
   Ui::ClientConfigDialog *ui = nullptr;
 };

--- a/src/lib/gui/dialogs/ClientConfigDialog.ui
+++ b/src/lib/gui/dialogs/ClientConfigDialog.ui
@@ -165,6 +165,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="btnClearServerHistory">
+     <property name="text">
+      <string>Clear Server History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>


### PR DESCRIPTION
Description
This PR implements the feature requested in #8114 to remember previously used server addresses.

Updates include:

1 Renamed lineHostname to cbHostname and converted it to an editable QComboBox.
2 The combo box now uses QRegularExpressionValidator to prevent invalid hostname/IP inputs.
3 Server history is only appended to client/recentRemoteHosts when the core successfully transitions to ConnectionState::Connected.
4 Added a "Clear Server History" button to the Client configuration dialog, which correctly clears the history but retains the currently active server.

AI tools used for this PR
I used Google DeepMind's Antigravity (Gemini) coding assistant to help refactor the C++ logic, set up the QT signals for the new clear button, and appropriately squash the git commits to keep the history clean.
Fixed/related issues
fixes: #8114

How has this been tested?
Logic was extensively reviewed against the requirements in #8114
I compiled and tested this locally on Windows to verify the UI dropdown works correctly, the hostnames save to history upon connection, and the clear button wipes the list,

