### PR TITLE
fix: don't recenter cursor or notify server on transient EiScreen shape churn

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -481,26 +481,49 @@ bool EiScreen::isPrimary() const
 
 void EiScreen::updateShape()
 {
-  m_w = 1;
-  m_h = 1;
-  m_x = std::numeric_limits<uint32_t>::max();
-  m_y = std::numeric_limits<uint32_t>::max();
+  std::uint32_t newW = 1;
+  std::uint32_t newH = 1;
+  std::uint32_t newX = std::numeric_limits<uint32_t>::max();
+  std::uint32_t newY = std::numeric_limits<uint32_t>::max();
+  bool foundRegion = false;
   for (auto it = m_eiDevices.begin(); it != m_eiDevices.end(); it++) {
     auto idx = 0;
     struct ei_region *r;
     while ((r = ei_device_get_region(*it, idx++)) != nullptr) {
-      m_x = std::min(ei_region_get_x(r), m_x);
-      m_y = std::min(ei_region_get_y(r), m_y);
-      m_w = std::max(ei_region_get_x(r) + ei_region_get_width(r), m_w);
-      m_h = std::max(ei_region_get_y(r) + ei_region_get_height(r), m_h);
+      foundRegion = true;
+      newX = std::min(ei_region_get_x(r), newX);
+      newY = std::min(ei_region_get_y(r), newY);
+      newW = std::max(ei_region_get_x(r) + ei_region_get_width(r), newW);
+      newH = std::max(ei_region_get_y(r) + ei_region_get_height(r), newH);
     }
   }
 
-  LOG_DEBUG("logical output size: %dx%d@%d.%d", m_w, m_h, m_x, m_y);
-  m_cursorX = m_x + m_w / 2;
-  m_cursorY = m_y + m_h / 2;
+  if (!foundRegion) {
+    LOG_DEBUG("logical output size: unchanged (no region-reporting device present)");
+    return;
+  }
 
-  sendEvent(EventTypes::ScreenShapeChanged, nullptr);
+  LOG_DEBUG("logical output size: %dx%d@%d.%d", newW, newH, newX, newY);
+
+  const bool changed = newX != m_x || newY != m_y || newW != m_w || newH != m_h;
+
+  if (!m_isShapeInitialized) {
+    m_cursorX = newX + newW / 2;
+    m_cursorY = newY + newH / 2;
+    m_isShapeInitialized = true;
+  } else if (changed) {
+    m_cursorX = std::clamp(m_cursorX, static_cast<int32_t>(newX), static_cast<int32_t>(newX + newW - 1));
+    m_cursorY = std::clamp(m_cursorY, static_cast<int32_t>(newY), static_cast<int32_t>(newY + newH - 1));
+  }
+
+  m_x = newX;
+  m_y = newY;
+  m_w = newW;
+  m_h = newH;
+
+  if (changed) {
+    sendEvent(EventTypes::ScreenShapeChanged, nullptr);
+  }
 }
 
 void EiScreen::addDevice(struct ei_device *device)

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -158,6 +158,7 @@ private:
   std::uint32_t m_y = 0;
   std::uint32_t m_w = 0;
   std::uint32_t m_h = 0;
+  bool m_isShapeInitialized = false;
 
   // true if mouse has entered the screen
   bool m_isOnScreen;


### PR DESCRIPTION
## Description

On the Wayland/libei backend, `EiScreen::updateShape()` recenters the cursor to
the middle of the screen and notifies the server of a "shape changed" event
every single time it's called, including during transient device-list churn
when no device is currently reporting a region.

The compositor can renegotiate the EIS device list (tear down and recreate a
device) for reasons that have nothing to do with deskflow. On KDE/KWin, for
example, simply opening the on-screen brightness/volume slider popup is enough
to trigger this. Each time it happens, `updateShape()` briefly sees a degenerate
"no region" state, recenters the tracked cursor to the middle of the screen, and
tells the server the shape changed. The server reacts to that, producing a
visible cursor jump with no user input involved.

This reproduces on stock `master`, with no other patches applied.

The fix: only touch tracked shape state (`m_x`/`m_y`/`m_w`/`m_h`, and the cursor
position) once a real region is actually found, and only notify the server when
the shape genuinely changed, not on every churn round-trip back to the same
values.

## AI tools used for this PR

Claude Code was used to help verify this fix (building, running the client on
real hardware, and drafting this description). The bug and the fix itself were
identified and written by me.

## Fixed/related issues

Found while testing #9894. Not tied to a filed issue, and not caused by that
PR (confirmed by reproducing it against stock `master` with none of that PR's
changes applied).

## How has this been tested?

Built from this branch (`cmake -B build -G Ninja && cmake --build build`, 26/26
unit tests passing) and run as the live client on real hardware (KWin Wayland /
Plasma, openSUSE Tumbleweed):

- Reproduced first against unpatched `master`: with the deskflow cursor parked
  on the client screen, opening the KDE brightness OSD reliably snapped the
  cursor to the middle of the screen.
- Applied this fix, rebuilt, redeployed the live client, repeated the same
  trigger: cursor stays exactly where it was.
