### PR TITLE
fix(win): stop TLS sockets busy-spinning the socket poll loop

### DIFF
--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -211,6 +211,16 @@ public:
   */
   virtual size_t writeSocket(ArchSocket s, const void *buf, size_t len) = 0;
 
+  //! Reset the writable poll hint for a socket
+  /*!
+  Tells pollSocket() to wait for a fresh writable notification instead of
+  assuming the socket is still writable. Needed by callers that write to a
+  socket without going through writeSocket(), e.g. OpenSSL's SSL_write().
+  */
+  virtual void resetPollWriteOnSocket(ArchSocket)
+  {
+  }
+
   //! Check error on socket
   /*!
   If the socket \c s is in an error state then throws an appropriate

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -555,6 +556,12 @@ size_t ArchNetworkWinsock::writeSocket(ArchSocket s, const void *buf, size_t len
     throwError(err);
   }
   return static_cast<size_t>(n);
+}
+
+void ArchNetworkWinsock::resetPollWriteOnSocket(ArchSocket s)
+{
+  assert(s != nullptr);
+  s->m_pollWrite = true;
 }
 
 void ArchNetworkWinsock::throwErrorOnSocket(ArchSocket s)

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -71,6 +72,7 @@ public:
   void unblockPollSocket(ArchThread thread) override;
   size_t readSocket(ArchSocket s, void *buf, size_t len) override;
   size_t writeSocket(ArchSocket s, const void *buf, size_t len) override;
+  void resetPollWriteOnSocket(ArchSocket s) override;
   void throwErrorOnSocket(ArchSocket) override;
   bool setNoDelayOnSocket(ArchSocket, bool noDelay) override;
   void setKeepAliveOnSocket(ArchSocket, bool keepAlive) override;

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -556,8 +556,8 @@ void SecureSocket::checkResult(int status, int &retry)
     break;
 
   case SSL_ERROR_WANT_WRITE:
-    // Need to make sure the socket is known to be writable so the impending
-    // poll action actually triggers on a write.
+    // SSL_write() bypasses writeSocket(), so reset the poll hint ourselves.
+    ARCH->resetPollWriteOnSocket(getSocket());
     setWritable(true);
     retry++;
     LOG_VERBOSE("want to write, error=%d, attempt=%d", errorCode, retry);

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -66,6 +66,7 @@ SecureSocket::SecureSocket(
 SecureSocket::~SecureSocket()
 {
   freeSSL();
+  free(m_writeStaticBuffer);
 }
 
 void SecureSocket::close()
@@ -174,26 +175,22 @@ TCPSocket::JobResult SecureSocket::doRead()
 TCPSocket::JobResult SecureSocket::doWrite()
 {
   using enum JobResult;
-  static bool s_retry = false;
-  static int s_retrySize = 0;
-  static int s_staticBufferSize = 0;
-  static void *s_staticBuffer = nullptr;
 
   // write data
   int bufferSize = 0;
   int bytesWrote = 0;
   int status = 0;
 
-  if (s_retry) {
-    bufferSize = s_retrySize;
+  if (m_writeRetry) {
+    bufferSize = m_writeRetrySize;
   } else {
     bufferSize = m_outputBuffer.getSize();
     if (bufferSize != 0) {
-      if (bufferSize > s_staticBufferSize) {
-        s_staticBuffer = realloc(s_staticBuffer, bufferSize);
-        s_staticBufferSize = bufferSize;
+      if (bufferSize > m_writeStaticBufferSize) {
+        m_writeStaticBuffer = realloc(m_writeStaticBuffer, bufferSize);
+        m_writeStaticBufferSize = bufferSize;
       }
-      memcpy(s_staticBuffer, m_outputBuffer.peek(bufferSize), bufferSize);
+      memcpy(m_writeStaticBuffer, m_outputBuffer.peek(bufferSize), bufferSize);
     }
   }
 
@@ -202,14 +199,14 @@ TCPSocket::JobResult SecureSocket::doWrite()
   }
 
   if (isSecureReady()) {
-    status = secureWrite(s_staticBuffer, bufferSize, bytesWrote);
+    status = secureWrite(m_writeStaticBuffer, bufferSize, bytesWrote);
     if (status > 0) {
-      s_retry = false;
+      m_writeRetry = false;
     } else if (status < 0) {
       return Break;
     } else if (status == 0) {
-      s_retry = true;
-      s_retrySize = bufferSize;
+      m_writeRetry = true;
+      m_writeRetrySize = bufferSize;
       return New;
     }
   } else {
@@ -232,7 +229,7 @@ int SecureSocket::secureRead(void *buffer, int size, int &read)
     LOG_VERBOSE("reading secure socket");
     read = SSL_read(m_ssl->m_ssl, buffer, size);
 
-    static int retry;
+    int retry = 0;
 
     // Check result will cleanup the connection in the case of a fatal
     checkResult(read, retry);
@@ -260,7 +257,7 @@ int SecureSocket::secureWrite(const void *buffer, int size, int &wrote)
 
     wrote = SSL_write(m_ssl->m_ssl, buffer, size);
 
-    static int retry;
+    int retry = 0;
 
     // Check result will cleanup the connection in the case of a fatal
     checkResult(wrote, retry);

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -96,4 +96,9 @@ private:
   bool m_secureReady = false;
   bool m_fatal = false;
   SecurityLevel m_securityLevel = SecurityLevel::Encrypted;
+
+  bool m_writeRetry = false;
+  int m_writeRetrySize = 0;
+  int m_writeStaticBufferSize = 0;
+  void *m_writeStaticBuffer = nullptr;
 };


### PR DESCRIPTION
## Description
I noticed this issue tracked on the [1.27.0 milestone](https://github.com/deskflow/deskflow/milestone/92), so I thought I'd take a stab at it.

While looking into #9364, I think I found a plausible explanation for the CPU behavior, though I'd welcome a second pair of eyes on this.

On Windows, `ArchNetworkWinsock::pollSocket()` caches a socket's writability (`m_pollWrite`): once `FD_WRITE` has fired, it stops waiting for writability and assumes the socket stays writable, forcing the poll timeout to `0` instead of blocking. As far as I can tell, the only place that resets this cache is `ArchNetworkWinsock::writeSocket()`, on `WSAEWOULDBLOCK`.

`SecureSocket` appears to never go through `writeSocket()` for actual I/O, since `SSL_write()`/`SSL_read()` operate directly on the raw socket. So my working theory is that once TLS hits any real backpressure, the cache gets stuck and the socket multiplexer's event loop stops blocking and busy-spins calling `SSL_write()` as fast as possible instead of waiting for the next real writable notification. This lines up with the reported symptoms as best I can tell: elevated CPU only on Windows, only with TLS enabled, with call stacks through `OPENSSL_Applink`/`ws2_32.dll`.

My proposed fix: add `IArchNetwork::resetPollWriteOnSocket()` (no-op by default) and call it from `SecureSocket::checkResult()`'s `SSL_ERROR_WANT_WRITE` case, mirroring what `writeSocket()` already does.

While in this code, I also converted `SecureSocket::doWrite()`/`secureRead()`/`secureWrite()`'s retry state from function-local `static` variables to instance members/plain locals. Those statics looked like shared mutable state across every `SecureSocket` instance in the process rather than per connection, which seemed worth fixing at the same time.

## Fixed/related issues
fixes: #9364

## How has this been tested?
I had a tough time proving this out on a Windows machine (that's not my primary platform, but I did try to replicate the issue on the one I had), so I couldn't reproduce the reported CPU spike directly on the affected platform myself. Here's what I did instead:
- Traced the control flow in `ArchNetworkWinsock.cpp`/`SecureSocket.cpp` to confirm `m_pollWrite` is only ever reset in `writeSocket()`, and that `SecureSocket` never calls it.
- Built a standalone harness reimplementing the same `pollSocket()`/`writeSocket()`/`checkResult()` control flow against a simulated backpressuring socket. The results looked promising: the unpatched logic pins ~100% CPU busy-spinning after a single would-block, while the fix matches the plain-TCP baseline (near-0% CPU, blocking properly).

This is encouraging but still just a hypothesis validated in isolation, not a confirmed fix on real hardware. If anyone hitting the original issue (or anyone with a Windows box handy) could give this a try and report back, that'd help a lot before this gets merged. Happy to adjust based on feedback.

## AI tools used for this PR
Claude (Sonnet 5) via Claude Code: used to investigate the root cause and write the fix, and to build the verification harness described above.
