### PR TITLE
fix(mac): preserve mouse event number during dragging - only affects macOS 27

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -61,6 +61,12 @@ enum
 
 static const double kCarbonLoopWaitTimeout = 10.0;
 
+// Synthetic mouse button and drag events require event numbers on macOS 27 and later.
+static inline bool needsEventNumber()
+{
+  return NSProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27;
+}
+
 int getSecureInputEventPID();
 std::string getProcessName(int pid);
 
@@ -463,6 +469,10 @@ void OSXScreen::postMouseEvent(CGPoint &pos) const
 
   CGEventRef event = CGEventCreateMouseEvent(nullptr, type, pos, static_cast<CGMouseButton>(button));
 
+  if (button != -1 && needsEventNumber()) {
+    CGEventSetIntegerValueField(event, kCGMouseEventNumber, m_mouseEventNumber);
+  }
+
   // Dragging events also need the click state
   CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
 
@@ -547,8 +557,7 @@ void OSXScreen::fakeMouseButton(ButtonID id, bool press)
 
   CGEventRef event = CGEventCreateMouseEvent(nullptr, type, pos, static_cast<CGMouseButton>(index));
 
-  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27) {
-    // Apps that use Carbon APIs on macOS 27 requires an incrementing event number for each synthetic click
+  if (needsEventNumber()) {
     if (press) {
       if (m_mouseEventNumber == 0) {
         // For some unknown reason, the first click event number must be unique and greater (but in the same ballpark)


### PR DESCRIPTION
## Description

On macOS 27, synthetic mouse-down and mouse-up events use an incrementing mouse event number, but the corresponding drag events retained the default event number of zero.

This prevented windows from being moved by their title bars. Set `kCGMouseEventNumber` on drag events while a mouse button is held so the complete mouse-down, drag, and mouse-up sequence uses the same event number.

## AI tools used for this PR

OpenAI Codex (GPT-5.6) was used to investigate the regression and validate a candidate fix. I manually typed the code, built and signed the application, and tested the submitted change.

## Fixed/related issues

None currently.

## How has this been tested?

Tested on:

- Apple Silicon Mac
- macOS 27 beta 4
- Xcode 27 beta
- Release build using CMake and Ninja
- Application and embedded `deskflow-core` signed with an Apple Development certificate
- Code signature verified using `codesign --verify --deep --strict`

Manual testing confirmed that:

- Windows can be moved by dragging their title bars.
- Clicking controls in background windows continues to work.
- Dragging across desktop icons continues to select multiple icons.