### PR TITLE
macOS: dispatch TIS/TSM input-source calls to the main queue (fixes #9924)

### DIFF
--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -66,7 +66,7 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
   AutoCFArray kbds(nullptr, CFRelease);
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    kbds = AutoCFArray(TISCreateInputSourceList(dict.get(), false), CFRelease);
+    runOnMainTISQueue([&] { kbds = AutoCFArray(TISCreateInputSourceList(dict.get(), false), CFRelease); });
   }
 
   for (CFIndex i = 0; i < CFArrayGetCount(kbds.get()); ++i) {
@@ -74,7 +74,9 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
     CFArrayRef layoutLanguages = nullptr;
     {
       std::lock_guard<std::mutex> lock(g_tisMutex);
-      layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceLanguages);
+      runOnMainTISQueue([&] {
+        layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceLanguages);
+      });
     }
     char temporaryCString[128] = {0};
     for (CFIndex index = 0; index < CFArrayGetCount(layoutLanguages) && layoutLanguages; index++) {
@@ -158,9 +160,11 @@ std::string AppUtilUnix::getCurrentLanguageCode()
   CFArrayRef layoutLanguages = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    source = AutoTISInputSourceRef(TISCopyCurrentKeyboardInputSource(), CFRelease);
-    if (source)
-      layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(source.get(), kTISPropertyInputSourceLanguages);
+    runOnMainTISQueue([&] {
+      source = AutoTISInputSourceRef(TISCopyCurrentKeyboardInputSource(), CFRelease);
+      if (source)
+        layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(source.get(), kTISPropertyInputSourceLanguages);
+    });
   }
   char temporaryCString[128] = {0};
   for (CFIndex index = 0; index < CFArrayGetCount(layoutLanguages) && layoutLanguages; index++) {

--- a/src/lib/platform/IOSXKeyResource.cpp
+++ b/src/lib/platform/IOSXKeyResource.cpp
@@ -106,9 +106,11 @@ KeyID IOSXKeyResource::getKeyID(uint8_t c)
     CFArrayRef langs = nullptr;
     {
       std::lock_guard<std::mutex> lock(g_tisMutex);
-      isref = AutoTISInputSourceRef(TISCopyCurrentKeyboardInputSource(), CFRelease);
-      if (isref)
-        langs = (CFArrayRef)TISGetInputSourceProperty(isref.get(), kTISPropertyInputSourceLanguages);
+      runOnMainTISQueue([&] {
+        isref = AutoTISInputSourceRef(TISCopyCurrentKeyboardInputSource(), CFRelease);
+        if (isref)
+          langs = (CFArrayRef)TISGetInputSourceProperty(isref.get(), kTISPropertyInputSourceLanguages);
+      });
     }
     CFStringEncoding encoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)CFArrayGetValueAtIndex(langs, 0));
     // convert to unicode

--- a/src/lib/platform/OSXAutoTypes.h
+++ b/src/lib/platform/OSXAutoTypes.h
@@ -6,8 +6,10 @@
 #pragma once
 
 #include <Carbon/Carbon.h>
+#include <dispatch/dispatch.h>
 #include <memory>
 #include <mutex>
+#include <pthread.h>
 
 using CFDeallocator = decltype(&CFRelease);
 using AutoCFArray = std::unique_ptr<const __CFArray, CFDeallocator>;
@@ -15,3 +17,18 @@ using AutoCFDictionary = std::unique_ptr<const __CFDictionary, CFDeallocator>;
 using AutoTISInputSourceRef = std::unique_ptr<__TISInputSource, CFDeallocator>;
 
 inline std::mutex g_tisMutex;
+
+// macOS 27 hard-asserts (dispatch_assert_queue) that TIS/TSM input-source APIs
+// run on the main dispatch queue. Callers already serialize access to these
+// APIs via g_tisMutex; wrap that critical section with this helper so it also
+// runs on the main queue when called from a background thread.
+template <typename Func> inline void runOnMainTISQueue(Func &&func)
+{
+  if (pthread_main_np()) {
+    func();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      func();
+    });
+  }
+}

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -297,9 +297,11 @@ KeyButton OSXKeyState::mapKeyFromEvent(KeyIDs &ids, KeyModifierMask *maskOut, CG
   CFDataRef ref = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    currentKeyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
-    if (currentKeyboardLayout)
-      ref = (CFDataRef)TISGetInputSourceProperty(currentKeyboardLayout.get(), kTISPropertyUnicodeKeyLayoutData);
+    runOnMainTISQueue([&] {
+      currentKeyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
+      if (currentKeyboardLayout)
+        ref = (CFDataRef)TISGetInputSourceProperty(currentKeyboardLayout.get(), kTISPropertyUnicodeKeyLayoutData);
+    });
   }
 
   if (!currentKeyboardLayout) {
@@ -437,9 +439,11 @@ int32_t OSXKeyState::pollActiveGroup() const
   CFDataRef id = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    keyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
-    if (keyboardLayout)
-      id = (CFDataRef)TISGetInputSourceProperty(keyboardLayout.get(), kTISPropertyInputSourceID);
+    runOnMainTISQueue([&] {
+      keyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
+      if (keyboardLayout)
+        id = (CFDataRef)TISGetInputSourceProperty(keyboardLayout.get(), kTISPropertyInputSourceID);
+    });
   }
 
   GroupMap::const_iterator i = m_groupMap.find(id);
@@ -478,7 +482,9 @@ void OSXKeyState::getKeyMap(deskflow::KeyMap &keyMap)
       CFDataRef id = nullptr;
       {
         std::lock_guard<std::mutex> lock(g_tisMutex);
-        id = (CFDataRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceID);
+        runOnMainTISQueue([&] {
+          id = (CFDataRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceID);
+        });
       }
       m_groupMap[id] = g;
     }
@@ -498,7 +504,9 @@ void OSXKeyState::getKeyMap(deskflow::KeyMap &keyMap)
     CFDataRef resourceRef = nullptr;
     {
       std::lock_guard<std::mutex> lock(g_tisMutex);
-      resourceRef = (CFDataRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyUnicodeKeyLayoutData);
+      runOnMainTISQueue([&] {
+        resourceRef = (CFDataRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyUnicodeKeyLayoutData);
+      });
     }
 
     layoutValid = resourceRef != nullptr;
@@ -876,7 +884,7 @@ bool OSXKeyState::getGroups(AutoCFArray &groups) const
   AutoCFArray kbds(nullptr, CFRelease);
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    kbds = AutoCFArray(TISCreateInputSourceList(dict.get(), false), CFRelease);
+    runOnMainTISQueue([&] { kbds = AutoCFArray(TISCreateInputSourceList(dict.get(), false), CFRelease); });
   }
 
   if (CFArrayGetCount(kbds.get()) > 0) {
@@ -899,9 +907,11 @@ void OSXKeyState::setGroup(int32_t group)
   CFBooleanRef canBeSetted = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    AutoTISInputSourceRef source(TISCopyCurrentKeyboardInputSource(), CFRelease);
-    if (source)
-      canBeSetted = (CFBooleanRef)TISGetInputSourceProperty(source.get(), kTISPropertyInputSourceIsEnableCapable);
+    runOnMainTISQueue([&] {
+      AutoTISInputSourceRef source(TISCopyCurrentKeyboardInputSource(), CFRelease);
+      if (source)
+        canBeSetted = (CFBooleanRef)TISGetInputSourceProperty(source.get(), kTISPropertyInputSourceIsEnableCapable);
+    });
   }
   if (!canBeSetted) {
     LOG_WARN("needed keyboard layout is disabled for programmatically selection");
@@ -910,9 +920,11 @@ void OSXKeyState::setGroup(int32_t group)
 
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    if (TISSelectInputSource(keyboardLayout) != noErr) {
-      LOG_WARN("failed to set needed keyboard layout");
-    }
+    runOnMainTISQueue([&] {
+      if (TISSelectInputSource(keyboardLayout) != noErr) {
+        LOG_WARN("failed to set needed keyboard layout");
+      }
+    });
   }
 
   LOG_VERBOSE("keyboard layout change to %d", group);


### PR DESCRIPTION
Fixes #9924.

## Problem

macOS 27 hard-asserts (`dispatch_assert_queue`) that TIS/TSM input-source APIs (`TISCreateInputSourceList`, `TISGetInputSourceProperty`, `TISCopyCurrentKeyboardInputSource`, etc.) run on the **main dispatch queue**. `g_tisMutex` already serializes access to these calls across Deskflow's own threads, which was sufficient on older macOS, but it doesn't satisfy the main-queue requirement — the call still executes on whichever background thread holds the lock, and now traps with `EXC_BREAKPOINT`/`SIGTRAP` instead of just risking a race.

Concretely: running `deskflow-core` headless as a server, a client connecting triggers `ClientProxyUnknown::initProxy()` → `ClientProxy1_8::synchronizeLanguages()` → `AppUtilUnix::getKeyboardLayoutList()` → `TISCreateInputSourceList()` from a background event-queue thread, which traps every time on macOS 27. Full crash trace and root-cause writeup in #9924.

## Fix

Adds `runOnMainTISQueue()` next to `g_tisMutex` in `OSXAutoTypes.h`:

```cpp
template <typename Func> inline void runOnMainTISQueue(Func &&func)
{
  if (pthread_main_np()) {
    func();
  } else {
    dispatch_sync(dispatch_get_main_queue(), ^{
      func();
    });
  }
}
```

and wraps every `g_tisMutex`-guarded TIS/TSM call site in it, across `AppUtilUnix.cpp`, `OSXKeyState.cpp`, and `IOSXKeyResource.cpp` (8 sites total). Runs inline when already on the main thread (no dispatch overhead in the common GUI-thread case), otherwise `dispatch_sync`'s to the main queue.

## Testing

- Built `deskflow-core` target locally against Qt 6.11.1 on macOS 27.0 beta 2 (Apple Silicon).
- Reproduced the original crash reliably on unpatched v1.26.0 by connecting a client to a headless server.
- Confirmed the patched build accepts client connections without crashing (log shows the previously-fatal `local languages: en` / `synchronizeLanguages` path completing normally, client connects successfully).
- Ran as a LaunchAgent-managed background server for real day-to-day use post-patch.

Have not run the full test suite / GUI build in this pass (scoped the local build to the `deskflow-core` target); happy to expand testing if maintainers want it before merge.