### PR TITLE
fix(mac): allow screen switching at interior display edges

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -111,8 +111,16 @@ private:
   void sendEvent(EventTypes type, void * = nullptr) const;
   void sendClipboardEvent(EventTypes type, ClipboardID id) const;
 
+  // returns true if the given point lies on one of the displays
+  bool isPointOnDisplay(double x, double y) const;
+
+  // moves a point that lies inside the bounding box of all displays but
+  // on no display (a "dead zone" of a non-rectangular arrangement) onto
+  // the nearest display
+  void clampToDisplays(int32_t &x, int32_t &y) const;
+
   // message handlers
-  bool onMouseMove();
+  bool onMouseMove(double deltaX, double deltaY);
   // mouse button handler.  pressed is true if this is a mousedown
   // event, false if it is a mouseup event.  macButton is the index
   // of the button pressed using the mac button mapping.
@@ -231,6 +239,7 @@ private:
   int32_t m_x, m_y;
   int32_t m_w, m_h;
   int32_t m_xCenter, m_yCenter;
+  std::vector<CGRect> m_displayRects;
 
   // mouse state
   mutable int32_t m_xCursor, m_yCursor;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -35,6 +35,7 @@
 
 #include <AppKit/NSEvent.h>
 #include <AvailabilityMacros.h>
+#include <algorithm>
 #include <IOKit/hidsystem/event_status_driver.h>
 #include <dispatch/dispatch.h>
 #include <libproc.h>
@@ -270,6 +271,11 @@ void OSXScreen::warpCursor(int32_t x, int32_t y)
     return;
   }
 
+  // the server computes screen-entry positions on the bounding box of all
+  // displays; with a non-rectangular arrangement that point may lie on no
+  // display.  move it onto the nearest display before warping.
+  clampToDisplays(x, y);
+
   // move cursor without generating events
   CGPoint pos;
   pos.x = x;
@@ -280,6 +286,75 @@ void OSXScreen::warpCursor(int32_t x, int32_t y)
   m_xCursor = x;
   m_yCursor = y;
   m_cursorPosValid = true;
+}
+
+bool OSXScreen::isPointOnDisplay(double x, double y) const
+{
+  const CGPoint point = CGPointMake(x, y);
+  for (const CGRect &rect : m_displayRects) {
+    if (CGRectContainsPoint(rect, point)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void OSXScreen::clampToDisplays(int32_t &x, int32_t &y) const
+{
+  if (m_displayRects.empty() || isPointOnDisplay(x, y)) {
+    return;
+  }
+
+  // entry positions sit next to the bounding box edge on the axis that was
+  // crossed while the other axis carries the mapped position, so preserve
+  // the axis that is farther from the bounding box edge.
+  const int32_t xEdgeDist = std::min(x - m_x, (m_x + m_w - 1) - x);
+  const int32_t yEdgeDist = std::min(y - m_y, (m_y + m_h - 1) - y);
+  const bool preserveY = (xEdgeDist <= yEdgeDist);
+
+  const int32_t xOrig = x;
+  const int32_t yOrig = y;
+  double bestDist = -1;
+  auto consider = [&](double cx, double cy) {
+    const double dx = cx - xOrig;
+    const double dy = cy - yOrig;
+    const double dist = dx * dx + dy * dy;
+    if (bestDist < 0 || dist < bestDist) {
+      bestDist = dist;
+      x = (int32_t)cx;
+      y = (int32_t)cy;
+    }
+  };
+
+  for (const CGRect &rect : m_displayRects) {
+    const double minX = CGRectGetMinX(rect);
+    const double maxX = CGRectGetMaxX(rect) - 1;
+    const double minY = CGRectGetMinY(rect);
+    const double maxY = CGRectGetMaxY(rect) - 1;
+    const double cx = std::min(std::max((double)xOrig, minX), maxX);
+    const double cy = std::min(std::max((double)yOrig, minY), maxY);
+    if (preserveY) {
+      if (yOrig >= minY && yOrig <= maxY) {
+        consider(cx, yOrig);
+      }
+    } else {
+      if (xOrig >= minX && xOrig <= maxX) {
+        consider(xOrig, cy);
+      }
+    }
+  }
+
+  if (bestDist < 0) {
+    // no display spans the preserved coordinate; fall back to the nearest
+    // point on any display.
+    for (const CGRect &rect : m_displayRects) {
+      const double cx = std::min(std::max((double)xOrig, CGRectGetMinX(rect)), CGRectGetMaxX(rect) - 1);
+      const double cy = std::min(std::max((double)yOrig, CGRectGetMinY(rect)), CGRectGetMaxY(rect) - 1);
+      consider(cx, cy);
+    }
+  }
+
+  LOG_DEBUG("warp target %d,%d is on no display; clamped to %d,%d", xOrig, yOrig, x, y);
 }
 
 void OSXScreen::fakeInputBegin()
@@ -958,7 +1033,7 @@ void OSXScreen::handleSystemEvent(const Event &event)
   }
 }
 
-bool OSXScreen::onMouseMove()
+bool OSXScreen::onMouseMove(double deltaX, double deltaY)
 {
   // when we receive a mouse-move event, it is possible it was queued for a period
   // and that the mouse has already moved again since then.  to handle this, we need
@@ -974,7 +1049,29 @@ bool OSXScreen::onMouseMove()
   CGFloat x = mx - m_xCursor;
   CGFloat y = my - m_yCursor;
 
-  if ((x == 0 && y == 0) || (mx == m_xCenter && mx == m_yCenter)) {
+  // with a non-rectangular display arrangement the OS pins the cursor at
+  // display edges that lie inside the bounding box of all displays.  the
+  // server only switches screens when the cursor reaches the bounding box
+  // edge, which the cursor can never do from such an edge.  if the cursor
+  // is pushed against one of those edges, report a position at the
+  // bounding box edge instead so the server can consider a switch.
+  int32_t xReport = (int32_t)mx;
+  int32_t yReport = (int32_t)my;
+  if (m_isOnScreen) {
+    if (deltaX > 0 && !isPointOnDisplay(mx + 1, my)) {
+      xReport = m_x + m_w - 1;
+    } else if (deltaX < 0 && !isPointOnDisplay(mx - 1, my)) {
+      xReport = m_x;
+    }
+    if (deltaY > 0 && !isPointOnDisplay(mx, my + 1)) {
+      yReport = m_y + m_h - 1;
+    } else if (deltaY < 0 && !isPointOnDisplay(mx, my - 1)) {
+      yReport = m_y;
+    }
+  }
+  const bool pinnedAtInnerEdge = (xReport != (int32_t)mx || yReport != (int32_t)my);
+
+  if ((x == 0 && y == 0 && !pinnedAtInnerEdge) || (mx == m_xCenter && mx == m_yCenter)) {
     return true;
   }
 
@@ -984,7 +1081,7 @@ bool OSXScreen::onMouseMove()
 
   if (m_isOnScreen) {
     // motion on primary screen
-    sendEvent(EventTypes::PrimaryScreenMotionOnPrimary, MotionInfo::alloc(m_xCursor, m_yCursor));
+    sendEvent(EventTypes::PrimaryScreenMotionOnPrimary, MotionInfo::alloc(xReport, yReport));
   } else {
     // motion on secondary screen.  warp mouse back to
     // center.
@@ -1330,10 +1427,14 @@ bool OSXScreen::updateScreenShape()
 
   // get smallest rect enclosing all display rects
   CGRect totalBounds = CGRectZero;
+  std::vector<CGRect> displayRects;
+  displayRects.reserve(displayCount);
   for (CGDisplayCount i = 0; i < displayCount; ++i) {
     CGRect bounds = CGDisplayBounds(displays[i]);
+    displayRects.push_back(bounds);
     totalBounds = CGRectUnion(totalBounds, bounds);
   }
+  m_displayRects = std::move(displayRects);
 
   // get shape of default screen
   m_x = (int32_t)totalBounds.origin.x;
@@ -1691,8 +1792,13 @@ CGEventRef OSXScreen::handleCGInputEvent(CGEventTapProxy proxy, CGEventType type
   case kCGEventOtherMouseDragged:
   case kCGEventMouseMoved:
     // we intentionally ignore the position in the event here as the events are
-    // queued and will no longer be accurate when we process them.
-    screen->onMouseMove();
+    // queued and will no longer be accurate when we process them.  the deltas
+    // are still useful: they tell us the direction the mouse is being pushed
+    // even when the cursor is pinned against a display edge.
+    screen->onMouseMove(
+        CGEventGetDoubleValueField(event, kCGMouseEventDeltaX),
+        CGEventGetDoubleValueField(event, kCGMouseEventDeltaY)
+    );
 
     // The system ignores our cursor-centering calls if
     // we don't return the event. This should be harmless,


### PR DESCRIPTION
On macOS, the screen shape reported to the server is the bounding box of all displays. With a non-rectangular arrangement, the OS pins the cursor at display edges that lie inside that bounding box, so the cursor can never reach the bounding box edge and no screen switch happens from those edges.

  ## Description

 Setup that triggers the bug: a server with two external displays (A, B) above the built-in display (C), and a client (D) physically to the right of C:

```
Physical arrangement (server = one machine with displays A, B, C):

+---------------+---------------+
|               |               |
|       A       |       B       |
|  (external)   |  (external)   |
|               |               |
+-------+-------+-------+-------+--------+
		|               |                |
		|       C       |        D       |
		|  (built-in)   |    (client)    |
		|               |                |
		+---------------+----------------+
						^
		   cursor should cross here (C <-> D)

Screen shape reported to the server (bounding box of A+B+C):

+---------------+---------------+
|       A       |       B       |
|               |               |
+-------+-------+-------+-------+ <-- D attaches to this edge
|.......|       C       |.......|
|.......|               |.......| <-- ". . ." = dead zone: no display
+-------+---------------+-------+
						^
	  macOS pins the cursor at C's right edge, which is inside
	  the bounding box -- the switch to D never triggers
```

Because B extends further right than C, the bounding box's right edge is B's right edge, which the cursor can never reach from C. The reverse trip has the same problem: entry positions computed on the bounding box can land in the dead zone where no display exists.

Changes (all in `src/lib/platform/OSXScreen.{h,mm}`):

  - The CGEvent tap now forwards the raw mouse deltas to `onMouseMove`. When the cursor is pushed against a display edge with no display beyond it (checked against cached per-display rects), the reported position is promoted to the bounding box edge on that axis, so the server's existing jump logic can trigger. For rectangular arrangements the promoted position equals the actual position, so behavior is unchanged.
  - `warpCursor` clamps targets that lie on no display onto the nearest display, preserving the coordinate mapped along the entered edge (new `clampToDisplays` helper).
  - `updateScreenShape` caches the individual display bounds in `m_displayRects`.

Known limitations: the crossing height is still mapped over the full bounding-box height (flat screen model), so exiting from C enters D proportionally lower rather than perfectly straight; and since the bounding box edge is shared, leaving from B's right edge also switches to D. Equivalent fixes for the Windows/X11/libei backends are out of scope here.

## AI tools used for this PR

  This PR was created with Claude Code using the Claude Fable 5 model (claude-fable-5). It was used for the root-cause analysis & writing the patch itself. I'm not familiar with C++ myself, I validated the behavior on my own setup (see below), but the code deserves an extra-careful review.

## Fixed/related issues

No existing issue found for this; happy to link one if a maintainer knows of a duplicate.

## How has this been tested?

Manually, on the arrangement shown above:

  - Server: MacBook Pro (Apple Silicon), macOS 26, two external displays above the built-in display; built from source (Release, Qt 6.11).
  - Client: MacBook Pro, macOS.
  - Before the patch, the cursor could not leave C's right edge; the client was only reachable via B's right edge. After the patch, the cursor crosses C ↔ D directly in both directions, and returning from D lands on C (not B).
  - Verified existing behavior is unchanged where the display edge coincides with the bounding box edge (crossing from B to D still works).

No automated tests added, the behavior depends on live CoreGraphics display geometry and cursor pinning, which the existing test setup doesn't simulate.