### PR TITLE
fix(win): hide the parked cursor on the primary screen via mouse capture

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -533,8 +533,11 @@ void setCursorVisibility(bool visible)
 
 void MSWindowsDesks::deskEnter(Desk *desk)
 {
+  // restore the cursor shape while this thread still has the mouse capture
+  SetCursor(LoadCursor(nullptr, IDC_ARROW));
+  ReleaseCapture();
+
   if (!m_isPrimary) {
-    ReleaseCapture();
     if (m_relativeMouseMoves) {
       restoreRelativeCursorPosition(desk);
     }
@@ -622,6 +625,14 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
         AttachThreadInput(thatThread, thisThread, FALSE);
       }
     }
+
+    // capture the mouse so this window owns the parked cursor; the
+    // WS_EX_TRANSPARENT desk window never wins hit-testing without it
+    SetCapture(desk->m_window);
+
+    // WM_SETCURSOR is not sent while the mouse is captured, so display
+    // the blank cursor explicitly
+    SetCursor(m_cursor);
   } else {
     // move hider window under the cursor center, raise, and show it
     SetWindowPos(desk->m_window, HWND_TOP, m_xCenter, m_yCenter, 1, 1, SWP_NOACTIVATE | SWP_SHOWWINDOW);


### PR DESCRIPTION
## Description

While the server is on a secondary screen, the Windows primary parks the cursor at the center of the primary display, shows a 1x1 desk window with a blank class cursor underneath it, and calls `ShowCursor(FALSE)` on the desk thread. This does not reliably hide the cursor: the desk window is created with `WS_EX_TRANSPARENT`, so it never wins hit-testing. `WindowFromPoint()` at the parked position returns whatever application window lies beneath the center of the screen, that window's cursor shape is what gets displayed, and the desk thread's `ShowCursor()` display counter does not apply to the foreign window's thread either. The user sees an arrow parked in the middle of the primary screen the whole time a client is being controlled.

The secondary-screen path in `deskLeave()` has always solved the same problem by capturing the mouse (`SetCapture`), which makes the desk window own the cursor regardless of z-order and hit-testing. This change applies the same approach to the primary path:

- capture the mouse at the end of the primary branch of `deskLeave()`;
- because `WM_SETCURSOR` is not sent while the mouse is captured, the cursor would keep its pre-capture shape, so explicitly display the blank cursor with `SetCursor()` (which takes effect for the thread holding the capture);
- in `deskEnter()`, restore a normal arrow before releasing the capture (after `ReleaseCapture()` this thread can no longer set the cursor), and release the capture unconditionally instead of only for secondary screens.

Verified with `GetCursorInfo`/`GetGUIThreadInfo`: before the change, the parked state reported the underlying application's arrow cursor; after the change, the desk window holds the capture and the displayed cursor is the blank one.

Note: third-party cursor customization tools that periodically re-set the system cursor can still override the blank cursor (observed with one cursor beautifier on the test machine); this change fixes the stock Windows behavior.

## Disclosure of AI use

This PR was developed with the help of an AI coding assistant (Claude Code). The root-cause analysis, the change and the testing were verified on real hardware before submission.

## Related Issue

Likely the same root cause as #8918: whether the cursor gets hidden today depends on which window happens to lie under the center of the primary display and on that window's thread state.

## How Has This Been Tested?

- Windows 11 Pro for Workstations (build 26200) server, 3840x2160 primary display, KDE Plasma (Wayland) client; MSVC / Qt 6.10.3 builds on top of v1.26.0 and current master.
- Measured the parked-cursor state while controlling the client: `GetGUIThreadInfo` shows the desk window holding the mouse capture, and `GetCursorInfo` shows the blank cursor displayed (previously the underlying application's arrow).
- Crossing back restores the normal cursor with the first mouse movement.
