### PR TITLE
Fix Wayland portal clipboard ownership

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -405,17 +405,26 @@ void EiScreen::leave()
 
 bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 {
-  if (!clipboard) {
-    return false;
-  }
-
   // If using portal input capture, set clipboard there
   if (m_portalInputCapture) {
     IClipboard *targetClipboard = m_portalInputCapture->getClipboard(id);
     if (!targetClipboard) {
       return false;
     }
-    return IClipboard::copy(targetClipboard, clipboard);
+
+    bool ok = false;
+    if (clipboard) {
+      ok = IClipboard::copy(targetClipboard, clipboard);
+    } else if (targetClipboard->open(0)) {
+      ok = targetClipboard->empty();
+      targetClipboard->close();
+    }
+
+    if (ok && id == kClipboardClipboard) {
+      m_portalInputCapture->claimClipboard();
+    }
+
+    return ok;
   }
 
   // Otherwise use our own clipboard
@@ -423,7 +432,13 @@ bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
     return false;
   }
 
-  bool ok = IClipboard::copy(m_clipboard, clipboard);
+  bool ok = false;
+  if (clipboard) {
+    ok = IClipboard::copy(m_clipboard, clipboard);
+  } else if (m_clipboard->open(0)) {
+    ok = m_clipboard->empty();
+    m_clipboard->close();
+  }
 
   if (ok && m_portalRemoteDesktop && id == kClipboardClipboard) {
     m_portalRemoteDesktop->claimClipboard();

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -254,6 +254,24 @@ void PortalInputCapture::claimClipboardOwnership([[maybe_unused]] XdpSession *se
 #endif
 }
 
+void PortalInputCapture::claimClipboard() const
+{
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  if (!m_session) {
+    LOG_DEBUG("portal input capture clipboard claim deferred, no session yet");
+    return;
+  }
+
+  XdpSession *session = xdp_input_capture_session_get_session(m_session);
+  if (!xdp_session_is_clipboard_enabled(session)) {
+    LOG_WARN("portal input capture clipboard not enabled on session, cannot claim");
+    return;
+  }
+
+  claimClipboardOwnership(session);
+#endif
+}
+
 void PortalInputCapture::readClipboardSelection(XdpSession *session) const
 {
 #ifdef HAVE_LIBPORTAL_CLIPBOARD

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -38,6 +38,7 @@ public:
   void disable();
   void release();
   void release(double x, double y);
+  void claimClipboard() const;
   bool isActive() const
   {
     return m_isActive;


### PR DESCRIPTION
## Summary
Fix Wayland portal clipboard ownership so clipboard contents received from another screen are advertised back to the local portal selection.

This enables clipboard sharing between Linux Wayland and Windows by making the Wayland primary/input-capture path claim clipboard ownership after updating its clipboard cache. It also preserves clipboard grab behavior for the EI clipboard cache when `setClipboard()` is called with `nullptr`.

## Tested
- Linux: Ubuntu 26.04 LTS + KDE Plasma + Wayland
- Windows: Windows 11 Pro 25H2 with latest updates
- Verified clipboard sharing between Linux and Windows
- Built `platform` target with `HAVE_LIBPORTAL_CLIPBOARD` enabled