### PR TITLE
fix: prevent X11 clipboard deadlock on client connect

### DIFF
--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -287,7 +287,7 @@ private:
   Window m_window;
   ClipboardID m_id;
   Atom m_selection;
-  mutable std::mutex m_mutex;
+  mutable std::recursive_mutex m_mutex;
   mutable bool m_open = false;
   mutable Time m_time = 0;
   bool m_owner = false;


### PR DESCRIPTION
## Description

`XWindowsClipboard::m_mutex` is a non-recursive `std::mutex`, but `empty()` and `checkCache()` lock it then call `clearCache()` -> `doClearCache()` which re-locks it on the same thread -> self-deadlock (from 0042b43b). Freezes the client on connect during the clipboard grab, so the server kills it after ~9s. Fix: make it a `recursive_mutex`.

Bisected (good anchor: 5e79e4996):

```
$ git bisect good
0042b43baca3853991c0bc194a69775ad0e2a557 is the first bad commit
commit 0042b43baca3853991c0bc194a69775ad0e2a557
Date:   Thu Jun 18 20:30:04 2026 -0400

    refactor: use Mutex to protect vars in XWindowClipboard

 src/lib/platform/XWindowsClipboard.cpp | 14 +++++++++++++-
 src/lib/platform/XWindowsClipboard.h   |  2 ++
 2 files changed, 15 insertions(+), 1 deletion(-)
```

## AI tools used for this PR

Claude (Opus 4.8) - found the deadlock

## Fixed/related issues

?

## How has this been tested?

X11 client now connects instead of hanging right after "empty clipboard 0".
