### PR TITLE
fix(win): stop dead keys and releases from desyncing when relaying to a client

### DIFF
--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -401,7 +401,7 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   // character-less key-up so the client can release it.  this mirrors the
   // n == 0 case above.  the dead key's own release is handled earlier and
   // never reaches this point.
-  if (charAndVirtKey == 0 && (lParam & 0x80000000u) != 0) {
+  if (charAndVirtKey == 0 && kf_up) {
     charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
   }
 

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -378,8 +378,13 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   }
   }
 
-  // put back the dead key, if any, for the application to use
-  if (g_deadVirtKey != 0) {
+  // put back the dead key, if any, for the application to use.
+  // only do this when a local app will actually consume the event, i.e. when
+  // we're NOT relaying to a client.  in relay mode the event is eaten below,
+  // so re-injecting the dead key here helps no local app; it only re-arms the
+  // layout's pending dead key, which then composes again with the next relayed
+  // key (e.g. "não" would be typed as "nãõ" on the client).
+  if (g_mode != kHOOK_RELAY_EVENTS && g_deadVirtKey != 0) {
     ToUnicode((UINT)g_deadVirtKey, (g_deadLParam & 0x10ff0000u) >> 16, g_deadKeyState, wc, 2, flags);
   }
 

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -394,6 +394,17 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
     g_deadLParam = 0;
   }
 
+  // safety net: a physical key release must always reach the client, otherwise
+  // the key stays stuck "down" there.  if the translation above produced no
+  // key message for a release event (e.g. a key that maps to a dead key on
+  // release, or a key released while a dead key was pending), relay a
+  // character-less key-up so the client can release it.  this mirrors the
+  // n == 0 case above.  the dead key's own release is handled earlier and
+  // never reaches this point.
+  if (charAndVirtKey == 0 && (lParam & 0x80000000u) != 0) {
+    charAndVirtKey = makeKeyMsg((UINT)wParam, 0, noAltGr);
+  }
+
   // forward message to our window.  do this whether or not we're
   // forwarding events to clients because this'll keep our thread's
   // key state table up to date.  that's important for querying


### PR DESCRIPTION
## Description
On Windows, the low-level keyboard hook (`MSWindowsHook.cpp`) translates key events with `ToUnicode()` and keeps its own dead-key state. That state was leaking into the relay path and caused two desync bugs on the client:

1. **Accents composed twice.** After a dead key composed a character (e.g. `~` + `a` = `ã`), the hook re-armed the pending dead key "for the application to use". But when relaying, the event is discarded and no local app consumes it, so re-arming only made the dead key compose again with the next relayed key, `não` was typed as `nãõ` on the client.

2. **Keys stuck "down".** A key release whose translation produced no character (for example, a key released while a dead key was pending) was never forwarded, so the client never got the key-up and the key stayed pressed.

This PR makes two small, focused changes:

- Only re-inject the pending dead key when the event will actually be consumed by a local app, i.e. when we are not relaying (`g_mode != kHOOK_RELAY_EVENTS`). The real composition still runs and the composed character is still relayed; only the useless post-composition re-arm is skipped in relay mode.
- Always relay a physical key release. If translation produced no key message for a release event, forward a character-less key-up (same shape as the existing `n == 0` case) so the client can release the key. This never fabricates a release: it only fires when Windows already reported a key-up (`KF_UP`), so held keys and auto-repeat are unaffected.

The local composition path (cursor on the server's own screen) is intentionally left untouched here — that case is handled separately by #9919.

## AI tools used for this PR
Claude Opus 4.8, used to review the hook's dead-key handling and used to generate this pull request description.

## Fixed/related issues
- related: #9254 (fixes the client-side dead-key and stuck-key desync; the server's own screen is covered by #9919)

## How has this been tested?
Windows server with the `Portuguese (Brazil ABNT)` layout, client on Linux X11 / Linux Wayland.

Dead-key composition (cursor on a client screen):
- Type `~` then `a` then `o` -> expected `ão`; before the fix: `ãõ` (dead key leaked into the next character).
- Type `´` then `a` then `e` -> expected `áe`; before the fix: `áé`.

Stuck keys (cursor on a client screen):
- Type accented sequences quickly and confirm no key stays pressed on the client after release.