### PR TITLE
fix(mac): ensure background clicks work correctly on macOS 27

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -236,6 +236,9 @@ private:
   mutable int32_t m_xCursor, m_yCursor;
   mutable bool m_cursorPosValid;
 
+  // mouse event number (needed for macOS 27)
+  uint32_t m_mouseEventNumber = 0;
+
   /* FIXME: this data structure is explicitly marked mutable due
      to a need to track the state of buttons since the remote
      side only lets us know of change events, and because the

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -547,6 +547,22 @@ void OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
   CGEventRef event = CGEventCreateMouseEvent(nullptr, type, pos, static_cast<CGMouseButton>(index));
 
+  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27) {
+    // Apps that use Carbon APIs on macOS 27 requires an incrementing event number for each synthetic click
+    if (press) {
+      if (m_mouseEventNumber == 0) {
+        // For some unknown reason, the first click event number must be unique and greater (but in the same ballpark)
+        // than the last event number used by the system.
+        m_mouseEventNumber =
+            CGEventSourceCounterForEventType(kCGEventSourceStateHIDSystemState, kCGEventLeftMouseDown) +
+            CGEventSourceCounterForEventType(kCGEventSourceStateHIDSystemState, kCGEventRightMouseDown) +
+            CGEventSourceCounterForEventType(kCGEventSourceStateHIDSystemState, kCGEventOtherMouseDown);
+      }
+      ++m_mouseEventNumber;
+    }
+    CGEventSetIntegerValueField(event, kCGMouseEventNumber, m_mouseEventNumber);
+  }
+
   CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
 
   // Fix for sticky keys


### PR DESCRIPTION
## Description
Fixes clicks not bringing up background application to foreground on macOS 27.
Investigation showed that click events need to be numbered to be properly processed on apps using Carbon APIs on this new version of macOS.

Thanks @bho3538 and @ZeroSegFault for helping providing their version of this fix. It was of great help.
I tried their fix first but realized that the first click upon connecting to a server was still not working (any subsequent clicks worked fine). After a lot of trial and error I realized that there are even stricter rules about the event number tag on the first click sent by a given process.

## AI tools used for this PR
Claude Fable 5 was used to discuss possible solutions and create a small reproducer.
Code was fully human written.

## Fixed/related issues
fixes:#9852

## How has this been tested?
Tested on macOS 27 as client, and certified that there was no side effects on macOS 26 (as client and server)
