### PR TITLE
fix(wayland): fix mouse scroll jitter and missing scroll events on a wayland host to a mac client

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -28,7 +28,8 @@
 #include <unistd.h>
 #include <vector>
 
-// Values are in fractional wheel-click units (1.0 == one full 120-unit click)
+// Values are in fractional wheel-click units (1.0 == one full 120-unit click) for trackpad
+// and pixels in scroll wheel events.
 struct ScrollRemainder
 {
   double x;
@@ -813,8 +814,7 @@ void EiScreen::onPointerScrollEvent(ei_event *event)
 void EiScreen::onPointerScrollDiscreteEvent(ei_event *event)
 {
   // both libei and deskflow use multiples of 120 to represent
-  // one scroll wheel click event so we can just forward things
-  // as-is.
+  // one scroll wheel click event
 
   assert(m_isPrimary);
 
@@ -823,10 +823,26 @@ void EiScreen::onPointerScrollDiscreteEvent(ei_event *event)
 
   LOG_VERBOSE("event: scroll discrete (%d, %d)", dx, dy);
 
+  // accumulate fractional ticks, then emit 120 units at a time
+  struct ei_device *device = ei_event_get_device(event);
+  auto *remainder = static_cast<struct ScrollRemainder *>(ei_device_get_user_data(device));
+  if (!remainder) {
+    remainder = new ScrollRemainder();
+    ei_device_set_user_data(device, remainder);
+  }
+
+  double ax = remainder->x + dx;
+  double ay = remainder->y + dy;
+  auto cx = static_cast<int32_t>(ax / s_scrollDelta) * s_scrollDelta;
+  auto cy = static_cast<int32_t>(ay / s_scrollDelta) * s_scrollDelta;
+  remainder->x = ax - cx;
+  remainder->y = ay - cy;
+
   // libei and deskflow seem to use opposite directions, so we have
   // to send the opposite of the value reported by EI if we want to
   // remain compatible with other platforms (including X11).
-  sendEvent(EventTypes::PrimaryScreenWheel, WheelInfo::alloc(-dx, -dy));
+  if (cx != 0 || cy != 0)
+    sendEvent(EventTypes::PrimaryScreenWheel, WheelInfo::alloc(-cx, -cy));
 }
 
 void EiScreen::onMotionEvent(ei_event *event)


### PR DESCRIPTION
## Description
Hi-res mouse wheels (like my logitech G502) send scrolls as fractional clicks. On a mac client, fractional events are truncated to zero lines. This fix accumulates those fractional events then emits the entire click 120 units at a time

## AI tools used for this PR
Qwen 3.6 27b to find relevant file, provide relevant function to edit (Discrete event vs normal event). no code was written by AI

## Fixed/related issues
Fixes #9120

## How has this been tested?
Server: Arch Linux kernel 7.1.3
DE: KDE Plasma 6.7.3 Wayland
Mouse: Logitech G502 X Lightspeed

Client:
Macbook Pro M3
macOS Tahoe 26.3.1
Deskflow 1.26.0 release build

Moving mouse over to Macbook client, then scrolling lines in VS Code without increasing the scroll sensitivity to 10 in the client settings like suggested in #9120 . These settings remained at 1