### PR TITLE
Fix Portal IC thread cleanup on throw

### DIFF
--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -516,7 +516,16 @@ int ServerApp::mainLoop()
   }
 
   // start server, etc
-  appUtil().startNode();
+  try {
+    appUtil().startNode();
+  } catch (...) {
+    // a fatal startup failure (e.g. the listen address is already in use)
+    // exits by throwing, which unwinds past the cleanup at the end of this
+    // function. tear the server down here so the screen and its worker
+    // threads don't outlive the app and call into freed globals on exit.
+    cleanupServer();
+    throw;
+  }
 
   // handle hangup signal by reloading the server's configuration
   ARCH->setSignalHandler(Arch::ThreadSignal::Hangup, &reloadSignalHandler, nullptr);

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -519,10 +519,8 @@ int ServerApp::mainLoop()
   try {
     appUtil().startNode();
   } catch (...) {
-    // a fatal startup failure (e.g. the listen address is already in use)
-    // exits by throwing, which unwinds past the cleanup at the end of this
-    // function. tear the server down here so the screen and its worker
-    // threads don't outlive the app and call into freed globals on exit.
+    // a fatal startup failure exits by throwing, skipping the cleanup below;
+    // tear down here so the screen's worker threads don't outlive the app.
     cleanupServer();
     throw;
   }

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -94,6 +94,7 @@ EiScreen::~EiScreen()
   delete m_clipboard;
 
   delete m_portalRemoteDesktop;
+  delete m_portalInputCapture;
 }
 
 void EiScreen::eiLogEvent(ei_log_priority priority, const char *message) const

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -205,12 +205,15 @@ PortalInputCapture::~PortalInputCapture()
   if (m_session) {
     using enum Signal;
     XdpSession *parentSession = xdp_input_capture_session_get_session(m_session);
-    g_signal_handler_disconnect(G_OBJECT(parentSession), m_signals.at(SessionClosed));
+    if (m_signals.at(SessionClosed) != 0)
+      g_signal_handler_disconnect(parentSession, m_signals.at(SessionClosed));
     g_signal_handler_disconnect(m_session, m_signals.at(Disabled));
     g_signal_handler_disconnect(m_session, m_signals.at(Activated));
     g_signal_handler_disconnect(m_session, m_signals.at(Deactivated));
     g_signal_handler_disconnect(m_session, m_signals.at(ZonesChanged));
-    g_signal_handler_disconnect(m_session, m_signals.at(SelectionTransfer));
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+    g_signal_handler_disconnect(parentSession, m_signals.at(SelectionTransfer));
+#endif
     g_object_unref(m_session);
   }
 


### PR DESCRIPTION
## Description

Server aborted with `pure virtual method called` when startup failed after the screen was created (e.g. port in use): the EiScreen portal input-capture thread outlived the Arch singleton and hit its freed vtable on teardown. Clean up the screen on startup failure, delete the leaked `PortalInputCapture` so its thread joins, and fix its signal disconnect.

## AI tools used for this PR

Claude Code (Claude Opus 4.8, 1M context) - repro, core-dump analysis, fix.

## Fixed/related issues

None.

## How has this been tested?

Fedora/Wayland/libei. Repro'd via port-in-use (core dump confirmed the thread/vtable crash); after the fix, 5+ runs exit 1 cleanly, no abort, no glib critical.
