### PR TITLE
fix: clamp modifier translation table index, not the translated value

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -387,6 +387,11 @@ void ServerProxy::sendInfo(const ClientInfo &info)
 
 KeyID ServerProxy::translateKey(KeyID id) const
 {
+  return translateKey(id, m_modifierTranslationTable);
+}
+
+KeyID ServerProxy::translateKey(KeyID id, const KeyModifierID *modifierTranslationTable)
+{
   static const KeyID s_translationTable[kKeyModifierIDLast][2] = {
       {kKeyNone, kKeyNone},     {kKeyShift_L, kKeyShift_R}, {kKeyControl_L, kKeyControl_R}, {kKeyAlt_L, kKeyAlt_R},
       {kKeyMeta_L, kKeyMeta_R}, {kKeySuper_L, kKeySuper_R}, {kKeyAltGr, kKeyAltGr}
@@ -455,41 +460,49 @@ KeyID ServerProxy::translateKey(KeyID id) const
   }
 
   if (id2 != kKeyModifierIDNull) {
-    return std::clamp<KeyModifierMask>(
-        s_translationTable[m_modifierTranslationTable[id2]][side], 0, kKeyModifierIDLast - 1
-    );
+    const auto mappedID = std::clamp<KeyModifierID>(modifierTranslationTable[id2], 0, kKeyModifierIDLast - 1);
+    return s_translationTable[mappedID][side];
   } else {
-    return std::clamp<KeyModifierMask>(id, 0, kKeyModifierIDLast - 1);
+    return id;
   }
 }
 
 KeyModifierMask ServerProxy::translateModifierMask(KeyModifierMask mask) const
 {
+  return translateModifierMask(mask, m_modifierTranslationTable);
+}
+
+KeyModifierMask ServerProxy::translateModifierMask(KeyModifierMask mask, const KeyModifierID *modifierTranslationTable)
+{
   static const KeyModifierMask s_masks[kKeyModifierIDLast] = {0x0000,          KeyModifierShift, KeyModifierControl,
                                                               KeyModifierAlt,  KeyModifierMeta,  KeyModifierSuper,
                                                               KeyModifierAltGr};
+  const auto translatedMask = [modifierTranslationTable](KeyModifierID id) {
+    const auto mappedID = std::clamp<KeyModifierID>(modifierTranslationTable[id], 0, kKeyModifierIDLast - 1);
+    return s_masks[mappedID];
+  };
 
   KeyModifierMask newMask = mask & ~(KeyModifierShift | KeyModifierControl | KeyModifierAlt | KeyModifierMeta |
                                      KeyModifierSuper | KeyModifierAltGr);
   if ((mask & KeyModifierShift) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDShift]];
+    newMask |= translatedMask(kKeyModifierIDShift);
   }
   if ((mask & KeyModifierControl) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDControl]];
+    newMask |= translatedMask(kKeyModifierIDControl);
   }
   if ((mask & KeyModifierAlt) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDAlt]];
+    newMask |= translatedMask(kKeyModifierIDAlt);
   }
   if ((mask & KeyModifierAltGr) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDAltGr]];
+    newMask |= translatedMask(kKeyModifierIDAltGr);
   }
   if ((mask & KeyModifierMeta) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDMeta]];
+    newMask |= translatedMask(kKeyModifierIDMeta);
   }
   if ((mask & KeyModifierSuper) != 0) {
-    newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDSuper]];
+    newMask |= translatedMask(kKeyModifierIDSuper);
   }
-  return std::clamp<KeyModifierMask>(newMask, 0, kKeyModifierIDLast - 1);
+  return newMask;
 }
 
 void ServerProxy::enter()

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -505,6 +505,118 @@ KeyModifierMask ServerProxy::translateModifierMask(KeyModifierMask mask, const K
   return newMask;
 }
 
+KeyModifierID ServerProxy::modifierIDForKey(KeyID id)
+{
+  switch (id) {
+  case kKeyShift_L:
+  case kKeyShift_R:
+    return kKeyModifierIDShift;
+
+  case kKeyControl_L:
+  case kKeyControl_R:
+    return kKeyModifierIDControl;
+
+  case kKeyAlt_L:
+  case kKeyAlt_R:
+    return kKeyModifierIDAlt;
+
+  case kKeyMeta_L:
+  case kKeyMeta_R:
+    return kKeyModifierIDMeta;
+
+  case kKeySuper_L:
+  case kKeySuper_R:
+    return kKeyModifierIDSuper;
+
+  case kKeyAltGr:
+    return kKeyModifierIDAltGr;
+
+  default:
+    return kKeyModifierIDNull;
+  }
+}
+
+KeyModifierMask ServerProxy::modifierMaskForID(KeyModifierID id)
+{
+  switch (id) {
+  case kKeyModifierIDShift:
+    return KeyModifierShift;
+  case kKeyModifierIDControl:
+    return KeyModifierControl;
+  case kKeyModifierIDAlt:
+    return KeyModifierAlt;
+  case kKeyModifierIDMeta:
+    return KeyModifierMeta;
+  case kKeyModifierIDSuper:
+    return KeyModifierSuper;
+  case kKeyModifierIDAltGr:
+    return KeyModifierAltGr;
+  default:
+    return 0;
+  }
+}
+
+KeyModifierMask ServerProxy::activeModifierMask(KeyButton ignoredButton, bool ignoreButton) const
+{
+  int counts[kKeyModifierIDLast];
+  for (KeyModifierID id = 0; id < kKeyModifierIDLast; ++id) {
+    counts[id] = m_activeModifierKeyCounts[id];
+  }
+
+  if (ignoreButton) {
+    auto buttonIt = m_activeModifierButtons.find(ignoredButton);
+    if (buttonIt != m_activeModifierButtons.end() && counts[buttonIt->second] > 0) {
+      --counts[buttonIt->second];
+    }
+  }
+
+  KeyModifierMask mask = 0;
+  for (KeyModifierID id = 0; id < kKeyModifierIDLast; ++id) {
+    if (counts[id] > 0) {
+      mask |= modifierMaskForID(id);
+    }
+  }
+  return mask;
+}
+
+KeyModifierMask ServerProxy::mergeActiveModifiers(KeyModifierMask mask, KeyButton button) const
+{
+  return mask | activeModifierMask(button, true);
+}
+
+void ServerProxy::updateActiveModifier(KeyID id, KeyButton button, bool pressed)
+{
+  KeyModifierID modifierID = modifierIDForKey(id);
+  if (modifierID == kKeyModifierIDNull) {
+    return;
+  }
+
+  if (pressed) {
+    if (m_activeModifierButtons.try_emplace(button, modifierID).second) {
+      ++m_activeModifierKeyCounts[modifierID];
+    }
+  } else {
+    auto buttonIt = m_activeModifierButtons.find(button);
+    if (buttonIt == m_activeModifierButtons.end()) {
+      return;
+    }
+
+    KeyModifierID activeModifierID = buttonIt->second;
+    if (m_activeModifierKeyCounts[activeModifierID] > 0) {
+      --m_activeModifierKeyCounts[activeModifierID];
+    }
+    m_activeModifierButtons.erase(buttonIt);
+  }
+}
+
+void ServerProxy::clearActiveModifiers()
+{
+  for (KeyModifierID id = 0; id < kKeyModifierIDLast; ++id) {
+    m_activeModifierKeyCounts[id] = 0;
+  }
+  m_activeModifierButtons.clear();
+}
+
 void ServerProxy::enter()
 {
   // parse
@@ -523,6 +635,7 @@ void ServerProxy::enter()
   m_seqNum = seqNum;
   m_serverLayout = "";
   m_isUserNotifiedAboutLayoutSyncError = false;
+  clearActiveModifiers();
 
   // forward
   m_client->enter(x, y, seqNum, static_cast<KeyModifierMask>(mask), false);
@@ -535,6 +648,7 @@ void ServerProxy::leave()
 
   // send last mouse motion
   flushCompressedMouse();
+  clearActiveModifiers();
 
   // forward
   m_client->leave();
@@ -595,11 +709,13 @@ void ServerProxy::keyDown(uint16_t id, uint16_t mask, uint16_t button, const std
   // translate
   KeyID id2 = translateKey(static_cast<KeyID>(id));
   KeyModifierMask mask2 = translateModifierMask(static_cast<KeyModifierMask>(mask));
+  mask2 = mergeActiveModifiers(mask2, button);
   if (id2 != static_cast<KeyID>(id) || mask2 != static_cast<KeyModifierMask>(mask))
     LOG_VERBOSE("key down translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
   // forward
   m_client->keyDown(id2, mask2, button, lang);
+  updateActiveModifier(id2, button, true);
 }
 
 void ServerProxy::keyRepeat()
@@ -623,6 +739,7 @@ void ServerProxy::keyRepeat()
   // translate
   KeyID id2 = translateKey(static_cast<KeyID>(id));
   KeyModifierMask mask2 = translateModifierMask(static_cast<KeyModifierMask>(mask));
+  mask2 = mergeActiveModifiers(mask2, button);
   if (id2 != static_cast<KeyID>(id) || mask2 != static_cast<KeyModifierMask>(mask))
     LOG_VERBOSE("key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
@@ -650,6 +767,7 @@ void ServerProxy::keyUp()
 
   // forward
   m_client->keyUp(id2, mask2, button);
+  updateActiveModifier(id2, button, false);
 }
 
 void ServerProxy::mouseDown()
@@ -784,6 +902,7 @@ void ServerProxy::resetOptions()
   for (KeyModifierID id = 0; id < kKeyModifierIDLast; ++id) {
     m_modifierTranslationTable[id] = id;
   }
+  clearActiveModifiers();
 }
 
 void ServerProxy::setOptions()

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -29,6 +29,8 @@ to the server and messages from the server to calls on the client.
 */
 class ServerProxy
 {
+  friend class ServerProxyTests;
+
 public:
   /*!
   Process messages from the server on \p stream and forward to
@@ -73,6 +75,8 @@ private:
   // modifier key translation
   KeyID translateKey(KeyID) const;
   KeyModifierMask translateModifierMask(KeyModifierMask) const;
+  static KeyID translateKey(KeyID, const KeyModifierID *);
+  static KeyModifierMask translateModifierMask(KeyModifierMask, const KeyModifierID *);
 
   // event handlers
   void handleData();

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -13,6 +13,8 @@
 #include "deskflow/KeyTypes.h"
 #include "deskflow/KeyboardLayoutManager.h"
 
+#include <map>
+
 class Client;
 class ClientInfo;
 class EventQueueTimer;
@@ -77,6 +79,12 @@ private:
   KeyModifierMask translateModifierMask(KeyModifierMask) const;
   static KeyID translateKey(KeyID, const KeyModifierID *);
   static KeyModifierMask translateModifierMask(KeyModifierMask, const KeyModifierID *);
+  static KeyModifierID modifierIDForKey(KeyID);
+  static KeyModifierMask modifierMaskForID(KeyModifierID);
+  KeyModifierMask activeModifierMask(KeyButton ignoredButton, bool ignoreButton) const;
+  KeyModifierMask mergeActiveModifiers(KeyModifierMask, KeyButton) const;
+  void updateActiveModifier(KeyID, KeyButton, bool pressed);
+  void clearActiveModifiers();
 
   // event handlers
   void handleData();
@@ -122,6 +130,8 @@ private:
   bool m_ignoreMouse = false;
 
   KeyModifierID m_modifierTranslationTable[kKeyModifierIDLast];
+  int m_activeModifierKeyCounts[kKeyModifierIDLast] = {};
+  std::map<KeyButton, KeyModifierID> m_activeModifierButtons;
 
   double m_keepAliveAlarm = 0.0;
   EventQueueTimer *m_keepAliveAlarmTimer = nullptr;

--- a/src/unittests/CMakeLists.txt
+++ b/src/unittests/CMakeLists.txt
@@ -57,6 +57,7 @@ enable_testing()
 find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Test)
 
 add_subdirectory(base)
+add_subdirectory(client)
 add_subdirectory(common)
 add_subdirectory(deskflow)
 add_subdirectory(gui)

--- a/src/unittests/client/CMakeLists.txt
+++ b/src/unittests/client/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+
+if(WIN32)
+  set(extra_libs platform version)
+endif()
+
+create_test(
+  NAME ServerProxyTests
+  DEPENDS client
+  LIBS arch base app io net ${extra_libs}
+  SOURCE ServerProxyTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/client"
+)

--- a/src/unittests/client/ServerProxyTests.cpp
+++ b/src/unittests/client/ServerProxyTests.cpp
@@ -1,0 +1,58 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "ServerProxyTests.h"
+
+#include "client/ServerProxy.h"
+
+#include <array>
+
+namespace {
+
+std::array<KeyModifierID, kKeyModifierIDLast> identityModifierMap()
+{
+  std::array<KeyModifierID, kKeyModifierIDLast> modifiers;
+  for (KeyModifierID id = 0; id < kKeyModifierIDLast; ++id) {
+    modifiers[id] = id;
+  }
+  return modifiers;
+}
+
+} // namespace
+
+void ServerProxyTests::translateKey_regularKey_returnsOriginalKey()
+{
+  auto modifiers = identityModifierMap();
+
+  QCOMPARE(ServerProxy::translateKey('p', modifiers.data()), static_cast<KeyID>('p'));
+}
+
+void ServerProxyTests::translateKey_mappedModifier_clampsOnlyModifierIndex()
+{
+  auto modifiers = identityModifierMap();
+  modifiers[kKeyModifierIDShift] = kKeyModifierIDSuper;
+
+  QCOMPARE(ServerProxy::translateKey(kKeyShift_L, modifiers.data()), kKeySuper_L);
+}
+
+void ServerProxyTests::translateModifierMask_lockModifier_preservesHighBits()
+{
+  auto modifiers = identityModifierMap();
+
+  QCOMPARE(ServerProxy::translateModifierMask(KeyModifierNumLock, modifiers.data()), KeyModifierNumLock);
+}
+
+void ServerProxyTests::translateModifierMask_mappedModifier_preservesUnmappedBits()
+{
+  auto modifiers = identityModifierMap();
+  modifiers[kKeyModifierIDControl] = kKeyModifierIDAlt;
+
+  const auto mask = KeyModifierControl | KeyModifierNumLock;
+  const auto expectedMask = KeyModifierAlt | KeyModifierNumLock;
+  QCOMPARE(ServerProxy::translateModifierMask(mask, modifiers.data()), expectedMask);
+}
+
+QTEST_MAIN(ServerProxyTests)

--- a/src/unittests/client/ServerProxyTests.h
+++ b/src/unittests/client/ServerProxyTests.h
@@ -1,0 +1,18 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include <QTest>
+
+class ServerProxyTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void translateKey_regularKey_returnsOriginalKey();
+  void translateKey_mappedModifier_clampsOnlyModifierIndex();
+  void translateModifierMask_lockModifier_preservesHighBits();
+  void translateModifierMask_mappedModifier_preservesUnmappedBits();
+};


### PR DESCRIPTION
## Description

Commit 205a3c80 ("fix: clamp mapped modifiers") applied `std::clamp` to the *results* of the client's key/modifier translation instead of the table index that needed bounds checking. On any client built from a revision containing it:

- `translateKey()` clamps the returned `KeyID` to `[0, kKeyModifierIDLast - 1]` = `[0, 6]`: translated modifier keys turn into bogus key ids, and ordinary key ids collapse to 6, mangling key events.
- `translateModifierMask()` clamps the rebuilt modifier mask the same way, stripping `KeyModifierMeta`/`KeyModifierSuper` and all lock bits (num/caps/scroll lock) from every key event.

**First commit** clamps the translation table lookup index instead and returns translated values unchanged. It adds unit tests for both functions; the translation helpers get static overloads taking the table as a parameter so they can be tested without a server connection. The new test binary links `net` explicitly because the client library references `NetworkAddress`, which MSVC resolves strictly.

**Second commit**, independent of the regression: if a key event arrives whose modifier mask omits modifiers that are still physically held on the client (key down delivered, no key up yet), the client synthesizes modifier releases around the key and shortcuts like Ctrl+X stop working. Track active non-lock modifier presses per key button and merge them into subsequent key event masks when the incoming mask omits them. The tracked state is cleared on enter, leave and resetOptions to avoid stale modifier state.

## Disclosure of AI use

This PR was developed with the help of AI coding assistants (Claude Code and OpenAI Codex). The analysis and changes were reviewed and tested on real hardware before submission.

## Related Issue

Regression introduced by 205a3c80; no open issue found for it yet.

## How Has This Been Tested?

- New unit tests: 6/6 pass on Windows (MSVC, Qt 6.10.3); the change also builds and its tests pass on Linux.
- Real setup: Windows 11 server + KDE Plasma (Wayland) client. With a client built from a post-205a3c80 revision, key ids and lock/modifier masks arrive mangled; with this change they arrive intact and modifier shortcuts work.
- `deskflow-core` builds cleanly on Windows with the change applied.
