### PR TITLE
refactor: remove unused address option from old config

### DIFF
--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -484,9 +484,11 @@ void Config::readSectionOptions(ConfigReadContext &s)
 
   std::string line;
   while (s.readLine(line)) {
-    // check for end of section
     if (line == "end") {
       return;
+    } else if (const auto l = QString::fromStdString(line).simplified();
+               !l.startsWith(QStringLiteral("keystroke")) && !l.startsWith(QStringLiteral("mousepress"))) {
+      continue;
     }
 
     // parse argument:  `nameAndArgs = [values][;[values]]'
@@ -501,9 +503,6 @@ void Config::readSectionOptions(ConfigReadContext &s)
     s.parseNameWithArgs("name", line, "=", i, name, nameArgs);
     ++i;
     s.parseNameWithArgs("value", line, ",;\n", i, value, valueArgs);
-
-    if (m_oldNames.contains(name))
-      continue;
 
     // make filter rule
     InputFilter::Rule rule(parseCondition(s, name, nameArgs));

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -471,6 +471,17 @@ void Config::readSectionOptions(ConfigReadContext &s)
   addOption("", kOptionClipboardSharing, Settings::value(Settings::Server::EnableClipboard).toBool());
   addOption("", kOptionClipboardSharingSize, Settings::value(Settings::Server::ClipboardSize).toUInt() * 1024);
 
+  if (const auto address = Settings::value(Settings::Core::Interface).toString(); !address.isEmpty()) {
+    m_deskflowAddress = NetworkAddress(address.toStdString(), Settings::value(Settings::Core::Port).toInt());
+  } else {
+    m_deskflowAddress = NetworkAddress(Settings::value(Settings::Core::Port).toInt());
+  }
+  try {
+    m_deskflowAddress.resolve();
+  } catch (SocketAddressException &e) {
+    throw ServerConfigReadException(s, std::string("invalid address argument ") + e.what());
+  }
+
   std::string line;
   while (s.readLine(line)) {
     // check for end of section
@@ -491,66 +502,45 @@ void Config::readSectionOptions(ConfigReadContext &s)
     ++i;
     s.parseNameWithArgs("value", line, ",;\n", i, value, valueArgs);
 
-    bool handled = true;
-
     if (m_oldNames.contains(name))
       continue;
 
-    if (name == "address") {
-      try {
-        m_deskflowAddress = NetworkAddress(value, kDefaultPort);
-        m_deskflowAddress.resolve();
-      } catch (SocketAddressException &e) {
-        throw ServerConfigReadException(s, std::string("invalid address argument ") + e.what());
-      }
-    } else {
-      handled = false;
+    // make filter rule
+    InputFilter::Rule rule(parseCondition(s, name, nameArgs));
+
+    // save first action (if any)
+    if (!value.empty() || line[i] != ';') {
+      parseAction(s, value, valueArgs, rule, true);
     }
 
-    if (handled) {
-      // make sure handled options aren't followed by more values
-      if (i < line.size() && (line[i] == ',' || line[i] == ';')) {
-        throw ServerConfigReadException(s, std::string("too many arguments for: ").append(name));
-      }
-    } else {
-      // make filter rule
-      InputFilter::Rule rule(parseCondition(s, name, nameArgs));
+    // get remaining activate actions
+    while (i < line.length() && line[i] != ';') {
+      ++i;
+      s.parseNameWithArgs("value", line, ",;\n", i, value, valueArgs);
+      parseAction(s, value, valueArgs, rule, true);
+    }
 
-      // save first action (if any)
-      if (!value.empty() || line[i] != ';') {
-        parseAction(s, value, valueArgs, rule, true);
+    // get deactivate actions
+    if (i < line.length() && line[i] == ';') {
+      // allow trailing ';'
+      i = line.find_first_not_of(" \t", i + 1);
+      if (i == std::string::npos) {
+        i = line.length();
+      } else {
+        --i;
       }
 
-      // get remaining activate actions
-      while (i < line.length() && line[i] != ';') {
+      // get actions
+      while (i < line.length()) {
         ++i;
-        s.parseNameWithArgs("value", line, ",;\n", i, value, valueArgs);
-        parseAction(s, value, valueArgs, rule, true);
+        s.parseNameWithArgs("value", line, ",\n", i, value, valueArgs);
+        parseAction(s, value, valueArgs, rule, false);
       }
-
-      // get deactivate actions
-      if (i < line.length() && line[i] == ';') {
-        // allow trailing ';'
-        i = line.find_first_not_of(" \t", i + 1);
-        if (i == std::string::npos) {
-          i = line.length();
-        } else {
-          --i;
-        }
-
-        // get actions
-        while (i < line.length()) {
-          ++i;
-          s.parseNameWithArgs("value", line, ",\n", i, value, valueArgs);
-          parseAction(s, value, valueArgs, rule, false);
-        }
-      }
-
-      // add rule
-      m_inputFilter.addFilterRule(rule);
     }
-  }
 
+    // add rule
+    m_inputFilter.addFilterRule(rule);
+  }
   throw ServerConfigReadException(s, "unexpected end of options section");
 }
 

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -419,22 +419,6 @@ private:
   InputFilter m_inputFilter;
   bool m_hasLockToScreenAction = false;
   IEventQueue *m_events;
-  inline static const QStringList m_oldNames = {
-      QStringLiteral("clipboardSharing"),
-      QStringLiteral("clipboardSharingSize"),
-      QStringLiteral("switchCornerSize"),
-      QStringLiteral("switchCorners"),
-      QStringLiteral("switchNeeds"),
-      QStringLiteral("protocol"),
-      QStringLiteral("heartbeat"),
-      QStringLiteral("switchDelay"),
-      QStringLiteral("switchDoubleTap"),
-      QStringLiteral("relativeMouseMoves"),
-      QStringLiteral("win32KeepForeground"),
-      QStringLiteral("disableLockToScreen"),
-      QStringLiteral("defaultLockToScreenState"),
-      QStringLiteral("address")
-  };
 };
 
 //! Configuration read context

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -432,7 +432,8 @@ private:
       QStringLiteral("relativeMouseMoves"),
       QStringLiteral("win32KeepForeground"),
       QStringLiteral("disableLockToScreen"),
-      QStringLiteral("defaultLockToScreenState")
+      QStringLiteral("defaultLockToScreenState"),
+      QStringLiteral("address")
   };
 };
 


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Remove the `address` option from the old config.
 - Modify `Config::readSectionOptions` to only look only for `keypress` / `mousepress` and `end` tags 
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #9881 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local smoke test. 