### PR TITLE
fix: remove redundant child process modifier

### DIFF
--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -15,11 +15,6 @@
 #include "OSXHelpers.h"
 #endif
 
-#ifdef Q_OS_LINUX
-#include <signal.h>
-#include <sys/prctl.h>
-#endif
-
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -223,14 +218,6 @@ void CoreProcess::startForegroundProcess(const QStringList &args)
   // core command can be easily copy/pasted to the terminal for testing.
   const auto quoted = makeQuotedArgs(m_appPath, args);
   qInfo("running command: %s", qPrintable(quoted));
-
-#ifdef Q_OS_LINUX
-  m_process->setChildProcessModifier([] {
-    // the core process becomes orphaned when the gui process exits abruptly (e.g. with kill -9),
-    // so ensure the os also kills the core when that happens to the gui.
-    prctl(PR_SET_PDEATHSIG, SIGTERM);
-  });
-#endif
 
   m_process->start(m_appPath, args);
 


### PR DESCRIPTION
## Description

Remove the Linux-only `PR_SET_PDEATHSIG` child process modifier from `CoreProcess::startForegroundProcess`. Orphaned core cleanup is now handled cross-platform via IPC (the same approach used for the macOS fix), so the modifier is redundant. 

## AI tools used for this PR

Code removed manually. Claude Fable 5 reminded me to also remove the includes.

## Fixed/related issues

None.

## How has this been tested?

Restart when already running (change the git hash or it won't kill existing Core).