### PR TITLE
build: enable CMP0207

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if(POLICY CMP0156)
   cmake_policy(SET CMP0156 NEW)
 endif()
 
+# Use native paths to collect dependents on windows
+if(POLICY CMP0207)
+  cmake_policy(SET CMP0207 NEW)
+endif()
+
 #Project level options
 option(BUILD_INSTALLER "Build installer" ON)
 option(ENABLE_COVERAGE "Enable test coverage" OFF)


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Set [CMake Policy 0207](https://cmake.org/cmake/help/latest/policy/CMP0207.html) to `NEW`

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Several build warnings on windows when using cmake 4.3 + 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local build on linux, CI testing

Plan to check the portable package has the same items also