### PR TITLE
fix bug of keystroke always sending the first hotkey shortcut

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -224,7 +224,7 @@ void EiScreen::warpCursor(int32_t x, int32_t y)
 std::uint32_t EiScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 {
   static std::uint32_t next_id;
-  std::uint32_t id = std::min(++next_id, 1u);
+  std::uint32_t id = std::max(++next_id, 1u);
 
   // Bug: id rollover means duplicate hotkey ids. Oh well.
 


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->

fix `registerHotKey` bug of always returning the first hotkey shortcut

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->

Anthropic Claude Code Opus 4.8

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->


## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

### Environment

- Server: Deskflow 1.26.0 (Arch `deskflow 1.26.0-2`), KDE Plasma / Wayland, libei backend
- Client: Deskflow 1.26.0, macOS
- Protocol: synergy

### Config

Deskflow.conf
```conf
[core]
computerName=REDACTED
coreMode=2
enableEnterCommand=false
enableExitCommand=false
enterCommand=
exitCommand=
interface=REDACTED
language=en
lastVersion=1.26.0.9999
port=24800
preventSleep=false
processMode=1

[daemon]
elevate=true

[gui]
autoHide=true
closeReminder=false
closeToTray=true
enableUpdateCheck=false
logExpanded=true
showVersionInTitle=true
shownFirstConnectedMessage=true
shownServerFirstStartMessage=true
startCoreWithGui=false
symbolicTrayIcon=false

[log]
guiDebug=false
level=WARNING
toFile=false

[screen_REDACTED]
aliases=REDACTED, REDACTED

[screen_REDACTED]
aliases=REDACTED, REDACTED

[screen_REDACTED]
aliases=REDACTED

[screen_REDACTED]
aliases=REDACTED, REDACTED

[screen_REDACTED]
aliases=REDACTED, REDACTED

[security]
checkPeerFingerprints=true
keySize=4096
tlsEnabled=true

[server]
clipboardSize=3
defaultLockToComputerState=false
disableLockToComputer=false
enableClipboard=true
enableHeatbeat=true
enableSwitchDelay=false
enableSwitchDoubleTap=false
externalConfig=true
heartbeat=5000
protocol=synergy
relativeMouseMoves=false
switchDelay=250
switchDoubleTap=250
win32KeepForeground=true
xdpRestoreToken=REDACTED
```

deskflow-server.conf
```conf
section: screens
	REDACTED:
	REDACTED:
	REDACTED:
	REDACTED:
	REDACTED:
		ctrl = meta
		super = ctrl
end

section: links
	REDACTED:
		up = REDACTED
		down = REDACTED
		left = REDACTED
		right = REDACTED
	REDACTED:
		up = REDACTED
		down = REDACTED
	REDACTED:
		right = REDACTED
		left = REDACTED
	REDACTED:
		left = REDACTED
		right = REDACTED
	REDACTED:
		up = REDACTED
		down = REDACTED
end

section: options
	keystroke(Alt+Tab) = keystroke(Meta+Tab, REDACTED)
	keystroke(Super+s) = keystroke(Super+Alt+s, REDACTED)
	keystroke(Super+f) = keystroke(Super+Alt+f, REDACTED)
	keystroke(Super+k) = keystroke(Super+Alt+k, REDACTED)
end

# vi:noet:
```