### PR TITLE
Move screen options 1

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -169,6 +169,7 @@ Each screen will have a section where its configuration will be stored, if the s
 |Option              |    Valid Values    |Description|
 |:-------------------|:------------------:|:-----------|
 | aliases            | Comma separated list of hostnames | Names here will be used as alternatives for the computer. Names must be valid hostnames. |
+| name               | Valid hostname | The name of the client. |
 
 
 ### InternalConfig

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -378,3 +378,15 @@ QVariant Settings::screenDefaults(const QString &key)
 {
   return QVariant();
 }
+
+QStringList Settings::knownScreens()
+{
+  const QStringList knownGroups = instance()->m_settings->childGroups();
+  QStringList screens;
+  for (const auto &group : knownGroups) {
+    if (group.startsWith("screen_")) {
+      screens.append(Settings::value(QStringLiteral("%1/name").arg(group)).toString());
+    }
+  }
+  return screens;
+}

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -123,6 +123,8 @@ void Settings::cleanSettings()
       continue;
     if (const auto group = key.mid(0, key.indexOf('/')); !m_validKeys.contains(key) && m_validGroup.contains(group))
       m_settings->remove(key);
+    if (m_settings->value(key) == "QStringList" && m_settings->value(key).toStringList().isEmpty())
+      m_settings->remove(key);
     if (!m_settings->value(key).canConvert<QStringList>() && m_settings->value(key).toString().isEmpty())
       m_settings->remove(key);
   }
@@ -169,6 +171,11 @@ QString Settings::cleanComputerName(const QString &name)
 
 QVariant Settings::defaultValue(const QString &key)
 {
+  if (key.startsWith(QStringLiteral("screen_"))) {
+    const auto screenKey = key.mid(0, key.indexOf('/') + 1);
+    return screenDefaults(screenKey);
+  }
+
   if (m_defaultFalseValues.contains(key))
     return false;
 
@@ -365,4 +372,9 @@ void Settings::removeUnknownScreens(const QStringList &knownScreens)
       continue;
     instance()->m_settings->remove(group);
   }
+}
+
+QVariant Settings::screenDefaults(const QString &key)
+{
+  return QVariant();
 }

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -195,6 +195,7 @@ public:
   static QStringList validGroups();
   static QString portableSettingsFile();
   static void removeUnknownScreens(const QStringList &knownScreens);
+  static QVariant screenDefaults(const QString &key);
 
 Q_SIGNALS:
   void settingsChanged(const QString key);

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -126,6 +126,7 @@ public:
   struct Screen
   {
     inline static const auto Aliases = QStringLiteral("screen_%1/aliases");
+    inline static const auto Name = QStringLiteral("screen_%1/name");
   };
 
   // Track Removed keys to make upgrading config easier

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -197,6 +197,7 @@ public:
   static QString portableSettingsFile();
   static void removeUnknownScreens(const QStringList &knownScreens);
   static QVariant screenDefaults(const QString &key);
+  static QStringList knownScreens();
 
 Q_SIGNALS:
   void settingsChanged(const QString key);

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -38,13 +38,13 @@ void Screen::loadSettings(QSettingsProxy &settings)
 
 void Screen::saveSettings(QSettingsProxy &settings) const
 {
-
   const auto screenName = name();
   settings.setValue("name", screenName);
 
   if (screenName.isEmpty())
     return;
 
+  Settings::setValue(Settings::Screen::Name.arg(screenName), screenName);
   Settings::setValue(Settings::Screen::Aliases.arg(screenName), m_Aliases);
 
   settings.setValue("switchCornerSize", switchCornerSize());

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -97,6 +97,7 @@ void ServerConfigDialog::accept()
       continue;
     screenNames.append(QStringLiteral("screen_%1").arg(screenName));
     Settings::setValue(Settings::Screen::Aliases.arg(screenName), screen.aliases());
+    Settings::setValue(Settings::Screen::Name.arg(screenName), screenName);
   }
   Settings::removeUnknownScreens(screenNames);
   QDialog::accept();


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->

WIP More to come to this POST 1.27 release 

 - Move the screen options to general config 
   - name 
 - new method to remove unknown screen names. 
 - new method to get screen defaults
 - new method to get knownScreens (postConfiguration)
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
part of #9959 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
