### PR TITLE
fix: prevent crash in fingerprint trust dialog

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -706,7 +706,7 @@ void MainWindow::applyConfig()
   if (const auto host = Settings::value(Settings::Client::RemoteHost).toString(); !host.isEmpty())
     ui->lineHostname->setText(host);
 
-  updateLocalFingerprint();
+  updateFingerprintButton();
   setTrayIcon();
 
   if (const auto ip = Settings::value(Settings::Core::Interface).toString(); !ip.isEmpty()) {
@@ -991,7 +991,7 @@ void MainWindow::coreConnectionStateChanged(ConnectionState state)
   }
 }
 
-void MainWindow::updateLocalFingerprint()
+void MainWindow::updateFingerprintButton()
 {
   m_statusBar->setBtnFingerprintVisible(TlsUtility::isEnabled() && !m_fingerprint.data.isEmpty());
 }
@@ -1189,7 +1189,7 @@ bool MainWindow::generateCertificate()
 
   m_fingerprint = {QCryptographicHash::Sha256, TlsUtility::certFingerprint()};
 
-  updateLocalFingerprint();
+  updateFingerprintButton();
   return true;
 }
 

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -352,9 +352,13 @@ void MainWindow::settingsChanged(const QString &key)
 
   if ((key == Settings::Security::Certificate) || (key == Settings::Security::KeySize) ||
       (key == Settings::Security::TlsEnabled) || (key == Settings::Security::CheckPeers)) {
-    if (TlsUtility::isEnabled() && !TlsUtility::isCertValid()) {
-      qWarning() << tr("invalid certificate, generating a new one");
-      TlsUtility::generateCertificate();
+    if (TlsUtility::isEnabled()) {
+      if (!TlsUtility::isCertValid()) {
+        qWarning() << tr("invalid certificate, generating a new one");
+        TlsUtility::generateCertificate();
+      }
+      m_fingerprint = {QCryptographicHash::Sha256, TlsUtility::certFingerprint()};
+      updateFingerprintButton();
     }
     updateSecurityIcon(m_statusBar->securityIconVisible());
     return;
@@ -1188,7 +1192,6 @@ bool MainWindow::generateCertificate()
   }
 
   m_fingerprint = {QCryptographicHash::Sha256, TlsUtility::certFingerprint()};
-
   updateFingerprintButton();
   return true;
 }

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -124,7 +124,7 @@ private:
   void secureSocket(bool secureSocket);
   void connectSlots();
   void handleLogLine(const QString &line);
-  void updateLocalFingerprint();
+  void updateFingerprintButton();
   void updateScreenName();
   void saveSettings() const;
   void showConfigureServer(const QString &message);

--- a/src/lib/gui/widgets/FingerprintPreview.cpp
+++ b/src/lib/gui/widgets/FingerprintPreview.cpp
@@ -7,6 +7,7 @@
 #include "FingerprintPreview.h"
 #include "common/PlatformInfo.h"
 
+#include <QDebug>
 #include <QFont>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -23,10 +24,21 @@ FingerprintPreview::FingerprintPreview(
   setFrameStyle(QFrame::Sunken);
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
-  setLayout(
-      fingerprint.type == QCryptographicHash::Sha256 ? sha256Layout(fingerprint, titleText, hashMode) : emptyLayout()
-  );
+  if (fingerprint.type == QCryptographicHash::Sha256) {
+    setLayout(sha256Layout(fingerprint, titleText, hashMode));
+  } else {
+    qWarning() << "cannot render fingerprint, unsupported type:" << Fingerprint::typeToString(fingerprint.type);
+    setLayout(emptyLayout());
+  }
+
   adjustSize();
+
+  if (!m_lblArt) {
+    qDebug() << "sizing preview without art padding, no art label";
+    setFixedSize(size());
+    return;
+  }
+
   int artPadding = 48;
   if (deskflow::platform::isMac())
     artPadding = 32;


### PR DESCRIPTION
## Description
Fixes a null ptr crash in the fingerprint trust dialog. `m_fingerprint` wasn't refreshed when we regenerated the cert, so an invalid local fingerprint reached `FingerprintPreview`, which left `m_lblArt` null and crashed in `setFixedSize`.

## AI tools used for this PR
Claude Code (claude-opus-4-8, 1M context) - diagnosed the crash and fixed.

## Fixed/related issues
None.

## How has this been tested?
Smoke tested

## Original bug stack trace 
```
QWidget::width() const (/usr/include/x86_64-linux-gnu/qt6/QtWidgets/qwidget.h:900)
FingerprintPreview::FingerprintPreview(QWidget*, Fingerprint const&, QString const&, bool) (/home/nick/Projects/deskflow/src/lib/gui/widgets/FingerprintPreview.cpp:33)
FingerprintDialog::makeCompareLayout(Fingerprint const&, bool, Fingerprint const&) (/home/nick/Projects/deskflow/src/lib/gui/dialogs/FingerprintDialog.cpp:103)
FingerprintDialog::FingerprintDialog(QWidget*, Fingerprint const&, FingerprintDialogMode, Fingerprint const&) (/home/nick/Projects/deskflow/src/lib/gui/dialogs/FingerprintDialog.cpp:35)
MainWindow::handlePeerFingerprint(QString const&) (/home/nick/Projects/deskflow/src/lib/gui/MainWindow.cpp:871)
QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (MainWindow::*)(QString const&)>::call(void (MainWindow::*)(QString const&), MainWindow*, void**)::'lambda'()::operator()() const (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:152)
void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (MainWindow::*)(QString const&)>::call(void (MainWindow::*)(QString const&), MainWindow*, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (MainWindow::*)(QString const&)>::call(void (MainWindow::*)(QString const&), MainWindow*, void**)::'lambda'()&&) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65)
QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (MainWindow::*)(QString const&)>::call(void (MainWindow::*)(QString const&), MainWindow*, void**) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:151)
void QtPrivate::FunctionPointer<void (MainWindow::*)(QString const&)>::call<QtPrivate::List<QString const&>, void>(void (MainWindow::*)(QString const&), MainWindow*, void**) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:199)
QtPrivate::QCallableObject<void (MainWindow::*)(QString const&), QtPrivate::List<QString const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:570)
___lldb_unnamed_symbol15705 (Unknown Source:0)
deskflow::gui::CoreProcess::peerFingerprint(QString const&) (/home/nick/Projects/deskflow/build/src/lib/gui/gui_autogen/TAC5DWH4SE/moc_CoreProcess.cpp:441)
deskflow::gui::CoreProcess::onCoreIpcMessageReceived(QString const&, QString const&) (/home/nick/Projects/deskflow/src/lib/gui/core/CoreProcess.cpp:599)
QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<QString const&, QString const&>, void, void (deskflow::gui::CoreProcess::*)(QString const&, QString const&)>::call(void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), deskflow::gui::CoreProcess*, void**)::'lambda'()::operator()() const (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:152)
void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<QString const&, QString const&>, void, void (deskflow::gui::CoreProcess::*)(QString const&, QString const&)>::call(void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), deskflow::gui::CoreProcess*, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<QString const&, QString const&>, void, void (deskflow::gui::CoreProcess::*)(QString const&, QString const&)>::call(void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), deskflow::gui::CoreProcess*, void**)::'lambda'()&&) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65)
QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<QString const&, QString const&>, void, void (deskflow::gui::CoreProcess::*)(QString const&, QString const&)>::call(void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), deskflow::gui::CoreProcess*, void**) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:151)
void QtPrivate::FunctionPointer<void (deskflow::gui::CoreProcess::*)(QString const&, QString const&)>::call<QtPrivate::List<QString const&, QString const&>, void>(void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), deskflow::gui::CoreProcess*, void**) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:199)
QtPrivate::QCallableObject<void (deskflow::gui::CoreProcess::*)(QString const&, QString const&), QtPrivate::List<QString const&, QString const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (/usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:570)
___lldb_unnamed_symbol15705 (Unknown Source:0)
deskflow::gui::ipc::CoreIpcClient::commandReceived(QString const&, QString const&) (/home/nick/Projects/deskflow/build/src/lib/gui/gui_autogen/NX6PWWVH4D/moc_CoreIpcClient.cpp:145)
```
