### PR TITLE
i18n: make sure log levels text is translated

### DIFF
--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -200,19 +200,19 @@ void SettingsDialog::showReadOnlyMessage()
 
 void SettingsDialog::updateText()
 {
-  const auto logLevelNames = LogLevel::logLevelNames();
+  const auto logLevels = LogLevel::logLevelNames().count();
   const QStringList toolTips = {tr("Required messages"),        tr("Non-fatal errors"), tr("General warnings"),
                                 tr("General events [Default]"), tr("Debug entries"),    tr("Verbose debug output")};
   if (ui->comboLogLevel->count() == 0) {
     const auto logLevelOptions = LogLevel::logLevelOptions();
-    for (int i = 0; i < logLevelNames.count(); i++) {
-      ui->comboLogLevel->addItem(logLevelNames.at(i));
+    for (int i = 0; i < logLevels; i++) {
+      ui->comboLogLevel->addItem(LogLevel::toString(i));
       ui->comboLogLevel->setItemData(i, logLevelOptions.at(i), Qt::UserRole);
       ui->comboLogLevel->setItemData(i, toolTips.at(i), Qt::ToolTipRole);
     }
   } else {
-    for (int i = 0; i < logLevelNames.count(); i++) {
-      ui->comboLogLevel->setItemData(i, logLevelNames.at(i), Qt::DisplayRole);
+    for (int i = 0; i < logLevels; i++) {
+      ui->comboLogLevel->setItemData(i, LogLevel::toString(i), Qt::DisplayRole);
       ui->comboLogLevel->setItemData(i, toolTips.at(i), Qt::ToolTipRole);
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Ensure the log levels shown to the user in the settings dialog are translated to the selected language.
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
mentioned in #9926  that this was missing
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Run set to another language. picked a loglevel saved changed languages to be sure its saved / recalled correctly with non english text.