### PR TITLE
feat: using xkbregistry instead of manually parsing evdev.xml

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
 # SPDX-FileCopyrightText: (C) 2024 - 2025 Deskflow Developers
 # SPDX-FileCopyrightText: (C) 2024 Symless Ltd
 # SPDX-License-Identifier: MIT
@@ -150,11 +151,12 @@ macro(configure_unix_libs)
     find_package(PkgConfig)
     if(PKG_CONFIG_FOUND)
       pkg_check_modules(LIBXKBCOMMON REQUIRED xkbcommon)
+      pkg_check_modules(LIBXKBREGISTRY REQUIRED xkbregistry)
       pkg_check_modules(GLIB2 REQUIRED glib-2.0)
       find_library(LIBM m)
       include_directories(${LIBXKBCOMMON_INCLUDE_DIRS} ${GLIB2_INCLUDE_DIRS}
                           ${LIBM_INCLUDE_DIRS})
-      
+
       message(STATUS "xkbcommon version: ${LIBXKBCOMMON_VERSION}")
     else()
       message(WARNING "pkg-config not found, skipping wayland libraries")

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -301,6 +301,11 @@ void Client::resetOptions()
 
 void Client::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   for (auto index = options.begin(); index != options.end(); ++index) {
     const OptionID id = *index;
     if (id == kOptionClipboardSharing) {

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -773,6 +773,11 @@ void ServerProxy::setOptions()
   ProtocolUtil::readf(m_stream, kMsgDSetOptions + 4, &options);
   LOG_VERBOSE("recv set options size=%d", options.size());
 
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   // forward
   m_client->setOptions(options);
 

--- a/src/lib/deskflow/CMakeLists.txt
+++ b/src/lib/deskflow/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
 # SPDX-FileCopyrightText: (C) 2024 - 2025 Chris Rizzitello <sithlord48@gmail.com>
 # SPDX-FileCopyrightText: (C) 2012 - 2025 Symless Ltd
 # SPDX-FileCopyrightText: (C) 2009 - 2012 Nick Bolton
@@ -109,6 +110,6 @@ if(UNIX)
   )
 
   if(NOT APPLE)
-    target_link_libraries(${lib_name} PRIVATE Qt6::Xml)
+    target_link_libraries(${lib_name} PRIVATE ${LIBXKBREGISTRY_LINK_LIBRARIES})
   endif()
 endif()

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -281,6 +281,11 @@ void Screen::resetOptions()
 
 void Screen::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
+
   // update options
   for (uint32_t i = 0, n = (uint32_t)options.size(); i < n; i += 2) {
     if (options[i] == kOptionHalfDuplexCapsLock) {

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -18,7 +19,6 @@
 #include <platform/OSXAutoTypes.h>
 #endif
 
-#include <filesystem>
 
 AppUtilUnix::AppUtilUnix(const IEventQueue *)
 {
@@ -45,17 +45,7 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
   std::vector<std::string> layoutLangCodes;
 
 #if WINAPI_XWINDOWS
-  // Check /usr/local first used on bsd and some systems
-  std::vector<std::string> evdev_candidate = {
-      "/usr/share/X11/xkb/rules/evdev.xml",       // Linux
-      "/usr/local/share/X11/xkb/rules/evdev.xml", // FreeBSD, DragonFlyBSD
-      "/usr/X11R7/lib/X11/xkb/rules/evdev.xml",   // NetBSD
-      "/usr/X11R6/share/X11/xkb/rules/evdev.xml", // OpenBSD
-  };
-
-  for (auto it = evdev_candidate.begin(); it != evdev_candidate.end() && !std::filesystem::exists(m_evdev = *it); it++)
-    ;
-  layoutLangCodes = X11LayoutsParser::getX11LanguageList(m_evdev);
+  layoutLangCodes = X11LayoutsParser::getX11LanguageList();
 
 #elif defined(Q_OS_MAC)
   CFStringRef keys[] = {kTISPropertyInputSourceCategory};
@@ -151,7 +141,7 @@ std::string AppUtilUnix::getCurrentLanguageCode()
   XFree(kbdDescr);
   XCloseDisplay(display);
 
-  result = X11LayoutsParser::convertLayoutToISO(m_evdev, result);
+  result = X11LayoutsParser::convertLayoutToISO(result);
 
 #elif defined(Q_OS_MAC)
   AutoTISInputSourceRef source(nullptr, CFRelease);

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -23,5 +23,4 @@ public:
   void startNode() override;
   std::vector<std::string> getKeyboardLayoutList() override;
   std::string getCurrentLanguageCode() override;
-  std::string m_evdev;
 };

--- a/src/lib/deskflow/unix/X11LayoutsParser.cpp
+++ b/src/lib/deskflow/unix/X11LayoutsParser.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -9,13 +10,14 @@
 #include <algorithm>
 #include <sstream>
 
-#include <QDomDocument>
-#include <QFile>
+#include "base/Log.h"
 
 #include "DeskflowXkbKeyboard.h"
 #include "ISO639Table.h"
 #include "X11LayoutsParser.h"
-#include "base/Log.h"
+
+#include <xkbcommon/xkbregistry.h>
+
 
 namespace {
 
@@ -31,64 +33,56 @@ void splitLine(std::vector<std::string> &parts, const std::string &line, char de
 
 } // namespace
 
-bool X11LayoutsParser::readXMLConfigItemElem(const QDomNode &node, std::vector<Lang> &langList)
+std::vector<X11LayoutsParser::Lang> X11LayoutsParser::getAllLanguageData()
 {
-  auto configItemElem = node.firstChildElement("configItem");
-  if (configItemElem.isNull()) {
-    LOG_WARN("failed to read \"configItem\" in xml file");
-    return false;
-  }
+    std::vector<Lang> allCodes;
 
-  langList.emplace_back();
-  if (auto nameElem = configItemElem.firstChildElement("name"); !nameElem.isNull())
-    langList.back().name = nameElem.toElement().text().toStdString();
+    rxkb_context *ctx = rxkb_context_new(RXKB_CONTEXT_NO_FLAGS);
 
-  if (auto languageListElem = configItemElem.elementsByTagName("languageList"); !languageListElem.isEmpty()) {
-    for (int i = 0; i < languageListElem.count(); i++) {
-      const auto isoElem = languageListElem.at(i).namedItem("iso639Id").toElement();
-      langList.back().layoutBaseISO639_2.emplace_back(isoElem.text().toStdString());
+    if (!ctx) {
+        LOG_WARN("failed to create xkb registry context");
+        return allCodes;
     }
-  }
 
-  return true;
-}
+    if (!rxkb_context_parse_default_ruleset(ctx)) {
+        LOG_WARN("failed to parse xkb registry ruleset");
+        rxkb_context_unref(ctx);
+        return allCodes;
+    }
 
-std::vector<X11LayoutsParser::Lang> X11LayoutsParser::getAllLanguageData(const std::string &pathToEvdevFile)
-{
-  std::vector<Lang> allCodes;
+    for (rxkb_layout *layout = rxkb_layout_first((ctx)); layout; layout = rxkb_layout_next(layout)) {
+        const char *name = rxkb_layout_get_name(layout);
+        const char *variant = rxkb_layout_get_variant(layout);
 
-  QFile inFile(QString::fromStdString(pathToEvdevFile));
-  if (!inFile.open(QIODevice::ReadOnly)) {
-    LOG_WARN("unable to open %s", pathToEvdevFile.c_str());
+        std::vector<std::string> isoCodes;
+        for (rxkb_iso639_code *isoCode = rxkb_layout_get_iso639_first(layout); isoCode; isoCode = rxkb_iso639_code_next(isoCode)) {
+            if (const char *code = rxkb_iso639_code_get_code(isoCode)) {
+                isoCodes.emplace_back(code);
+            }
+        }
+
+        if (!variant) {
+            allCodes.emplace_back();
+            allCodes.back().name = name ? name : "";
+            allCodes.back().layoutBaseISO639_2 = std::move(isoCodes);
+        } else {
+            auto requiredName = name ? name : std::string{};
+            auto iterator =std::ranges::find_if(
+                allCodes,
+                [&](const Lang &l) {
+                    return l.name == requiredName;
+                }
+            );
+            if (iterator == allCodes.end()) continue;
+
+            iterator->variants.emplace_back();
+            iterator->variants.back().name = variant;
+            iterator->variants.back().layoutBaseISO639_2 = std::move(isoCodes);
+        }
+    }
+
+    rxkb_context_unref(ctx);
     return allCodes;
-  }
-
-  QDomDocument xmlDoc;
-  xmlDoc.setContent(inFile.readAll());
-
-  const auto xkbConfigElem = xmlDoc.firstChildElement("xkbConfigRegistry");
-  if (xkbConfigElem.isNull()) {
-    LOG_WARN("failed to read xkbConfigRegistry in %s", pathToEvdevFile.c_str());
-    return allCodes;
-  }
-
-  auto layoutListElem = xkbConfigElem.firstChildElement("layoutList");
-  if (layoutListElem.isNull()) {
-    LOG_WARN("failed to read layoutList in %s", pathToEvdevFile.c_str());
-    return allCodes;
-  }
-
-  const auto layouts = layoutListElem.elementsByTagName("layout");
-  for (int i = 0; i < layouts.count(); i++) {
-    auto item = layouts.at(i);
-    if (!readXMLConfigItemElem(item, allCodes))
-      continue;
-
-    auto variantListElem = item.namedItem("variantList").childNodes();
-    for (int j = 0; j < variantListElem.count(); j++)
-      readXMLConfigItemElem(variantListElem.at(j), allCodes.back().variants);
-  }
-  return allCodes;
 }
 
 void X11LayoutsParser::appendVectorUniq(const std::vector<std::string> &source, std::vector<std::string> &dst)
@@ -101,13 +95,13 @@ void X11LayoutsParser::appendVectorUniq(const std::vector<std::string> &source, 
 }
 
 void X11LayoutsParser::convertLayoutToISO639_2(
-    const std::string &pathToEvdevFile, bool needToReloadEvdev, const std::vector<std::string> &layoutNames,
+    const std::vector<std::string> &layoutNames,
     const std::vector<std::string> &layoutVariantNames, std::vector<std::string> &iso639_2Codes
 )
 {
   static std::vector<X11LayoutsParser::Lang> allLang;
-  if (allLang.empty() || needToReloadEvdev) {
-    allLang = getAllLanguageData(pathToEvdevFile);
+  if (allLang.empty()) {
+    allLang = getAllLanguageData();
   }
   for (size_t i = 0; i < layoutNames.size(); i++) {
     const auto &layoutName = layoutNames[i];
@@ -154,7 +148,7 @@ void X11LayoutsParser::convertLayoutToISO639_2(
   }
 }
 
-std::vector<std::string> X11LayoutsParser::getX11LanguageList(const std::string &pathToEvdevFile)
+std::vector<std::string> X11LayoutsParser::getX11LanguageList()
 {
   std::vector<std::string> layoutNames;
   std::vector<std::string> layoutVariantNames;
@@ -165,12 +159,12 @@ std::vector<std::string> X11LayoutsParser::getX11LanguageList(const std::string 
 
   std::vector<std::string> iso639_2Codes;
   iso639_2Codes.reserve(layoutNames.size());
-  convertLayoutToISO639_2(pathToEvdevFile, true, layoutNames, layoutVariantNames, iso639_2Codes);
+  convertLayoutToISO639_2( layoutNames, layoutVariantNames, iso639_2Codes);
   return convertISO639_2ToISO639_1(iso639_2Codes);
 }
 
 std::string X11LayoutsParser::convertLayoutToISO(
-    const std::string &pathToEvdevFile, const std::string &layoutLangCode, bool needToReloadFiles
+    const std::string &layoutLangCode
 )
 {
   if (layoutLangCode.empty()) {
@@ -179,7 +173,7 @@ std::string X11LayoutsParser::convertLayoutToISO(
   }
 
   std::vector<std::string> iso639_2Codes;
-  convertLayoutToISO639_2(pathToEvdevFile, needToReloadFiles, {layoutLangCode}, {""}, iso639_2Codes);
+  convertLayoutToISO639_2({layoutLangCode}, {""}, iso639_2Codes);
   if (iso639_2Codes.empty()) {
     LOG_WARN("failed to convert layout lang code: \"%s\"", layoutLangCode.c_str());
     return "";

--- a/src/lib/deskflow/unix/X11LayoutsParser.h
+++ b/src/lib/deskflow/unix/X11LayoutsParser.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -11,14 +12,12 @@
 #include <string>
 #include <vector>
 
-class QDomNode;
-
 class X11LayoutsParser
 {
 public:
-  static std::vector<std::string> getX11LanguageList(const std::string &pathToEvdevFile);
+  static std::vector<std::string> getX11LanguageList();
   static std::string convertLayoutToISO(
-      const std::string &pathToEvdevFile, const std::string &layoutLangCode, bool needToReloadFiles = false
+       const std::string &layoutLangCode
   );
 
 private:
@@ -29,15 +28,15 @@ private:
     std::vector<Lang> variants;
   };
 
-  static bool readXMLConfigItemElem(const QDomNode &node, std::vector<Lang> &langList);
-
-  static std::vector<Lang> getAllLanguageData(const std::string &pathToEvdevFile);
+  static std::vector<Lang> getAllLanguageData();
 
   static void appendVectorUniq(const std::vector<std::string> &source, std::vector<std::string> &dst);
 
-  static void convertLayoutToISO639_2(
-      const std::string &pathToEvdevFile, bool needToReloadEvdev, const std::vector<std::string> &layoutNames,
-      const std::vector<std::string> &layoutVariantNames, std::vector<std::string> &iso639_2Codes
+  static void convertLayoutToISO639_2
+  (
+      const std::vector<std::string> &layoutNames,
+      const std::vector<std::string> &layoutVariantNames,
+      std::vector<std::string> &iso639_2Codes
   );
 
   static std::vector<std::string> convertISO639_2ToISO639_1(const std::vector<std::string> &iso639_2Codes);

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -200,19 +200,19 @@ void SettingsDialog::showReadOnlyMessage()
 
 void SettingsDialog::updateText()
 {
-  const auto logLevelNames = LogLevel::logLevelNames();
+  const auto logLevels = LogLevel::logLevelNames().count();
   const QStringList toolTips = {tr("Required messages"),        tr("Non-fatal errors"), tr("General warnings"),
                                 tr("General events [Default]"), tr("Debug entries"),    tr("Verbose debug output")};
   if (ui->comboLogLevel->count() == 0) {
     const auto logLevelOptions = LogLevel::logLevelOptions();
-    for (int i = 0; i < logLevelNames.count(); i++) {
-      ui->comboLogLevel->addItem(logLevelNames.at(i));
+    for (int i = 0; i < logLevels; i++) {
+      ui->comboLogLevel->addItem(LogLevel::toString(i));
       ui->comboLogLevel->setItemData(i, logLevelOptions.at(i), Qt::UserRole);
       ui->comboLogLevel->setItemData(i, toolTips.at(i), Qt::ToolTipRole);
     }
   } else {
-    for (int i = 0; i < logLevelNames.count(); i++) {
-      ui->comboLogLevel->setItemData(i, logLevelNames.at(i), Qt::DisplayRole);
+    for (int i = 0; i < logLevels; i++) {
+      ui->comboLogLevel->setItemData(i, LogLevel::toString(i), Qt::DisplayRole);
       ui->comboLogLevel->setItemData(i, toolTips.at(i), Qt::ToolTipRole);
     }
   }

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -400,6 +400,10 @@ void XWindowsScreen::resetOptions()
 
 void XWindowsScreen::setOptions(const OptionsList &options)
 {
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, can not process them");
+    return;
+  }
   for (uint32_t i = 0, n = options.size(); i < n; i += 2) {
     if (options[i] == kOptionXTestXineramaUnaware) {
       m_xtestIsXineramaUnaware = (options[i + 1] != 0);

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -350,6 +350,11 @@ void ClientProxy1_0::resetOptions()
 void ClientProxy1_0::setOptions(const OptionsList &options)
 {
   LOG_VERBOSE("send set options to \"%s\" size=%d", getName().c_str(), options.size());
+  if (options.size() % 2 != 0) {
+    LOG_ERR("options are the incorrect size, not sending");
+    return;
+  }
+
   ProtocolUtil::writef(getStream(), kMsgDSetOptions, &options);
 
   // check options

--- a/src/unittests/deskflow/X11LayoutParserTests.cpp
+++ b/src/unittests/deskflow/X11LayoutParserTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2014 - 2016 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -9,77 +10,17 @@
 
 #include "deskflow/unix/X11LayoutsParser.h"
 
-void X11LayoutParserTests::initTestCase()
-{
-  QDir dir;
-  QVERIFY(dir.mkpath(kTestDir));
-
-  QFile correctEvdevFile(kTestCorrectFile);
-  QVERIFY(correctEvdevFile.open(QIODevice::WriteOnly));
-  correctEvdevFile.write(kCorrectEvContents.toUtf8());
-  correctEvdevFile.close();
-
-  QVERIFY(correctEvdevFile.open(QIODevice::ReadOnly));
-  QCOMPARE(correctEvdevFile.readAll(), kCorrectEvContents);
-  correctEvdevFile.close();
-
-  QFile futureEvdevFile(kTestFutureFile);
-  QVERIFY(futureEvdevFile.open(QIODevice::WriteOnly));
-  futureEvdevFile.write(kFutureEvContents.toUtf8());
-  futureEvdevFile.close();
-
-  QVERIFY(futureEvdevFile.open(QIODevice::ReadOnly));
-  QCOMPARE(futureEvdevFile.readAll(), kFutureEvContents);
-  futureEvdevFile.close();
-
-  QFile badEvdevFile1(kTestBadFile1);
-  QVERIFY(badEvdevFile1.open(QIODevice::WriteOnly));
-  badEvdevFile1.write(kBadEv1Contents.toUtf8());
-  badEvdevFile1.close();
-
-  QVERIFY(badEvdevFile1.open(QIODevice::ReadOnly));
-  QCOMPARE(badEvdevFile1.readAll(), kBadEv1Contents);
-  badEvdevFile1.close();
-
-  QFile badEvdevFile2(kTestBadFile2);
-  QVERIFY(badEvdevFile2.open(QIODevice::WriteOnly));
-  badEvdevFile2.write(kBadEv2Contents.toUtf8());
-  badEvdevFile2.close();
-
-  QVERIFY(badEvdevFile2.open(QIODevice::ReadOnly));
-  QCOMPARE(badEvdevFile2.readAll(), kBadEv2Contents);
-  badEvdevFile2.close();
-
-  QFile badEvdevFile3(kTestBadFile3);
-  QVERIFY(badEvdevFile3.open(QIODevice::WriteOnly));
-  badEvdevFile3.write(kBadEv3Contents.toUtf8());
-  badEvdevFile3.close();
-
-  QVERIFY(badEvdevFile3.open(QIODevice::ReadOnly));
-  QCOMPARE(badEvdevFile3.readAll(), kBadEv3Contents);
-  badEvdevFile3.close();
-}
-
-void X11LayoutParserTests::xmlParse()
-{
-  const QString badPath = QStringLiteral("%1/%2").arg(kTestDir, "notafile");
-  QVERIFY(X11LayoutsParser::getX11LanguageList(badPath.toStdString()).empty());
-
-  // we would like to check the method
-  // X11LayoutsParser::getAllLanguageData(kTestCorrectFile.toStdString());
-  // however it's logic is flawed making as the return list size is based on number of languges host has installed
-  // this is correct on a real system but makes it hard to test the method
-
-  QVERIFY(X11LayoutsParser::getX11LanguageList(kTestBadFile1.toStdString()).empty());
-  QVERIFY(X11LayoutsParser::getX11LanguageList(kTestBadFile2.toStdString()).empty());
-  QVERIFY(X11LayoutsParser::getX11LanguageList(kTestBadFile3.toStdString()).empty());
-}
-
 void X11LayoutParserTests::convertLayouts()
 {
-  QCOMPARE(X11LayoutsParser::convertLayoutToISO(kTestCorrectFile.toStdString(), "us", true), "en");
-  QCOMPARE(X11LayoutsParser::convertLayoutToISO(kTestBadFile1.toStdString(), "us", true), "");
-  QCOMPARE(X11LayoutsParser::convertLayoutToISO(kTestFutureFile.toStdString(), "us", true), "");
+  // An empty layout name yields an empty result.
+  QCOMPARE(X11LayoutsParser::convertLayoutToISO(""), "");
+
+  // An unknown layout name is not present in the registry.
+  QCOMPARE(X11LayoutsParser::convertLayoutToISO("notARealLayout"), "");
+
+  // A well-known layout resolves to its ISO 639-1 code. "us" is always
+  // present in the xkeyboard-config data and maps to "eng" -> "en".
+  QCOMPARE(X11LayoutsParser::convertLayoutToISO("us"), "en");
 }
 
 QTEST_MAIN(X11LayoutParserTests)

--- a/src/unittests/deskflow/X11LayoutParserTests.h
+++ b/src/unittests/deskflow/X11LayoutParserTests.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 praharshaAdhikari <praharsha101@gmail.com>
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -13,92 +14,8 @@ class X11LayoutParserTests : public QObject
   Q_OBJECT
 private Q_SLOTS:
   // Test are run in order top to bottom
-  void initTestCase();
-  void xmlParse();
   void convertLayouts();
 
 private:
   Log m_log;
-  const QString kTestDir = "tmp/test";
-  const QString kTestCorrectFile = "tmp/test/correctEvdev.xml";
-  const QString kTestFutureFile = "tmp/test/evdevFromFuture.xml";
-  const QString kTestBadFile1 = "tmp/test/evdevBad1.xml";
-  const QString kTestBadFile2 = "tmp/test/evdevBad2.xml";
-  const QString kTestBadFile3 = "tmp/test/evdevBad3.xml";
-
-  const QString kCorrectEvContents = QStringLiteral(
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-      "<xkbConfigRegistry version=\"1.1\">\n"
-      "  <layoutList>\n"
-      "    <layout>\n"
-      "      <configItem>\n"
-      "        <name>us</name>\n"
-      "        <!-- Keyboard indicator for English layouts -->\n"
-      "        <shortDescription>en</shortDescription>\n"
-      "        <description>English (US)</description>\n"
-      "        <languageList>\n"
-      "          <iso639Id>eng</iso639Id>\n"
-      "        </languageList>\n"
-      "      </configItem>\n"
-      "      <variantList>\n"
-      "        <variant>\n"
-      "          <configItem>\n"
-      "            <name>eng</name>\n"
-      "            <shortDescription>eng</shortDescription>\n"
-      "            <description>Cherokee</description>\n"
-      "            <languageList>\n"
-      "              <iso639Id>eng</iso639Id>\n"
-      "            </languageList>\n"
-      "          </configItem>\n"
-      "        </variant>\n"
-      "      </variantList>\n"
-      "    </layout>\n"
-      "    <layout>\n"
-      "      <configItem>\n"
-      "        <name>ru</name>\n"
-      "        <!-- Keyboard indicator for Russian layouts -->\n"
-      "        <shortDescription>ru</shortDescription>\n"
-      "        <description>Russian</description>\n"
-      "        <languageList>\n"
-      "          <iso639Id>rus</iso639Id>\n"
-      "        </languageList>\n"
-      "      </configItem>\n"
-      "    </layout>\n"
-      "  </layoutList>\n"
-      "</xkbConfigRegistry>\n"
-  );
-
-  const QString kFutureEvContents = QStringLiteral(
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-      "<xkbConfigRegistry version=\"1.1\">\n"
-      "  <layoutList>\n"
-      "    <layout>\n"
-      "      <configItem>\n"
-      "        <name>futureLangName</name>\n"
-      "        <languageList>\n"
-      "          <iso639Id>fln</iso639Id>\n"
-      "        </languageList>\n"
-      "      </configItem>\n"
-      "    </layout>\n"
-      "  </layoutList>\n"
-      "</xkbConfigRegistry>\n"
-  );
-
-  const QString kBadEv1Contents = QStringLiteral("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-
-  const QString kBadEv2Contents = QStringLiteral(
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-      "<xkbConfigRegistry version=\"1.1\">\n"
-      "</xkbConfigRegistry>"
-  );
-
-  const QString kBadEv3Contents = QStringLiteral(
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-      "<xkbConfigRegistry version=\"1.1\">\n"
-      "  <layoutList>\n"
-      "    <layout>\n"
-      "    </layout>\n"
-      "  </layoutList>\n"
-      "</xkbConfigRegistry>\n"
-  );
 };

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -183,11 +183,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;接続試行が失敗している場合、クライアントがサーバーへの再接続を試みる頻度を徐々に落とせるようにします。接続試行の間隔は当初1秒から開始され、最大で5分まで延長されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;接続試行が失敗し続けている場合に、クライアントがサーバーへ再接続を試みる頻度を徐々に下げます。接続試行の間隔は当初1秒から開始され、最大で5分まで延長されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Use dynamic reconnection time based on connection attempts</source>
-        <translation type="unfinished">接続試行回数に基づき、再接続時間を動的に調整する</translation>
+        <translation>接続試行回数に基づき、再接続時間を動的に調整する</translation>
     </message>
 </context>
 <context>
@@ -304,27 +304,27 @@ Do you want to connect to the server?
     <name>LogLevel</name>
     <message>
         <source>Fatal</source>
-        <translation type="unfinished">重大</translation>
+        <translation>重大</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">エラー</translation>
+        <translation>エラー</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation type="unfinished">警告</translation>
+        <translation>警告</translation>
     </message>
     <message>
         <source>Info</source>
-        <translation type="unfinished">情報</translation>
+        <translation>情報</translation>
     </message>
     <message>
         <source>Debug</source>
-        <translation type="unfinished">デバッグ</translation>
+        <translation>デバッグ</translation>
     </message>
     <message>
         <source>Verbose</source>
-        <translation type="unfinished">冗長</translation>
+        <translation>冗長</translation>
     </message>
 </context>
 <context>
@@ -564,35 +564,35 @@ Valid names:
     </message>
     <message>
         <source>read</source>
-        <translation type="unfinished">読み取り</translation>
+        <translation>読み取り</translation>
     </message>
     <message>
         <source>read and write</source>
-        <translation type="unfinished">読み書き</translation>
+        <translation>書き込み</translation>
     </message>
     <message>
         <source>The Core executable could not be started.
 Please check if you have sufficient permissions to run %1.</source>
-        <translation type="unfinished">Coreの実行ファイルを起動できませんでした。
+        <translation>Coreの実行ファイルを起動できませんでした。
 %1を実行するための十分な権限があるか確認してください。</translation>
     </message>
     <message>
         <source>
 Additionally, check you are able to %1 the server config file: %2</source>
-        <translation type="unfinished">
-また、サーバー設定ファイルを%1できることを確認してください: %2</translation>
+        <translation>
+また、サーバー設定ファイルへの%1権限があることを確認してください: %2</translation>
     </message>
     <message>
         <source>Don&apos;t show this again</source>
-        <translation type="unfinished"></translation>
+        <translation>再表示しない</translation>
     </message>
     <message>
         <source>Missing Keyboard Layouts</source>
-        <translation type="unfinished"></translation>
+        <translation>キーボードレイアウトの不足</translation>
     </message>
     <message>
         <source>&lt;p&gt;Keyboard layout support requires matching layouts on all computers. The following layouts from the other computer are not installed on this computer:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Please install them to enable support for these layouts.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;キーボードレイアウトのサポートには対応するレイアウトが全てのコンピューターに必要です。別のコンピューターで使用されている以下のレイアウトがこのコンピューターにインストールされていません:&lt;/p&gt;&lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;サポートを有効にするには、これらのレイアウトをインストールしてください。&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -899,11 +899,11 @@ Additionally, check you are able to %1 the server config file: %2</source>
     </message>
     <message>
         <source>Alt Gr</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt Gr</translation>
     </message>
     <message>
         <source>Alt &amp;Gr</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt &amp;Gr</translation>
     </message>
 </context>
 <context>
@@ -1260,39 +1260,39 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">ウィンドウ(&amp;W)</translation>
+        <translation>ウィンドウ(&amp;W)</translation>
     </message>
     <message>
         <source>When the main window is closed</source>
-        <translation type="unfinished">メインウィンドウが閉じられているとき</translation>
+        <translation>メインウィンドウを閉じたとき</translation>
     </message>
     <message>
         <source>Exit</source>
-        <translation type="unfinished">終了</translation>
+        <translation>アプリケーションを終了する</translation>
     </message>
     <message>
         <source>Send to background</source>
-        <translation type="unfinished">バックグラウンドに送信</translation>
+        <translation>バックグラウンドで実行する</translation>
     </message>
     <message>
         <source>When the application starts</source>
-        <translation type="unfinished">アプリケーションが起動すると</translation>
+        <translation>アプリケーション起動時</translation>
     </message>
     <message>
         <source>Show the main window</source>
-        <translation type="unfinished">メインウィンドウを表示する</translation>
+        <translation>メインウィンドウを表示する</translation>
     </message>
     <message>
         <source>Run command on enter</source>
-        <translation type="unfinished">Enterキーでコマンドを実行</translation>
+        <translation>画面に入る時にコマンドを実行</translation>
     </message>
     <message>
         <source>Run command on exit</source>
-        <translation type="unfinished">終了時にコマンドを実行</translation>
+        <translation>画面から出る時にコマンドを実行</translation>
     </message>
     <message>
         <source>Using a log level higher than Info may affect performance.</source>
-        <translation type="unfinished">Infoよりも高いログレベルを使用すると、パフォーマンスに影響を及ぼす可能性があります。</translation>
+        <translation>Infoよりも高いログレベルを使用すると、パフォーマンスに影響を及ぼす可能性があります。</translation>
     </message>
 </context>
 <context>
@@ -1356,7 +1356,7 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>%1 is waiting %2 seconds before the next retry</source>
-        <translation type="unfinished">%1 は次の再試行まで %2 秒待機しています</translation>
+        <translation>%1 は次の再試行まであと %2 秒待機します</translation>
     </message>
     <message>
         <source>%1 Encryption Enabled</source>


### PR DESCRIPTION
## Description
Replaces the hand-rolled `QDomDocument` parsing of `evdev.xml` with **libxkbregistry**; Issue: #8816 

## AI tools used for this PR
Claude Opus 4.8 (via Claude Code) was used for guidance and code review: identifying the
correct `rxkb_*` API, rewriting the unit tests, and updating the REUSE license headers. All changes were
reviewed and applied by me.

## Fixed/related issues
fixes: #8816 

## How has this been tested?
Built with CMake + Ninja on Fedora 43 (GCC 15, Qt 6.10.3, libxkbregistry 1.11)
