### PR TITLE
i18n(es): Change Abierto -> Abrir

### DIFF
--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -388,7 +388,7 @@ Do you want to connect to the server?
     <message>
         <source>&amp;Open %1</source>
         <extracomment>%1 will be the replaced with the appname</extracomment>
-        <translation type="unfinished">Abiert&amp;o %1</translation>
+        <translation>Abr&amp;ir %1</translation>
     </message>
     <message>
         <source>&amp;Preferences</source>


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
Change the spanish translation for Open Deskflow from `Abierto Deskflow` -> `Abrir Deskflow` This was suggested by @DanielEsc0911 in the comment https://github.com/deskflow/deskflow/issues/8050#issuecomment-4959960786
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
None
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Smoke test