### PR TITLE
fix(client/keymap): filter incorrect AltGr keycode at construction time

### DIFF
--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -55,7 +55,16 @@ void KeyMap::addKeyEntry(const KeyItem &item)
   if (item.m_id == kKeyNone) {
     return;
   }
-
+  
+  // ignore AltGr mapped to XKB keycode 84 (X11 keycode 92 = SysRq/PrintScreen).
+  // X11 keycode 92 produces scancode 0x054 in Spice's XT table, which the VM
+  // interprets as SysRq instead of AltGr.  The correct AltGr entry uses
+  // X11 keycode 108 (Right Alt, scancode 0x138), which is XKB keycode 100.
+  // Deskflow stores XKB keycodes internally, which are 8 less than X11 keycodes.
+  if (item.m_id == kKeyAltGr && item.m_button == 84) {
+    return;
+  }
+  
   // resize number of groups for key
   auto numGroups = item.m_group + 1;
   if (getNumGroups() > numGroups) {
@@ -640,41 +649,29 @@ const KeyMap::KeyItem *KeyMap::mapModifierKey(
 int32_t KeyMap::findBestKey(const KeyEntryList &entryList, KeyModifierMask desiredState) const
 {
   // check for an item that can accommodate the desiredState exactly
-  // prefer highest button (keycode) to match physical Right Alt (keycode 108) on standard keyboards
-  int32_t bestExactIndex = -1;
-  KeyButton bestExactButton = 0;
   for (int32_t i = 0; i < (int32_t)entryList.size(); ++i) {
     const KeyItem &item = entryList[i].back();
     if ((item.m_required & desiredState) == item.m_required &&
         (item.m_required & desiredState) == (item.m_sensitive & desiredState)) {
-      if (item.m_button > bestExactButton) {
-        bestExactButton = item.m_button;
-        bestExactIndex = i;
-      }
+      LOG_VERBOSE("best key index %d of %d (exact)", i + 1, entryList.size());
+      return i;
     }
-  }
-  if (bestExactIndex != -1) {
-    LOG_VERBOSE("best key index %d of %d (exact, button %d)", bestExactIndex + 1, entryList.size(), bestExactButton);
-    return bestExactIndex;
   }
 
   // choose the item that requires the fewest modifier changes
-  // on tie, prefer highest button (keycode) to match physical Right Alt position
   int32_t bestCount = 32;
   int32_t bestIndex = -1;
-  KeyButton bestButton = 0;
   for (int32_t i = 0; i < (int32_t)entryList.size(); ++i) {
     const KeyItem &item = entryList[i].back();
     KeyModifierMask change = ((item.m_required ^ desiredState) & item.m_sensitive);
     int32_t n = getNumModifiers(change);
     if (n < bestCount) {
       bestCount = n;
-      bestButton = item.m_button;
       bestIndex = i;
     }
   }
   if (bestIndex != -1) {
-    LOG_VERBOSE("best key index %d of %d (%d modifiers, button %d)", bestIndex + 1, entryList.size(), bestCount, bestButton);
+    LOG_VERBOSE("best key index %d of %d (%d modifiers)", bestIndex + 1, entryList.size(), bestCount);
   }
 
   return bestIndex;

--- a/src/lib/deskflow/KeyMap.cpp
+++ b/src/lib/deskflow/KeyMap.cpp
@@ -640,29 +640,41 @@ const KeyMap::KeyItem *KeyMap::mapModifierKey(
 int32_t KeyMap::findBestKey(const KeyEntryList &entryList, KeyModifierMask desiredState) const
 {
   // check for an item that can accommodate the desiredState exactly
+  // prefer highest button (keycode) to match physical Right Alt (keycode 108) on standard keyboards
+  int32_t bestExactIndex = -1;
+  KeyButton bestExactButton = 0;
   for (int32_t i = 0; i < (int32_t)entryList.size(); ++i) {
     const KeyItem &item = entryList[i].back();
     if ((item.m_required & desiredState) == item.m_required &&
         (item.m_required & desiredState) == (item.m_sensitive & desiredState)) {
-      LOG_VERBOSE("best key index %d of %d (exact)", i + 1, entryList.size());
-      return i;
+      if (item.m_button > bestExactButton) {
+        bestExactButton = item.m_button;
+        bestExactIndex = i;
+      }
     }
+  }
+  if (bestExactIndex != -1) {
+    LOG_VERBOSE("best key index %d of %d (exact, button %d)", bestExactIndex + 1, entryList.size(), bestExactButton);
+    return bestExactIndex;
   }
 
   // choose the item that requires the fewest modifier changes
+  // on tie, prefer highest button (keycode) to match physical Right Alt position
   int32_t bestCount = 32;
   int32_t bestIndex = -1;
+  KeyButton bestButton = 0;
   for (int32_t i = 0; i < (int32_t)entryList.size(); ++i) {
     const KeyItem &item = entryList[i].back();
     KeyModifierMask change = ((item.m_required ^ desiredState) & item.m_sensitive);
     int32_t n = getNumModifiers(change);
     if (n < bestCount) {
       bestCount = n;
+      bestButton = item.m_button;
       bestIndex = i;
     }
   }
   if (bestIndex != -1) {
-    LOG_VERBOSE("best key index %d of %d (%d modifiers)", bestIndex + 1, entryList.size(), bestCount);
+    LOG_VERBOSE("best key index %d of %d (%d modifiers, button %d)", bestIndex + 1, entryList.size(), bestCount, bestButton);
   }
 
   return bestIndex;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
KeyMap: prefer highest keycode when multiple map to same keysym

When multiple keycodes produce the same keysym (e.g. ISO_Level3_Shift exists at both XKB keycode 92 and 108), findBestKey() now prefers the highest keycode instead of the first match.

This fixes AltGr (Right Alt) handling in VM environments. On standard keyboards, ISO_Level3_Shift is mapped to XKB keycode 108 (the physical Right Alt position). XKB also registers it at keycode 92. When deskflow faked AltGr, it used keycode 92, which spice-gtk translated to XT scancode 0x054 (SysRq/PrintScreen). The real keyboard uses keycode 108, which translates to scancode 0x138 (Right Alt).

By preferring the highest keycode, deskflow now generates identical input events to the physical keyboard:

  Before: hw keycode=92, scancode=0x054  (SysRq -> VM screenshot)
  After:  hw keycode=108, scancode=0x138 (Right Alt -> correct AltGr)

This matches XKB's standard Right Alt layout and ensures Spice/QEMU forward AltGr correctly to guest VMs instead of triggering host screenshot shortcuts.

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
local Qwen3.6-27B-FP8 did this

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->

Fixes: AltGr triggering PrintScreen/screenshot in VM guests via Spice

## How has this been tested?
It was only tested with the modified current source release version used in ubuntu26.04 - This source change is untested