### PR TITLE
fix: Claim Wayland portal clipboard after updates

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -405,17 +405,26 @@ void EiScreen::leave()
 
 bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 {
-  if (!clipboard) {
-    return false;
-  }
-
   // If using portal input capture, set clipboard there
   if (m_portalInputCapture) {
     IClipboard *targetClipboard = m_portalInputCapture->getClipboard(id);
     if (!targetClipboard) {
       return false;
     }
-    return IClipboard::copy(targetClipboard, clipboard);
+
+    bool ok = false;
+    if (clipboard) {
+      ok = IClipboard::copy(targetClipboard, clipboard);
+    } else if (targetClipboard->open(0)) {
+      ok = targetClipboard->empty();
+      targetClipboard->close();
+    }
+
+    if (ok && id == kClipboardClipboard) {
+      m_portalInputCapture->claimClipboard();
+    }
+
+    return ok;
   }
 
   // Otherwise use our own clipboard
@@ -423,7 +432,13 @@ bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
     return false;
   }
 
-  bool ok = IClipboard::copy(m_clipboard, clipboard);
+  bool ok = false;
+  if (clipboard) {
+    ok = IClipboard::copy(m_clipboard, clipboard);
+  } else if (m_clipboard->open(0)) {
+    ok = m_clipboard->empty();
+    m_clipboard->close();
+  }
 
   if (ok && m_portalRemoteDesktop && id == kClipboardClipboard) {
     m_portalRemoteDesktop->claimClipboard();

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -254,6 +254,27 @@ void PortalInputCapture::claimClipboardOwnership([[maybe_unused]] XdpSession *se
 #endif
 }
 
+void PortalInputCapture::claimClipboard() const
+{
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  if (!m_session) {
+    m_clipboardClaimPending = true;
+    LOG_DEBUG("portal input capture clipboard claim pending, no session yet");
+    return;
+  }
+
+  XdpSession *session = xdp_input_capture_session_get_session(m_session);
+  if (!xdp_session_is_clipboard_enabled(session)) {
+    m_clipboardClaimPending = true;
+    LOG_WARN("portal input capture clipboard not enabled on session, cannot claim");
+    return;
+  }
+
+  claimClipboardOwnership(session);
+  m_clipboardClaimPending = false;
+#endif
+}
+
 void PortalInputCapture::readClipboardSelection(XdpSession *session) const
 {
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
@@ -331,6 +352,10 @@ void PortalInputCapture::setupSession(XdpInputCaptureSession *session)
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
   m_signals.at(SelectionTransfer) =
       g_signal_connect(G_OBJECT(parentSession), "selection-transfer", G_CALLBACK(selectionTransfer), this);
+  if (m_clipboardClaimPending && xdp_session_is_clipboard_enabled(parentSession)) {
+    claimClipboardOwnership(parentSession);
+    m_clipboardClaimPending = false;
+  }
 #endif
 }
 

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -38,6 +38,7 @@ public:
   void disable();
   void release();
   void release(double x, double y);
+  void claimClipboard() const;
   bool isActive() const
   {
     return m_isActive;
@@ -166,6 +167,7 @@ private:
 
   bool m_enabled = false;
   bool m_isActive = false;
+  mutable bool m_clipboardClaimPending = false;
   std::uint32_t m_activationId = 0;
 
   std::vector<XdpInputCapturePointerBarrier *> m_barriers;


### PR DESCRIPTION
## Description
Claim the portal clipboard after the Wayland input-capture clipboard cache is updated.

## AI tools used for this PR
Codex / ChatGPT was used to inspect the code path, draft the patch, and run build checks.

## Fixed/related issues
related: #9288
related: #9600
related: #8031
related: #7600

## How has this been tested?
Tested clipboard sharing with Ubuntu 26.04 LTS + KDE Plasma + Wayland and Windows 11 Pro 25H2.

Built the Linux platform target with libportal clipboard support enabled.

macOS and Windows builds were not run locally.