### PR TITLE
fix(wayland): only add input-capture barriers on the outer desktop edge

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -777,8 +777,43 @@ void PortalInputCapture::handleZonesChanged(XdpInputCaptureSession *session, con
   const auto activeSides = m_screen->activeSides();
   using enum DirectionMask;
 
-  // May not correctly handle different sized screens
   auto zones = xdp_input_capture_session_get_zones(session);
+
+  // First pass: compute the bounding box (union) of all input-capture zones.
+  // A pointer barrier must lie on the outer boundary of the combined desktop and
+  // be adjacent to a single monitor edge. A barrier placed on an internal edge
+  // between two adjacent monitors is rejected by the portal ("adjacent to
+  // multiple monitor edges"), and a single rejected barrier fails the whole
+  // barrier set - so on a multi-monitor server input capture never engages.
+  gint unionLeft = 0;
+  gint unionTop = 0;
+  gint unionRight = 0;
+  gint unionBottom = 0;
+  bool boundsInit = false;
+  for (auto z = zones; z != nullptr; z = z->next) {
+    guint w;
+    guint h;
+    gint x;
+    gint y;
+    g_object_get(z->data, "width", &w, "height", &h, "x", &x, "y", &y, nullptr);
+    const gint right = x + static_cast<gint>(w);
+    const gint bottom = y + static_cast<gint>(h);
+    if (!boundsInit) {
+      unionLeft = x;
+      unionTop = y;
+      unionRight = right;
+      unionBottom = bottom;
+      boundsInit = true;
+    } else {
+      unionLeft = std::min(unionLeft, x);
+      unionTop = std::min(unionTop, y);
+      unionRight = std::max(unionRight, right);
+      unionBottom = std::max(unionBottom, bottom);
+    }
+  }
+
+  // Second pass: only add a barrier for a zone edge that is part of the outer
+  // boundary of the union (i.e. not an internal seam between two monitors).
   guint id = 0;
   while (zones != nullptr) {
     guint w;
@@ -789,19 +824,19 @@ void PortalInputCapture::handleZonesChanged(XdpInputCaptureSession *session, con
 
     LOG_DEBUG("input capture zone, %dx%d@%d,%d", w, h, x, y);
 
-    if (activeSides & static_cast<int>(LeftMask)) {
+    if ((activeSides & static_cast<int>(LeftMask)) && x == unionLeft) {
       addBarrier(++id, BarrierSide::Left, x, y, w, h);
     }
 
-    if (activeSides & static_cast<int>(RightMask)) {
+    if ((activeSides & static_cast<int>(RightMask)) && (x + static_cast<gint>(w)) == unionRight) {
       addBarrier(++id, BarrierSide::Right, x, y, w, h);
     }
 
-    if (activeSides & static_cast<int>(TopMask)) {
+    if ((activeSides & static_cast<int>(TopMask)) && y == unionTop) {
       addBarrier(++id, BarrierSide::Top, x, y, w, h);
     }
 
-    if (activeSides & static_cast<int>(BottomMask)) {
+    if ((activeSides & static_cast<int>(BottomMask)) && (y + static_cast<gint>(h)) == unionBottom) {
       addBarrier(++id, BarrierSide::Bottom, x, y, w, h);
     }
     zones = zones->next;


### PR DESCRIPTION
## Description

On a multi-monitor Wayland server, input capture never engaged: the pointer
could not cross the screen edge to a client, even though the same setup works
on a single-monitor server.

Root cause is in `PortalInputCapture::handleZonesChanged`. The portal reports
one input-capture zone per output. The current code adds a pointer barrier on
every active side of **every** zone. On a multi-monitor desktop that includes
the edges that sit on an **internal seam** between two adjacent monitors. The
portal rejects a barrier that is adjacent to more than one monitor edge
("Failed to add barrier: Adjacent to multiple monitor edges"), and because a
single rejected barrier fails the entire `set_pointer_barriers` request, *no*
barriers get installed and capture never starts.

The fix computes the union (bounding box) of all zones first, then adds a
barrier for a given side only when that zone edge lies on the outer boundary of
the union — internal seams are skipped. Single-monitor behaviour is unchanged
(the sole zone's edges are all on the outer boundary). No configuration or
protocol change; barrier geometry for the outer edges is identical to before.

The portal already provides everything needed (each zone's `x`, `y`, `width`,
`height`); this simply uses that data to distinguish outer edges from internal
seams.

## AI tools used for this PR

Claude (Anthropic, Opus 4.8) was used to diagnose the root cause from portal
debug logs and to author the patch and this description. The diagnosis and fix
were verified by a human on real hardware (see testing below).

## Fixed/related issues

No existing issue tracks this specific GNOME multi-monitor failure that I could
find. Related multi-monitor barrier discussion: #9745 (a different,
compositor-side case on Hyprland). Happy to open a tracking issue if preferred.

## How has this been tested?

Both stock and patched binaries were built from `master` and run on real
hardware with input-capture debug logging enabled.

Environment:
- Server: Ubuntu 26.04, GNOME Shell 50.1, Wayland, libportal 0.9.1.
- Two side-by-side outputs, both 2560×1440 logical (a 4K panel at 1.5× scale
  plus a native 1440p panel), so the combined desktop has an internal seam at
  x=2560. The client is to the left, so only the left side is active.
- Client: Windows (Deskflow 1.26.0) placed to the left of the server.

Before (stock `master`) — a left barrier is placed on *both* zones, including
the internal seam, and the seam barrier is rejected:
```
DEBUG   input capture zone, 2560x1440@2560,0
DEBUG   barrier (left) 1 at 2560,0-2560,1439      # internal seam
DEBUG   input capture zone, 2560x1440@0,0
DEBUG   barrier (left) 2 at 0,0-0,1439            # outer edge
WARNING failed to apply barrier 1 (2560/0-2560/1439)
```
One rejected barrier fails the whole `set_pointer_barriers` request, so input
capture never engages and the pointer cannot leave the server.

After (this patch) — the seam zone is skipped and only the outer-edge barrier
is created:
```
DEBUG   input capture zone, 2560x1440@2560,0      # seam zone: no barrier
DEBUG   input capture zone, 2560x1440@0,0
DEBUG   barrier (left) 1 at 0,0-0,1439            # outer edge only
```
`handleSetPointerBarriers` reports **0 failed barriers**, and the pointer
crosses to the Windows client and back reliably with working input injection.

Single-monitor behaviour is unchanged (the sole zone's edges are all on the
outer boundary). The barrier ids above (1 and 2) are already unique on `master`;
the duplicate-id issue that affected 1.26.0 is fixed separately and is unrelated
to this seam-rejection fix.
