### PR TITLE
fix: don't run dead-key ToUnicode translation on the server's own screen

### DIFF
--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -292,6 +292,12 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
     if (menu && (sc >= 0x47u && sc <= 0x52u && sc != 0x4au && sc != 0x4eu)) {
       return false;
     }
+
+    // We're on the server's own screen: we're only watching for the
+    // cursor to reach a jump zone, we are NOT relaying keystrokes to a
+    // client, so we have no need for the composed character here.
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, makeKeyMsg((UINT)wParam, 0, false), lParam);
+    return false;
   }
 
   // map the key event to a character.  we have to put the dead

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -309,6 +309,12 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
     if (menu && (sc >= 0x47u && sc <= 0x52u && sc != 0x4au && sc != 0x4eu)) {
       return false;
     }
+
+    // We're on the server's own screen: we're only watching for the
+    // cursor to reach a jump zone, we are NOT relaying keystrokes to a
+    // client, so we have no need for the composed character here.
+    PostThreadMessage(g_threadID, DESKFLOW_MSG_KEY, makeKeyMsg((UINT)wParam, 0, false), lParam);
+    return false;
   }
 
   // map the key event to a character.  we have to put the dead


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
This PR fixes **local dead-key accent composition being broken on the server's own screen**, Issue [#9254](https://github.com/deskflow/deskflow/issues/9254).

On Windows, the low-level keyboard hook (`MSWindowsHook.cpp`) runs `ToUnicode()` (together with `setDeadKey()`) to translate key events into characters. `ToUnicode()` has the side effect of consuming the pending dead-key state in the keyboard layout. When the cursor is on the server's *own* screen, deskflow is not relaying keystrokes to any client — it is only watching for the cursor to reach a jump zone. Running the dead-key translation there seems unnecessary, adding overhead, and it destroyed the dead-key state, so typing an accent (e.g. `´` + `a` = `á`) into local apps no longer composed correctly.

- When deskflow is on the server's own screen (`g_mode != kHOOK_RELAY_EVENTS`), stop running the dead-key / `ToUnicode()` composition path.
- Post the raw key event with no composed character and let the local OS handle dead-key composition normally.
- Keep the existing relay behavior (`kHOOK_RELAY_EVENTS`) untouched, so character composition for remote clients is unchanged.
- Early, character-less return on the server's own screen (`src/lib/platform/MSWindowsHook.cpp`)

Since I had the same problem as the original user on the related issue, I tried this approach that would be simple enough to fix without the need of any complex decision at this moment, since the existing relay behavior remains untouched.

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
Claude Opus 4.8, used to identify where the workaround should be placed and used to generate this pull request description.

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
- related: #9254 , fixes for the server not clients
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
This was tested with the generated .msi on the Continuous Integration for the Windows Server (where the issue seems to happen).

The client (Linux) didn't have any issues on the test, everything worked as it should:

1. Ran a deskflow **server** on Windows with a keyboard layout that uses dead keys for accents (ABNT).
2. With the cursor on the **server's own** screen, opened a local text editor and typed a dead-key accent sequence, e.g. `´` then `a`.
   - **Before:** the accent was dropped / not composed (`á` did not appear) if the text was typed too fast.
   - **After:** `á` is composed correctly.
3. Switched the cursor to a **client** screen and confirmed accented characters are still relayed and composed as before (no regression in the relay path).
