### PR TITLE
Performance & reliability: logging, TLS socket state, wake reconnect, and Windows tweaks

### DIFF
--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -219,14 +219,17 @@ bool Log::setFilter(const QString &maxPriority)
 
 void Log::setFilter(LogLevel::Level maxPriority)
 {
-  std::scoped_lock lock{m_mutex};
-  m_maxPriority = maxPriority;
+  m_maxPriority.store(maxPriority, std::memory_order_relaxed);
 }
 
 LogLevel::Level Log::getFilter() const
 {
-  std::scoped_lock lock{m_mutex};
-  return m_maxPriority;
+  return m_maxPriority.load(std::memory_order_relaxed);
+}
+
+bool Log::willPrint(LogLevel::Level level) const
+{
+  return level <= getFilter();
 }
 
 void Log::output(LogLevel::Level priority, const char *msg)

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -10,6 +10,7 @@
 
 #include "common/LogLevel.h"
 
+#include <atomic>
 #include <list>
 #include <mutex>
 
@@ -106,6 +107,13 @@ public:
   //! Get the minimum priority level.
   LogLevel::Level getFilter() const;
 
+  //! Test whether a message at \p level would pass the current filter.
+  /*!
+  Cheap, lock-free check used by the LOG_* macros to skip evaluating log
+  arguments for messages that would be discarded.
+  */
+  bool willPrint(LogLevel::Level level) const;
+
   //! Get the singleton instance of the log
   static Log *getInstance();
 
@@ -129,7 +137,7 @@ private:
   mutable std::mutex m_mutex;
   OutputterList m_outputters;
   OutputterList m_alwaysOutputters;
-  LogLevel::Level m_maxPriority;
+  std::atomic<LogLevel::Level> m_maxPriority;
 };
 
 /*!
@@ -212,10 +220,21 @@ otherwise it expands to a call that doesn't.
 #define CLOG_DEBUG CLOG_TRACE CLOG_TAG_DEBUG
 #define CLOG_VERBOSE CLOG_TRACE CLOG_TAG_VERBOSE
 
+// Level-gated log macros: the priority is checked (cheap, lock-free via
+// Log::willPrint) BEFORE the variadic arguments are evaluated, so a filtered-out
+// message never pays to build its arguments (e.g. per-input-event string
+// construction). The ternary keeps each macro a single expression, so it stays
+// safe as the unbraced body of an if/else. LOG_PRINT is intentionally unfiltered.
+#if defined(NOLOGGING)
+#define LOG_GATED(_level, _a1) ((void)0)
+#else
+#define LOG_GATED(_level, _a1) ((void)(CLOG->willPrint(_level) ? (CLOG->print _a1, 0) : 0))
+#endif
+
 #define LOG_PRINT(...) LOG((CLOG_PRINT __VA_ARGS__))
-#define LOG_CRIT(...) LOG((CLOG_CRIT __VA_ARGS__))
-#define LOG_ERR(...) LOG((CLOG_ERR __VA_ARGS__))
-#define LOG_WARN(...) LOG((CLOG_WARN __VA_ARGS__))
-#define LOG_INFO(...) LOG((CLOG_INFO __VA_ARGS__))
-#define LOG_DEBUG(...) LOG((CLOG_DEBUG __VA_ARGS__))
-#define LOG_VERBOSE(...) LOG((CLOG_VERBOSE __VA_ARGS__))
+#define LOG_CRIT(...) LOG_GATED(LogLevel::Level::Fatal, (CLOG_CRIT __VA_ARGS__))
+#define LOG_ERR(...) LOG_GATED(LogLevel::Level::Error, (CLOG_ERR __VA_ARGS__))
+#define LOG_WARN(...) LOG_GATED(LogLevel::Level::Warning, (CLOG_WARN __VA_ARGS__))
+#define LOG_INFO(...) LOG_GATED(LogLevel::Level::Info, (CLOG_INFO __VA_ARGS__))
+#define LOG_DEBUG(...) LOG_GATED(LogLevel::Level::Debug, (CLOG_DEBUG __VA_ARGS__))
+#define LOG_VERBOSE(...) LOG_GATED(LogLevel::Level::Verbose, (CLOG_VERBOSE __VA_ARGS__))

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -11,6 +11,7 @@
 #include "arch/Arch.h"
 #include "base/IEventQueue.h"
 #include "base/Log.h"
+#include "client/ResumePolicy.h"
 #include "client/ServerProxy.h"
 #include "common/NetworkProtocol.h"
 #include "common/Settings.h"
@@ -682,13 +683,34 @@ void Client::handleSuspend()
 
 void Client::handleResume()
 {
-  if (m_suspended) {
-    LOG_INFO("resume");
-    m_suspended = false;
-    if (m_connectOnResume) {
-      m_connectOnResume = false;
-      connect();
-    }
+  using enum deskflow::ResumeAction;
+
+  const bool wasSuspended = m_suspended;
+  m_suspended = false;
+
+  // The decision is a pure policy (see ResumePolicy.h) so it can be unit-tested
+  // without the Qt event machinery. It is robust to platforms (Windows 10/11)
+  // that deliver a resume signal with no preceding suspend.
+  switch (deskflow::decideResumeAction(wasSuspended, m_connectOnResume, isConnected())) {
+  case Reconnect:
+    LOG_INFO("resume: reconnecting");
+    m_connectOnResume = false;
+    connect();
+    break;
+
+  case DropStaleConnection:
+    // A resume arrived with no recorded suspend: the pre-sleep connection is
+    // stale (still appears live). Drop it so the client's auto-reconnect
+    // re-establishes it in ~1s instead of waiting for keep-alive death
+    // detection (~9s).
+    LOG_INFO("resume: dropping stale connection to force reconnect");
+    m_connectOnResume = false;
+    disconnect(nullptr);
+    break;
+
+  case None:
+    LOG_DEBUG("resume: no action needed");
+    break;
   }
 }
 

--- a/src/lib/client/ResumePolicy.h
+++ b/src/lib/client/ResumePolicy.h
@@ -1,0 +1,55 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+#pragma once
+
+namespace deskflow {
+
+/**
+ * @brief What a client should do when it receives a power "resume" signal.
+ */
+enum class ResumeAction
+{
+  None,               //!< Do nothing.
+  Reconnect,          //!< Establish a fresh connection (we are disconnected).
+  DropStaleConnection //!< Tear down an apparently-connected-but-stale link so
+                      //!< the normal auto-reconnect re-establishes it.
+};
+
+/**
+ * @brief Decide how a client should react to a power resume signal.
+ *
+ * Pure policy, extracted so it can be unit-tested without the client's Qt event
+ * machinery.
+ *
+ * Background: some platforms (Windows 10/11) deliver a resume signal (a
+ * repurposed WM_TIMECHANGE) with no preceding suspend signal. The historical
+ * logic only reconnected when a suspend had been recorded, so on those
+ * platforms a wake left the now-dead connection in place until keep-alive death
+ * detection noticed it (~9 s of dead input).
+ *
+ * @param wasSuspended     A matching suspend signal was recorded.
+ * @param wantedConnection There was a connection we intend to restore (only
+ *                         meaningful on the suspend path).
+ * @param appearsConnected We currently believe we are connected. After a real
+ *                         wake this is stale-true until the dead socket is
+ *                         noticed.
+ */
+constexpr ResumeAction decideResumeAction(bool wasSuspended, bool wantedConnection, bool appearsConnected)
+{
+  if (wasSuspended) {
+    // Normal suspend->resume: we disconnected on suspend, so reconnect iff we
+    // had a live connection beforehand.
+    return wantedConnection ? ResumeAction::Reconnect : ResumeAction::None;
+  }
+
+  // Resume with no recorded suspend (missed-suspend / Windows wake). If we still
+  // look connected, that link is stale after a wake: drop it so auto-reconnect
+  // re-establishes promptly. If we already look disconnected, a reconnect is
+  // already in flight, so there is nothing to do.
+  return appearsConnected ? ResumeAction::DropStaleConnection : ResumeAction::None;
+}
+
+} // namespace deskflow

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -31,8 +31,6 @@
 //
 static const std::size_t s_maxInputBufferSize = 1024 * 1024;
 
-static const float s_retryDelay = 0.01f;
-
 struct Ssl
 {
   SSL_CTX *m_context = nullptr;
@@ -117,8 +115,8 @@ void SecureSocket::secureAccept()
 TCPSocket::JobResult SecureSocket::doRead()
 {
   using enum JobResult;
-  static uint8_t buffer[4096];
-  static const auto bufferSize = std::size(buffer);
+  uint8_t buffer[4096];
+  const auto bufferSize = std::size(buffer);
   memset(buffer, 0, bufferSize);
   int bytesRead = 0;
   int status = 0;
@@ -174,26 +172,23 @@ TCPSocket::JobResult SecureSocket::doRead()
 TCPSocket::JobResult SecureSocket::doWrite()
 {
   using enum JobResult;
-  static bool s_retry = false;
-  static int s_retrySize = 0;
-  static int s_staticBufferSize = 0;
-  static void *s_staticBuffer = nullptr;
 
   // write data
   int bufferSize = 0;
   int bytesWrote = 0;
   int status = 0;
 
-  if (s_retry) {
-    bufferSize = s_retrySize;
+  if (m_writePending) {
+    // Resend exactly what the previous SSL_write() left pending; those bytes are
+    // still held in this connection's m_writeScratch.
+    bufferSize = m_writePendingSize;
   } else {
     bufferSize = m_outputBuffer.getSize();
     if (bufferSize != 0) {
-      if (bufferSize > s_staticBufferSize) {
-        s_staticBuffer = realloc(s_staticBuffer, bufferSize);
-        s_staticBufferSize = bufferSize;
+      if (static_cast<int>(m_writeScratch.size()) < bufferSize) {
+        m_writeScratch.resize(bufferSize);
       }
-      memcpy(s_staticBuffer, m_outputBuffer.peek(bufferSize), bufferSize);
+      memcpy(m_writeScratch.data(), m_outputBuffer.peek(bufferSize), bufferSize);
     }
   }
 
@@ -202,14 +197,14 @@ TCPSocket::JobResult SecureSocket::doWrite()
   }
 
   if (isSecureReady()) {
-    status = secureWrite(s_staticBuffer, bufferSize, bytesWrote);
+    status = secureWrite(m_writeScratch.data(), bufferSize, bytesWrote);
     if (status > 0) {
-      s_retry = false;
+      m_writePending = false;
     } else if (status < 0) {
       return Break;
     } else if (status == 0) {
-      s_retry = true;
-      s_retrySize = bufferSize;
+      m_writePending = true;
+      m_writePendingSize = bufferSize;
       return New;
     }
   } else {
@@ -232,7 +227,8 @@ int SecureSocket::secureRead(void *buffer, int size, int &read)
     LOG_VERBOSE("reading secure socket");
     read = SSL_read(m_ssl->m_ssl, buffer, size);
 
-    static int retry;
+    // per-connection retry counter (previously a shared function static)
+    int &retry = m_readSslRetry;
 
     // Check result will cleanup the connection in the case of a fatal
     checkResult(read, retry);
@@ -260,7 +256,8 @@ int SecureSocket::secureWrite(const void *buffer, int size, int &wrote)
 
     wrote = SSL_write(m_ssl->m_ssl, buffer, size);
 
-    static int retry;
+    // per-connection retry counter (previously a shared function static)
+    int &retry = m_writeSslRetry;
 
     // Check result will cleanup the connection in the case of a fatal
     checkResult(wrote, retry);
@@ -418,7 +415,8 @@ int SecureSocket::secureAccept(int socket)
   LOG_VERBOSE("accepting secure socket");
   int r = SSL_accept(m_ssl->m_ssl);
 
-  static int retry;
+  // per-connection retry counter (previously a shared function static)
+  int &retry = m_acceptSslRetry;
 
   checkResult(r, retry);
 
@@ -476,7 +474,8 @@ int SecureSocket::secureConnect(int socket)
 
   int r = SSL_connect(m_ssl->m_ssl);
 
-  static int retry;
+  // per-connection retry counter (previously a shared function static)
+  int &retry = m_connectSslRetry;
 
   checkResult(r, retry);
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -10,8 +10,10 @@
 #include "net/SecurityLevel.h"
 #include "net/TCPSocket.h"
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 class Event;
 class IEventQueue;
@@ -96,4 +98,20 @@ private:
   bool m_secureReady = false;
   bool m_fatal = false;
   SecurityLevel m_securityLevel = SecurityLevel::Encrypted;
+
+  // Per-connection I/O state. These were previously function-local `static`
+  // variables in doWrite()/secureRead()/secureWrite()/secureAccept()/
+  // secureConnect(), so every SecureSocket instance shared one write scratch
+  // buffer and one set of SSL retry counters. With more than one connection (a
+  // server with multiple clients), or across a disconnect/reconnect, one
+  // socket's partial-write or handshake-retry state could bleed into another.
+  // Making them members isolates state per connection and frees the write
+  // buffer with the socket instead of leaking it for the process lifetime.
+  std::vector<uint8_t> m_writeScratch;
+  bool m_writePending = false;
+  int m_writePendingSize = 0;
+  int m_readSslRetry = 0;
+  int m_writeSslRetry = 0;
+  int m_acceptSslRetry = 0;
+  int m_connectSslRetry = 0;
 };

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -641,7 +641,19 @@ void MSWindowsDesks::deskLeave(Desk *desk, HKL keyLayout)
     // this is largely a balance and out of our control, since windows can be unpredictable...
     // maybe another approach would be to repeatedly check the cursor visibility until it is hidden.
     LOG_VERBOSE("centering cursor on leave: %+d,%+d", m_xCenter, m_yCenter);
-    ARCH->sleep(0.03);
+
+    // Wait until Windows has actually hidden the cursor before centering, to
+    // avoid a flicker at screen center. Poll (up to the ~30 ms we used to always
+    // wait) and stop as soon as the cursor is hidden, so the transition is as
+    // snappy as the OS allows instead of paying a fixed delay on every switch.
+    for (int waitedMs = 0; waitedMs < 30; waitedMs += 5) {
+      CURSORINFO ci = {sizeof(CURSORINFO)};
+      if (GetCursorInfo(&ci) && (ci.flags & CURSOR_SHOWING) == 0) {
+        break;
+      }
+      ARCH->sleep(0.005);
+    }
+
     deskMouseMove(m_xCenter, m_yCenter);
   }
 }

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -343,6 +343,14 @@ void MSWindowsWatchdog::outputLoop(const void *)
 {
   static constexpr DWORD kBufSize = 4096;
 
+  // Adaptive idle backoff for the non-blocking pipe read: start short so trailing
+  // output is relayed quickly, then grow while the child is silent to avoid a
+  // needless steady ~10 Hz wakeup. Bounded so a stopping service (m_running ->
+  // false) is still noticed promptly.
+  static constexpr double kMinIdleSleep = 0.02;
+  static constexpr double kMaxIdleSleep = 0.2;
+  double idleSleep = kMinIdleSleep;
+
   BYTE raw[kBufSize];
   DWORD bytesRead = 0;
 
@@ -360,10 +368,17 @@ void MSWindowsWatchdog::outputLoop(const void *)
         LOG_WARN("could not read from output pipe, error: %s", windowsErrorToString(err).c_str());
       }
 
-      // Retry immediately when nothing to read or we get a transient error like ERROR_NO_DATA (pipe is non-blocking).
-      Arch::sleep(0.1);
+      // Nothing to read yet (the pipe is non-blocking). Sleep with an adaptive
+      // backoff so an idle child no longer costs a steady ~10 Hz wakeup.
+      Arch::sleep(idleSleep);
+      idleSleep *= 2.0;
+      if (idleSleep > kMaxIdleSleep)
+        idleSleep = kMaxIdleSleep;
       continue;
     }
+
+    // Got data: reset the backoff so subsequent output is picked up promptly.
+    idleSleep = kMinIdleSleep;
 
     const QString decoded =
         decoder.decode(QByteArray::fromRawData(reinterpret_cast<const char *>(raw), int(bytesRead)));

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -48,10 +48,21 @@ bool ClientProxy1_5::parseMessage(const uint8_t *code)
 
 void ClientProxy1_5::fileChunkReceived() const
 {
-  // do nothing
+  // File drag-and-drop is deprecated and no longer implemented, but a foreign or
+  // older client (e.g. Synergy/Barrier) may still send these messages. Read and
+  // discard the body ("%1i%s": a 1-byte mark and a length-prefixed chunk) so the
+  // message stream stays framed. Leaving it unread would misparse the body as
+  // the next message code and drop a burst of buffered input.
+  uint8_t mark = 0;
+  std::string content;
+  ProtocolUtil::readf(getStream(), kMsgDFileTransfer + 4, &mark, &content);
 }
 
 void ClientProxy1_5::dragInfoReceived() const
 {
-  // do nothing
+  // As above: consume the deprecated drag-info body ("%2i%s": a 2-byte file
+  // count and a length-prefixed path list) to keep the stream framed.
+  uint16_t fileCount = 0;
+  std::string content;
+  ProtocolUtil::readf(getStream(), kMsgDDragInfo + 4, &fileCount, &content);
 }

--- a/src/unittests/base/LogTests.cpp
+++ b/src/unittests/base/LogTests.cpp
@@ -22,6 +22,18 @@ QString sanitizeBuffer(const std::stringstream &in)
   return rtn;
 }
 
+namespace {
+// Side-effecting log argument used to observe whether the LOG_* macros evaluate
+// their arguments. If the macro is properly level-gated, a filtered-out message
+// must not call this at all.
+int s_probeCalls = 0;
+const char *probeArg()
+{
+  ++s_probeCalls;
+  return "x";
+}
+} // namespace
+
 void LogTests::initTestCase()
 {
   std::setlocale(LC_NUMERIC, "C");
@@ -92,6 +104,27 @@ void LogTests::printLevelToHigh()
   std::cout.rdbuf(old);
 
   QCOMPARE(string, QString{});
+}
+
+void LogTests::verboseArgsNotEvaluatedWhenFiltered()
+{
+  std::stringstream buffer;
+  std::streambuf *old = std::cout.rdbuf(buffer.rdbuf());
+
+  // Filter is Debug (from initTestCase), so a Verbose message is discarded and
+  // the LOG_VERBOSE macro must NOT evaluate its argument.
+  s_probeCalls = 0;
+  LOG_VERBOSE("%s", probeArg());
+  QCOMPARE(s_probeCalls, 0);
+
+  // Once the filter admits Verbose, the argument is evaluated exactly once.
+  m_log.setFilter(LogLevel::Level::Verbose);
+  LOG_VERBOSE("%s", probeArg());
+  QCOMPARE(s_probeCalls, 1);
+
+  // Restore the filter for subsequent ordered tests.
+  m_log.setFilter(LogLevel::Level::Debug);
+  std::cout.rdbuf(old);
 }
 
 void LogTests::printInfoWithFileAndLine()

--- a/src/unittests/base/LogTests.h
+++ b/src/unittests/base/LogTests.h
@@ -19,6 +19,7 @@ private Q_SLOTS:
   void printTestWithArgs();
   void printTestLogString();
   void printLevelToHigh();
+  void verboseArgsNotEvaluatedWhenFiltered();
   void printInfoWithFileAndLine();
   void printErrWithFileAndLine();
 

--- a/src/unittests/deskflow/CMakeLists.txt
+++ b/src/unittests/deskflow/CMakeLists.txt
@@ -37,6 +37,16 @@ create_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/deskflow"
 )
 
+# ResumePolicy is a header-only, dependency-free policy (client/ResumePolicy.h),
+# so this test only needs the base test harness.
+create_test(
+  NAME ResumePolicyTests
+  DEPENDS app
+  LIBS arch base ${extra_libs}
+  SOURCE ResumePolicyTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/deskflow"
+)
+
 create_test(
   NAME KeyStateTests
   DEPENDS app

--- a/src/unittests/deskflow/ResumePolicyTests.cpp
+++ b/src/unittests/deskflow/ResumePolicyTests.cpp
@@ -1,0 +1,43 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "ResumePolicyTests.h"
+
+using deskflow::decideResumeAction;
+using deskflow::ResumeAction;
+
+// Normal suspend->resume: the client disconnected on suspend, so it reconnects
+// iff it had a connection to restore.
+void ResumePolicyTests::suspendResumeReconnectsWhenPreviouslyConnected()
+{
+  QVERIFY(decideResumeAction(/*wasSuspended*/ true, /*wanted*/ true, /*connected*/ false) == ResumeAction::Reconnect);
+  QVERIFY(decideResumeAction(true, true, true) == ResumeAction::Reconnect);
+}
+
+void ResumePolicyTests::suspendResumeDoesNothingWhenNotPreviouslyConnected()
+{
+  QVERIFY(decideResumeAction(true, false, false) == ResumeAction::None);
+  QVERIFY(decideResumeAction(true, false, true) == ResumeAction::None);
+}
+
+// The fix: a resume with no recorded suspend (e.g. Windows 10/11, where the
+// suspend signal is dropped) must not be a silent no-op while the stale
+// connection still appears live -- it must be dropped so auto-reconnect runs.
+void ResumePolicyTests::missedSuspendWhileConnectedDropsStaleConnection()
+{
+  QVERIFY(decideResumeAction(/*wasSuspended*/ false, /*wanted*/ false, /*connected*/ true) == ResumeAction::DropStaleConnection);
+  QVERIFY(decideResumeAction(false, true, true) == ResumeAction::DropStaleConnection);
+}
+
+// A resume with no suspend while already disconnected: auto-reconnect is already
+// in flight, so do nothing.
+void ResumePolicyTests::missedSuspendWhileDisconnectedDoesNothing()
+{
+  QVERIFY(decideResumeAction(false, false, false) == ResumeAction::None);
+  QVERIFY(decideResumeAction(false, true, false) == ResumeAction::None);
+}
+
+QTEST_MAIN(ResumePolicyTests)

--- a/src/unittests/deskflow/ResumePolicyTests.h
+++ b/src/unittests/deskflow/ResumePolicyTests.h
@@ -1,0 +1,19 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "client/ResumePolicy.h"
+
+#include <QTest>
+
+class ResumePolicyTests : public QObject
+{
+  Q_OBJECT
+private Q_SLOTS:
+  void suspendResumeReconnectsWhenPreviouslyConnected();
+  void suspendResumeDoesNothingWhenNotPreviouslyConnected();
+  void missedSuspendWhileConnectedDropsStaleConnection();
+  void missedSuspendWhileDisconnectedDoesNothing();
+};


### PR DESCRIPTION
## Summary

Six independent performance/reliability improvements, each in its own commit so they can be reviewed or cherry-picked separately. Found via an audit focused on input latency and connection stability.

## Changes

1. **`perf(log)` — skip argument evaluation for filtered-out log messages.** In release builds `LOG_*` expanded to an unconditional `Log::print()`, so every call evaluated its arguments (e.g. per-input-event `getName()` string construction) and took the global log mutex via `getFilter()` before the level check discarded the message. The filter level is now atomic (lock-free) and the macros gate on a cheap `willPrint()` before evaluating arguments.

2. **`fix(net)` — per-connection SecureSocket I/O state.** `doWrite()`/`secureRead()`/`secureWrite()`/`secureAccept()`/`secureConnect()` held their scratch write buffer and SSL retry counters in function-local `static`s, shared across all instances. With multiple TLS clients (or across a reconnect) one connection's partial-write/handshake state could bleed into another; the write buffer was also leaked. Now per-connection members.

3. **`fix(server)` — consume deprecated file-transfer/drag message bodies.** `ClientProxy1_5` recognised `kMsgDFileTransfer`/`kMsgDDragInfo` but read none of the body, so a foreign/older client sending them desynced the message stream. The bodies are now read and discarded, keeping the stream framed.

4. **`fix(client)` — reconnect on wake when the suspend signal is missed.** On Windows 10/11 the suspend notification is often dropped and `WM_TIMECHANGE` stands in for resume, so `m_suspended` was never set and `handleResume()` (gated on it) did nothing — leaving the dead connection until keep-alive death detection (~9s). The resume decision is extracted into a pure, unit-tested policy that drops a stale connection so the existing auto-reconnect re-establishes in ~1s. The normal suspend→resume path and all other platforms are unchanged.

5. **`perf(daemon)` — adaptive backoff for the watchdog output poll.** The non-blocking output pipe was polled with a fixed 100ms sleep, costing a steady ~10 Hz wakeup in the always-running daemon. It now backs off (20→200 ms) while the child is silent and polls faster right after output; the pipe stays non-blocking so shutdown behaviour is unchanged.

6. **`perf(win)` — center the cursor as soon as it's hidden on screen leave.** Replaces a fixed 30 ms sleep with a bounded poll of cursor visibility, so the transition proceeds as soon as Windows hides the cursor (capped at the same ~30 ms).

## Verification

Built against Qt 6.10.1 + OpenSSL 3.0.16 (MSVC 2022). The full unit-test suite passes (**24/24**), including two new tests:
- `LogTests::verboseArgsNotEvaluatedWhenFiltered` — the lazy-evaluation property (#1)
- `ResumePolicyTests` — the resume-decision policy over its full input space (#4)

## Notes for reviewers

- **#4** deliberately trades a rare, cheap redundant reconnect on a spurious `WM_TIMECHANGE` (e.g. an NTP clock change) for reliable sub-second recovery after every real wake. The **server-side** resume path is intentionally left alone (its listener survives sleep; restarting on spurious signals would drop clients) and would benefit from a separate, integration-tested fix.
- **#5 and #6** are Win32 I/O / screen-transition code not covered by unit tests, so they are compile-verified and reasoned about, but their runtime behaviour (daemon wakeup cadence; cursor flicker) has not been measured end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
