### PR TITLE
fix: simplify key translation logic by removing clamping

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -455,11 +455,9 @@ KeyID ServerProxy::translateKey(KeyID id) const
   }
 
   if (id2 != kKeyModifierIDNull) {
-    return std::clamp<KeyModifierMask>(
-        s_translationTable[m_modifierTranslationTable[id2]][side], 0, kKeyModifierIDLast - 1
-    );
+    return s_translationTable[m_modifierTranslationTable[id2]][side];
   } else {
-    return std::clamp<KeyModifierMask>(id, 0, kKeyModifierIDLast - 1);
+    return id;
   }
 }
 
@@ -489,7 +487,7 @@ KeyModifierMask ServerProxy::translateModifierMask(KeyModifierMask mask) const
   if ((mask & KeyModifierSuper) != 0) {
     newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDSuper]];
   }
-  return std::clamp<KeyModifierMask>(newMask, 0, kKeyModifierIDLast - 1);
+  return newMask;
 }
 
 void ServerProxy::enter()


### PR DESCRIPTION
## Description
Fixes a client keyboard regression from 205a3c80 without weakening its security fix.

205a3c80 clamped the modifier index at its write site in `setOptions` (the real OOB fix, kept here), but also clamped the *outputs* of `translateKey()` and `translateModifierMask()` to `[0, 6]`. Those output clamps broke the keyboard: key codes collapsed to `6` and Meta/Super plus lock bits were dropped. They guarded nothing, so this PR just removes them and keeps the index clamp.

Minimal alternative to #9944.

## AI tools used for this PR
Claude Code (Claude Opus 4.8), to find the regression and reduce the fix.

## Fixed/related issues
Regression from 205a3c80. Must not regress GHSA-8rcq-7w87-h64j (PoC: deskflow/scripts#12).

## How has this been tested?
PoC and client keyboard test.
