### PR TITLE
fix(mac): prevent tray icon crash on macOS 26+

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -24,6 +24,7 @@
 #include <QSharedMemory>
 
 #if defined(Q_OS_MACOS)
+#include "gui/OSXHelpers.h"
 #include <Carbon/Carbon.h>
 #include <cstdlib>
 #endif
@@ -129,6 +130,8 @@ int main(int argc, char *argv[])
   qInfo("%s v%s", kAppName, kDisplayVersion);
 
 #if defined(Q_OS_MACOS)
+
+  installMacOSTrayCrashWorkaround();
 
   if (app.applicationDirPath().startsWith("/Volumes/")) {
     QString msgBody = QStringLiteral(

--- a/src/lib/gui/OSXHelpers.h
+++ b/src/lib/gui/OSXHelpers.h
@@ -14,3 +14,4 @@ bool showOSXNotification(const QString &title, const QString &body);
 bool isOSXInterfaceStyleDark();
 void forceAppActive();
 void macOSNativeHide();
+void installMacOSTrayCrashWorkaround();

--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -16,6 +16,8 @@
 
 #import <QtGlobal>
 
+#import <objc/runtime.h>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
@@ -106,4 +108,48 @@ void macOSNativeHide()
 {
   [NSApp hide:nil];
   [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+static bool isMouseEventType(NSEventType type)
+{
+  switch (type) {
+  case NSEventTypeLeftMouseDown:
+  case NSEventTypeLeftMouseUp:
+  case NSEventTypeRightMouseDown:
+  case NSEventTypeRightMouseUp:
+  case NSEventTypeOtherMouseDown:
+  case NSEventTypeOtherMouseUp:
+  case NSEventTypeLeftMouseDragged:
+  case NSEventTypeRightMouseDragged:
+  case NSEventTypeOtherMouseDragged:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static void guardNSEventMouseAccessor(SEL selector)
+{
+  Method method = class_getInstanceMethod([NSEvent class], selector);
+  if (method == nil)
+    return;
+  const auto original = reinterpret_cast<NSInteger (*)(id, SEL)>(method_getImplementation(method));
+  IMP guarded = imp_implementationWithBlock(^NSInteger(NSEvent *event) {
+    return isMouseEventType(event.type) ? original(event, selector) : 0;
+  });
+  method_setImplementation(method, guarded);
+}
+
+void installMacOSTrayCrashWorkaround()
+{
+  // On macOS 26+ status items are scene-based, so when the tray menu opens,
+  // NSApp.currentEvent is not a mouse event. Qt's
+  // QCocoaSystemTrayIcon::emitActivated() still calls -[NSEvent clickCount]
+  // on it, which raises NSInternalInconsistencyException and aborts the app
+  // (unfixed in Qt as of 6.11). Make the mouse-only NSEvent accessors Qt uses
+  // return 0 for non-mouse events instead of throwing.
+  if (![NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:{26, 0, 0}])
+    return;
+  guardNSEventMouseAccessor(@selector(clickCount));
+  guardNSEventMouseAccessor(@selector(buttonNumber));
 }


### PR DESCRIPTION
On macOS 26+ status items are scene-based, so opening the tray menu posts a notification where `NSApp.currentEvent` is not a mouse event. Qt's `QCocoaSystemTrayIcon::emitActivated()` still calls `-[NSEvent clickCount]` on it, which raises an `NSInternalInconsistencyException` and aborts the app. This is unfixed in Qt as of 6.11.

`installMacOSTrayCrashWorkaround()` swizzles the mouse-only `NSEvent` accessors `clickCount` and `buttonNumber` to return 0 for non-mouse events instead of throwing, guarded to run only on macOS 26 and later. A 0 click count makes Qt treat the activation as a plain trigger, so the existing menu behavior is preserved.

Built with Xcode 27 beta 3 and verified on macOS 27 beta 3 that clicking the menu bar tray icon opens the menu without crashing.
