### PR TITLE
fix: restore client protocol downgrade message

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -15,6 +15,7 @@
 #include "common/NetworkProtocol.h"
 #include "common/Settings.h"
 #include "deskflow/Clipboard.h"
+#include "deskflow/DeskflowException.h"
 #include "deskflow/IPlatformScreen.h"
 #include "deskflow/PacketStreamFilter.h"
 #include "deskflow/ProtocolTypes.h"
@@ -632,14 +633,29 @@ void Client::handleHello()
     return;
   }
 
-  LOG_DEBUG(
-      "saying hello back with version %s %d.%d", protocolName.c_str(), kProtocolMajorVersion, kProtocolMinorVersion
-  );
+  if (serverMajor != kProtocolMajorVersion) {
+    LOG_WARN("server protocol version not compatible: %d.%d", serverMajor, serverMinor);
+    sendConnectionFailedEvent(IncompatibleClientException(serverMajor, serverMinor).what());
+    cleanupTimer();
+    cleanupConnection();
+    return;
+  }
+
+  int16_t helloBackMinor = kProtocolMinorVersion;
+  if (serverMinor < kProtocolMinorVersion) {
+    helloBackMinor = serverMinor;
+    LOG_INFO(
+        "downgrading client protocol version from %d.%d to %d.%d", //
+        kProtocolMajorVersion, kProtocolMinorVersion, kProtocolMajorVersion, helloBackMinor
+    );
+  }
+
+  LOG_DEBUG("saying hello back with version %s %d.%d", protocolName.c_str(), kProtocolMajorVersion, helloBackMinor);
 
   // dynamically build write format for hello back since `ProtocolUtil::writef`
   // doesn't support formatting fixed length strings yet.
   std::string helloBackMessage = protocolName + kMsgHelloBackArgs;
-  ProtocolUtil::writef(m_stream, helloBackMessage.c_str(), kProtocolMajorVersion, kProtocolMinorVersion, &m_name);
+  ProtocolUtil::writef(m_stream, helloBackMessage.c_str(), kProtocolMajorVersion, helloBackMinor, &m_name);
 
   // now connected but waiting to complete handshake
   setupScreen();


### PR DESCRIPTION
## Description

Restores the client-side protocol version negotiation that was accidentally
removed along with the `HelloBack` class. `Client::handleHello` read the
server's version from the hello message and then ignored it, always replying
with the client's own protocol version.

The client now:
- downgrades its minor version to match an older server and logs it
  (`downgrading client protocol version from 1.8 to 1.6`), so the downgrade
  is no longer silent
- rejects a server with a different major protocol version via a connection
  failed event, instead of continuing with a version it never negotiated

The original downgrade message used `LOG_NOTE`; that level no longer exists,
so the message is logged at `LOG_INFO`.

## AI tools used for this PR

Claude Code (Claude Fable 5, model `claude-fable-5`) was used to write the fix
and to test it.

## Fixed/related issues

fixes: #9540

## How has this been tested?

Tested against a fake server (Python script) that sends a hello with a chosen
protocol version and prints the client's hello back reply:

- Server greets with 1.6: client logs the downgrade at INFO and replies with
  1.6 (fake server confirmed receiving `Synergy 1.6`).
- Server greets with 2.0: client logs
  `server protocol version not compatible: 2.0`, raises a connection failed
  event (`incompatible client 2.0`), and closes without sending a hello back.
- Server greets with 1.8: client replies with 1.8 and no downgrade message is
  logged.

Environment: Fedora Linux 44 (Wayland), local developer build, TLS disabled,
client run as `deskflow-core client` with an override settings file.

```python
import socket
import struct
import sys

major, minor = int(sys.argv[1]), int(sys.argv[2])

srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
srv.bind(("127.0.0.1", 24801))
srv.listen(1)
print("listening on 24801, will greet with protocol %d.%d" % (major, minor), flush=True)

conn, addr = srv.accept()
hello = b"Synergy" + struct.pack(">hh", major, minor)
conn.sendall(struct.pack(">I", len(hello)) + hello)

def read_exact(sock, n):
    buf = b""
    while len(buf) < n:
        chunk = sock.recv(n - len(buf))
        if not chunk:
            raise EOFError("peer closed, got %d of %d bytes" % (len(buf), n))
        buf += chunk
    return buf

conn.settimeout(10)
(length,) = struct.unpack(">I", read_exact(conn, 4))
payload = read_exact(conn, length)
proto = payload[:7].decode()
back_major, back_minor = struct.unpack(">hh", payload[7:11])
(name_len,) = struct.unpack(">I", payload[11:15])
name = payload[15 : 15 + name_len].decode()
print("hello back: proto=%s version=%d.%d name=%s" % (proto, back_major, back_minor, name), flush=True)
conn.close()
srv.close()
```