### PR TITLE
fix(macOS): stop desktop core during GUI quit

### DIFF
--- a/src/lib/deskflow/ipc/CoreIpcServer.cpp
+++ b/src/lib/deskflow/ipc/CoreIpcServer.cpp
@@ -15,7 +15,8 @@ namespace deskflow::core::ipc {
 
 static CoreIpcServer *s_instance = nullptr;
 
-CoreIpcServer::CoreIpcServer(QObject *parent) : IpcServer(parent, kCoreIpcName, QStringLiteral("core"))
+CoreIpcServer::CoreIpcServer(QObject *parent, QString socketName)
+    : IpcServer(parent, socketName.isEmpty() ? kCoreIpcName : socketName, QStringLiteral("core"))
 {
   assert(s_instance == nullptr);
   s_instance = this;

--- a/src/lib/deskflow/ipc/CoreIpcServer.h
+++ b/src/lib/deskflow/ipc/CoreIpcServer.h
@@ -20,7 +20,7 @@ class CoreIpcServer : public IpcServer
   Q_OBJECT
 
 public:
-  explicit CoreIpcServer(QObject *parent);
+  explicit CoreIpcServer(QObject *parent, QString socketName = {});
 
   static CoreIpcServer &instance();
 

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -258,6 +258,12 @@ void MainWindow::connectSlots()
 
   connect(m_actionQuit, &QAction::triggered, this, &MainWindow::close);
   connect(m_actionTrayQuit, &QAction::triggered, this, &MainWindow::close);
+
+  // On macOS an OS-initiated quit ([NSApp terminate:]) calls exit() without
+  // unwinding the C++ stack, so the MainWindow destructor (and its
+  // CoreProcess::cleanup) never runs and the core is orphaned. aboutToQuit
+  // fires on every quit path before the process exits, so stop the core there.
+  connect(qApp, &QCoreApplication::aboutToQuit, this, [this] { m_coreProcess.cleanup(); });
   connect(m_actionRestore, &QAction::triggered, this, &MainWindow::showAndActivate);
   connect(m_actionSettings, &QAction::triggered, this, &MainWindow::openSettings);
   connect(m_actionStartCore, &QAction::triggered, this, &MainWindow::startCore);
@@ -913,6 +919,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
   // any connected dock view acitons will be triggered
   // disconnect them before accepting the event
   disconnect(m_logDock->toggleViewAction(), &QAction::toggled, nullptr, nullptr);
+
+  // Stop the core synchronously here: on macOS an OS-initiated quit terminates
+  // the process (exit()) as soon as this returns NSTerminateNow, so neither the
+  // MainWindow destructor nor aboutToQuit is guaranteed to run. Cleaning up now
+  // ensures the desktop core is stopped instead of being orphaned.
+  m_coreProcess.cleanup();
 
   event->accept();
   QApplication::quit();

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -380,7 +380,8 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
     return;
   }
 
-  if (m_processState == ProcessState::Stopping) {
+  if (m_processState == ProcessState::Stopping && m_process &&
+      m_process->state() != QProcess::ProcessState::NotRunning) {
     qCritical("core process is stopping; refusing start until it exits");
     return;
   }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -30,6 +30,8 @@
 namespace deskflow::gui {
 
 const int kRetryDelay = 1000;
+const int kIpcStopTimeout = 3000;
+const int kProcessStopTimeout = 2000;
 const auto kLineSplitRegex = QRegularExpression("\r|\n|\r\n");
 
 QString CoreProcess::processModeToString(const Settings::ProcessMode mode)
@@ -99,11 +101,12 @@ QString CoreProcess::wrapIpv6(const QString &address)
 // CoreProcess
 //
 
-CoreProcess::CoreProcess(const ServerConfig &serverConfig)
+CoreProcess::CoreProcess(const ServerConfig &serverConfig, QString appPath)
     : m_serverConfig(serverConfig),
-      m_daemonIpcClient{new ipc::DaemonIpcClient(this)}
+      m_daemonIpcClient{new ipc::DaemonIpcClient(this)},
+      m_appPath{
+          appPath.isEmpty() ? QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kCoreBinName) : appPath}
 {
-  m_appPath = QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kCoreBinName);
   if (!QFile::exists(m_appPath)) {
     qFatal("core server binary does not exist");
     return;
@@ -268,7 +271,7 @@ void CoreProcess::startProcessFromDaemon()
   }
 }
 
-void CoreProcess::stopForegroundProcess() const
+void CoreProcess::stopForegroundProcess()
 {
   if (m_processState != ProcessState::Stopping) {
     qFatal("core process must be in stopping state");
@@ -281,11 +284,33 @@ void CoreProcess::stopForegroundProcess() const
   qInfo("stopping core desktop process");
 
   if (m_process->state() == QProcess::ProcessState::Running) {
-    qDebug("process is running, closing");
-    m_process->close();
-  } else {
-    qDebug("process is not running, skipping terminate");
+    if (m_coreIpcClient && m_coreIpcClient->isConnected()) {
+      qInfo("asking core desktop process to stop via IPC");
+      m_coreIpcClient->sendStop();
+      m_process->waitForFinished(kIpcStopTimeout);
+    }
+
+    if (m_process->state() == QProcess::ProcessState::Running) {
+      qWarning("core desktop process did not stop, terminating");
+      m_process->terminate();
+      m_process->waitForFinished(kProcessStopTimeout);
+    }
+
+    if (m_process->state() == QProcess::ProcessState::Running) {
+      qWarning("core desktop process did not terminate, killing");
+      m_process->kill();
+      m_process->waitForFinished(kProcessStopTimeout);
+    }
   }
+
+  if (m_process->state() != QProcess::ProcessState::NotRunning) {
+    qCritical("core desktop process did not exit after kill");
+    return;
+  }
+
+  delete m_process;
+  m_process = nullptr;
+  setProcessState(ProcessState::Stopped);
 }
 
 void CoreProcess::stopProcessFromDaemon()
@@ -461,12 +486,6 @@ void CoreProcess::stop(std::optional<ProcessMode> processModeOption)
 
   qInfo("stopping core process (%s mode)", qPrintable(processModeToString(processMode)));
 
-  if (m_coreIpcClient) {
-    m_coreIpcClient->disconnectFromServer();
-    m_coreIpcClient->deleteLater();
-    m_coreIpcClient = nullptr;
-  }
-
   if (m_processState == ProcessState::Starting) {
     qDebug("core process is starting, cancelling");
     setProcessState(ProcessState::Stopped);
@@ -481,6 +500,12 @@ void CoreProcess::stop(std::optional<ProcessMode> processModeOption)
 
   } else {
     qWarning("core process already stopped");
+  }
+
+  if (m_coreIpcClient) {
+    m_coreIpcClient->disconnectFromServer();
+    m_coreIpcClient->deleteLater();
+    m_coreIpcClient = nullptr;
   }
 
   setConnectionState(ConnectionState::Disconnected);

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -372,8 +372,15 @@ void CoreProcess::handleLogLines(const QString &text)
 
 void CoreProcess::start(std::optional<ProcessMode> processModeOption)
 {
+  QMutexLocker locker(&m_processMutex);
+
   if (m_processState == ProcessState::Started) {
     qCritical("core process already started");
+    return;
+  }
+
+  if (m_processState == ProcessState::Stopping) {
+    qCritical("core process is stopping; refusing start until it exits");
     return;
   }
 
@@ -381,8 +388,6 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
     qFatal("set core mode before starting");
     return;
   }
-
-  QMutexLocker locker(&m_processMutex);
 
   const auto currentMode = Settings::value(Settings::Core::ProcessMode).value<ProcessMode>();
   const auto processMode = processModeOption.value_or(currentMode);

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -546,8 +546,29 @@ void CoreProcess::cleanup()
 
   const auto isDesktop = Settings::value(Settings::Core::ProcessMode).value<ProcessMode>() == ProcessMode::Desktop;
   const auto isRunning = m_processState == ProcessState::Started;
-  if (isDesktop && isRunning) {
+  // A desktop-mode child can still be alive even when the tracked state is not
+  // exactly Started (e.g. Stopping/RetryPending, or an inconsistent Stopped).
+  // Stop it regardless, otherwise the QProcess destructor below would block the
+  // GUI forever on quit and/or leave an orphaned core behind.
+  const auto hasLiveChild = m_process && m_process->state() != QProcess::ProcessState::NotRunning;
+  if (isDesktop && (isRunning || hasLiveChild)) {
     stop();
+  }
+
+  // Final guarantee: never let ~QProcess perform an unbounded waitForFinished()
+  // during CoreProcess destruction. If the child somehow survived the staged
+  // stop, force-kill it with a bounded wait and, only if it still refuses to
+  // die, detach it so its destructor cannot block application quit.
+  if (m_process && m_process->state() != QProcess::ProcessState::NotRunning) {
+    qWarning("core process still running after cleanup; force killing");
+    m_process->kill();
+    m_process->waitForFinished(kProcessStopTimeout);
+  }
+  if (m_process && m_process->state() != QProcess::ProcessState::NotRunning) {
+    qCritical("core process still running after kill; detaching to avoid blocking quit");
+    m_process->disconnect();
+    m_process->setParent(nullptr);
+    m_process = nullptr;
   }
 }
 

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -101,11 +101,12 @@ QString CoreProcess::wrapIpv6(const QString &address)
 // CoreProcess
 //
 
-CoreProcess::CoreProcess(const ServerConfig &serverConfig, QString appPath)
+CoreProcess::CoreProcess(const ServerConfig &serverConfig, QString appPath, QString coreIpcName)
     : m_serverConfig(serverConfig),
       m_daemonIpcClient{new ipc::DaemonIpcClient(this)},
       m_appPath{
-          appPath.isEmpty() ? QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kCoreBinName) : appPath}
+          appPath.isEmpty() ? QStringLiteral("%1/%2").arg(QCoreApplication::applicationDirPath(), kCoreBinName) : appPath},
+      m_coreIpcName(std::move(coreIpcName))
 {
   if (!QFile::exists(m_appPath)) {
     qFatal("core server binary does not exist");
@@ -151,7 +152,7 @@ void CoreProcess::checkExistingProcess()
 {
   qInfo("checking existing core");
 
-  auto *client = new ipc::CoreIpcClient(this);
+  auto *client = new ipc::CoreIpcClient(this, m_coreIpcName);
   connect(client, &ipc::CoreIpcClient::connected, this, [client] {
     qInfo("existing core has matching version, leaving it running");
     client->deleteLater();
@@ -455,7 +456,7 @@ void CoreProcess::start(std::optional<ProcessMode> processModeOption)
             return;
           }
 
-          m_coreIpcClient = new ipc::CoreIpcClient(this);
+          m_coreIpcClient = new ipc::CoreIpcClient(this, m_coreIpcName);
           connect(m_coreIpcClient, &ipc::CoreIpcClient::commandReceived, this, &CoreProcess::onCoreIpcMessageReceived);
           connect(m_coreIpcClient, &ipc::CoreIpcClient::connected, this, [] {
             qDebug("connected to core ipc server");

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -15,6 +15,7 @@
 #include <QMutex>
 #include <QObject>
 #include <QProcess>
+#include <QString>
 #include <QTimer>
 
 namespace deskflow::gui {
@@ -38,7 +39,7 @@ public:
     StartFailed
   };
 
-  explicit CoreProcess(const ServerConfig &serverConfig);
+  explicit CoreProcess(const ServerConfig &serverConfig, QString appPath = {});
 
   void start(std::optional<ProcessMode> processMode = std::nullopt);
   void stop(std::optional<ProcessMode> processMode = std::nullopt);

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -39,7 +39,7 @@ public:
     StartFailed
   };
 
-  explicit CoreProcess(const ServerConfig &serverConfig, QString appPath = {});
+  explicit CoreProcess(const ServerConfig &serverConfig, QString appPath = {}, QString coreIpcName = {});
 
   void start(std::optional<ProcessMode> processMode = std::nullopt);
   void stop(std::optional<ProcessMode> processMode = std::nullopt);
@@ -135,6 +135,7 @@ private:
   FileTail *m_daemonFileTail = nullptr;
   QProcess *m_process = nullptr;
   QString m_appPath;
+  QString m_coreIpcName;
 };
 
 } // namespace deskflow::gui

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -106,7 +106,7 @@ private Q_SLOTS:
 private:
   void startForegroundProcess(const QStringList &args);
   void startProcessFromDaemon();
-  void stopForegroundProcess() const;
+  void stopForegroundProcess();
   void stopProcessFromDaemon();
   QPair<bool, QString> persistServerConfig() const;
   void setConnectionState(ConnectionState state);

--- a/src/lib/gui/ipc/CoreIpcClient.cpp
+++ b/src/lib/gui/ipc/CoreIpcClient.cpp
@@ -15,7 +15,8 @@
 
 namespace deskflow::gui::ipc {
 
-CoreIpcClient::CoreIpcClient(QObject *parent) : IpcClient(parent, kCoreIpcName, QStringLiteral("core"))
+CoreIpcClient::CoreIpcClient(QObject *parent, QString socketName)
+    : IpcClient(parent, socketName.isEmpty() ? kCoreIpcName : socketName, QStringLiteral("core"))
 {
   // do nothing
 }
@@ -23,6 +24,7 @@ CoreIpcClient::CoreIpcClient(QObject *parent) : IpcClient(parent, kCoreIpcName, 
 void CoreIpcClient::sendStop()
 {
   sendMessage(QStringLiteral("stop"));
+  flushSocket();
 }
 
 void CoreIpcClient::processCommand(const QString &command, const QStringList &parts)

--- a/src/lib/gui/ipc/CoreIpcClient.h
+++ b/src/lib/gui/ipc/CoreIpcClient.h
@@ -17,7 +17,7 @@ class CoreIpcClient : public IpcClient
   Q_OBJECT
 
 public:
-  explicit CoreIpcClient(QObject *parent = nullptr);
+  explicit CoreIpcClient(QObject *parent = nullptr, QString socketName = {});
 
   void sendStop();
 

--- a/src/lib/gui/ipc/IpcClient.cpp
+++ b/src/lib/gui/ipc/IpcClient.cpp
@@ -214,4 +214,11 @@ void IpcClient::sendMessage(const QString &message)
   qDebug().noquote() << QStringLiteral("%1 ipc client sent message: %2").arg(m_typeName, message);
 }
 
+void IpcClient::flushSocket()
+{
+  if (m_state == State::Connected) {
+    m_socket->flush();
+  }
+}
+
 } // namespace deskflow::gui::ipc

--- a/src/lib/gui/ipc/IpcClient.h
+++ b/src/lib/gui/ipc/IpcClient.h
@@ -54,6 +54,7 @@ protected:
   }
 
   void sendMessage(const QString &message);
+  void flushSocket();
 
 private:
   void attemptConnection();

--- a/src/unittests/gui/core/CMakeLists.txt
+++ b/src/unittests/gui/core/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 add_executable(CoreProcessTestChild CoreProcessTestChild.cpp)
-target_link_libraries(CoreProcessTestChild PRIVATE Qt6::Core)
+target_link_libraries(CoreProcessTestChild PRIVATE app base)
 set_target_properties(CoreProcessTestChild PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
 create_test(

--- a/src/unittests/gui/core/CMakeLists.txt
+++ b/src/unittests/gui/core/CMakeLists.txt
@@ -1,6 +1,18 @@
 # SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
 # SPDX-License-Identifier: MIT
 
+add_executable(CoreProcessTestChild CoreProcessTestChild.cpp)
+target_link_libraries(CoreProcessTestChild PRIVATE Qt6::Core)
+set_target_properties(CoreProcessTestChild PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+create_test(
+  NAME CoreProcessTests
+  DEPENDS gui
+  SOURCE CoreProcessTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
+)
+add_dependencies(CoreProcessTests CoreProcessTestChild)
+
 create_test(
   NAME NetworkMonitorTests
   DEPENDS gui

--- a/src/unittests/gui/core/CMakeLists.txt
+++ b/src/unittests/gui/core/CMakeLists.txt
@@ -11,6 +11,10 @@ create_test(
   SOURCE CoreProcessTests.cpp
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
 )
+target_compile_definitions(
+  CoreProcessTests
+  PRIVATE CORE_PROCESS_TEST_EXECUTABLE_SUFFIX=\"${CMAKE_EXECUTABLE_SUFFIX}\"
+)
 add_dependencies(CoreProcessTests CoreProcessTestChild)
 
 create_test(

--- a/src/unittests/gui/core/CoreProcessTestChild.cpp
+++ b/src/unittests/gui/core/CoreProcessTestChild.cpp
@@ -5,9 +5,22 @@
  */
 
 #include <QCoreApplication>
+#include <QDebug>
+
+#ifdef Q_OS_UNIX
+#include <csignal>
+#endif
 
 int main(int argc, char *argv[])
 {
   QCoreApplication app(argc, argv);
+
+#ifdef Q_OS_UNIX
+  if (qEnvironmentVariableIsSet("DESKFLOW_CORE_PROCESS_TEST_IGNORE_TERMINATE")) {
+    std::signal(SIGTERM, SIG_IGN);
+  }
+#endif
+
+  qInfo("ready");
   return app.exec();
 }

--- a/src/unittests/gui/core/CoreProcessTestChild.cpp
+++ b/src/unittests/gui/core/CoreProcessTestChild.cpp
@@ -1,0 +1,13 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <QCoreApplication>
+
+int main(int argc, char *argv[])
+{
+  QCoreApplication app(argc, argv);
+  return app.exec();
+}

--- a/src/unittests/gui/core/CoreProcessTestChild.cpp
+++ b/src/unittests/gui/core/CoreProcessTestChild.cpp
@@ -4,22 +4,55 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "base/Log.h"
+#include "deskflow/ipc/CoreIpcServer.h"
+
 #include <QCoreApplication>
 #include <QDebug>
+#include <QFile>
+
+#include <memory>
 
 #ifdef Q_OS_UNIX
 #include <csignal>
 #endif
 
+namespace {
+
+constexpr auto kIpcNameEnvironment = "DESKFLOW_CORE_PROCESS_TEST_IPC_NAME";
+constexpr auto kGracefulStopResultEnvironment = "DESKFLOW_CORE_PROCESS_TEST_GRACEFUL_STOP_RESULT";
+
+} // namespace
+
 int main(int argc, char *argv[])
 {
   QCoreApplication app(argc, argv);
+  Log log;
 
 #ifdef Q_OS_UNIX
   if (qEnvironmentVariableIsSet("DESKFLOW_CORE_PROCESS_TEST_IGNORE_TERMINATE")) {
     std::signal(SIGTERM, SIG_IGN);
   }
 #endif
+
+  const auto ipcName = qEnvironmentVariable(kIpcNameEnvironment);
+  if (!ipcName.isEmpty()) {
+    auto ipcServer = std::make_unique<deskflow::core::ipc::CoreIpcServer>(nullptr, ipcName);
+    QObject::connect(ipcServer.get(), &deskflow::core::ipc::IpcServer::stopProcessRequested, &app, [&app] {
+      QFile resultFile(qEnvironmentVariable(kGracefulStopResultEnvironment));
+      if (resultFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        resultFile.write("graceful-stop");
+      } else {
+        qWarning() << "failed to write graceful stop result:" << resultFile.fileName();
+      }
+      app.quit();
+    });
+    ipcServer->listen();
+    ipcServer->broadcastCommand(QStringLiteral("connectionState"), QStringLiteral("Connected"));
+
+    qInfo("ready");
+    return app.exec();
+  }
 
   qInfo("ready");
   return app.exec();

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -33,7 +33,9 @@ void CoreProcessTests::initTestCase()
 
 void CoreProcessTests::stop_terminatesDesktopChild()
 {
-  const auto childPath = QDir(QCoreApplication::applicationDirPath()).filePath("CoreProcessTestChild");
+  const auto childPath =
+    QDir(QCoreApplication::applicationDirPath()).filePath(
+      QStringLiteral("CoreProcessTestChild") + QLatin1String(QT_EXECUTABLE_SUFFIX));
   QVERIFY(QFile::exists(childPath));
 
   ServerConfig config;

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -17,6 +17,42 @@
 
 using namespace deskflow::gui;
 
+namespace {
+
+constexpr auto kIgnoreTerminateEnvironment = "DESKFLOW_CORE_PROCESS_TEST_IGNORE_TERMINATE";
+
+class ScopedEnvironmentVariable
+{
+public:
+  explicit ScopedEnvironmentVariable(const char *name)
+      : m_name(name),
+        m_wasSet(qEnvironmentVariableIsSet(name)),
+        m_oldValue(qgetenv(name))
+  {
+  }
+
+  bool set(const char *value)
+  {
+    return qputenv(m_name, value);
+  }
+
+  ~ScopedEnvironmentVariable()
+  {
+    if (m_wasSet) {
+      qputenv(m_name, m_oldValue);
+    } else {
+      qunsetenv(m_name);
+    }
+  }
+
+private:
+  const char *m_name;
+  bool m_wasSet;
+  QByteArray m_oldValue;
+};
+
+} // namespace
+
 void CoreProcessTests::initTestCase()
 {
   QDir dir;
@@ -50,6 +86,39 @@ void CoreProcessTests::stop_terminatesDesktopChild()
 
   coreProcess.stop(Settings::ProcessMode::Desktop);
   QTRY_COMPARE(coreProcess.processState(), deskflow::core::ProcessState::Stopped);
+}
+
+void CoreProcessTests::stop_killsDesktopChildIgnoringTerminate()
+{
+#ifdef Q_OS_WIN
+  QSKIP("QProcess::terminate() does not use SIGTERM on Windows");
+#else
+  ScopedEnvironmentVariable ignoreTerminate(kIgnoreTerminateEnvironment);
+  QVERIFY(ignoreTerminate.set("1"));
+
+  const auto childPath =
+      QDir(QCoreApplication::applicationDirPath()).filePath(
+          QStringLiteral("CoreProcessTestChild") + QStringLiteral(CORE_PROCESS_TEST_EXECUTABLE_SUFFIX));
+  QVERIFY(QFile::exists(childPath));
+
+  ServerConfig config;
+  CoreProcess coreProcess(config, childPath);
+  coreProcess.setMode(Settings::CoreMode::Client);
+
+  QSignalSpy logLineSpy(&coreProcess, &CoreProcess::logLine);
+  QVERIFY(logLineSpy.isValid());
+
+  coreProcess.start(Settings::ProcessMode::Desktop);
+  QCOMPARE(coreProcess.processState(), deskflow::core::ProcessState::Started);
+  if (!logLineSpy.wait(2000)) {
+    coreProcess.stop(Settings::ProcessMode::Desktop);
+    QFAIL("test child did not report readiness");
+  }
+  QCOMPARE(logLineSpy.first().first().toString(), QStringLiteral("ready"));
+
+  coreProcess.stop(Settings::ProcessMode::Desktop);
+  QTRY_COMPARE(coreProcess.processState(), deskflow::core::ProcessState::Stopped);
+#endif
 }
 
 QTEST_MAIN(CoreProcessTests)

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -35,7 +35,7 @@ void CoreProcessTests::stop_terminatesDesktopChild()
 {
   const auto childPath =
     QDir(QCoreApplication::applicationDirPath()).filePath(
-      QStringLiteral("CoreProcessTestChild") + QLatin1String(QT_EXECUTABLE_SUFFIX));
+      QStringLiteral("CoreProcessTestChild") + QStringLiteral(CORE_PROCESS_TEST_EXECUTABLE_SUFFIX));
   QVERIFY(QFile::exists(childPath));
 
   ServerConfig config;

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -1,0 +1,53 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CoreProcessTests.h"
+
+#include "common/Settings.h"
+#include "gui/config/ServerConfig.h"
+#include "gui/core/CoreProcess.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QSignalSpy>
+
+using namespace deskflow::gui;
+
+void CoreProcessTests::initTestCase()
+{
+  QDir dir;
+  QVERIFY(dir.mkpath(m_settingsPath));
+
+  QFile oldSettings(m_settingsFile);
+  if (oldSettings.exists())
+    oldSettings.remove();
+
+  Settings::setSettingsFile(m_settingsFile);
+  Settings::setStateFile(m_stateFile);
+  Settings::setValue(Settings::Core::ProcessMode, Settings::ProcessMode::Desktop);
+}
+
+void CoreProcessTests::stop_terminatesDesktopChild()
+{
+  const auto childPath = QDir(QCoreApplication::applicationDirPath()).filePath("CoreProcessTestChild");
+  QVERIFY(QFile::exists(childPath));
+
+  ServerConfig config;
+  CoreProcess coreProcess(config, childPath);
+  coreProcess.setMode(Settings::CoreMode::Client);
+
+  QSignalSpy processStateChangedSpy(&coreProcess, &CoreProcess::processStateChanged);
+  QVERIFY(processStateChangedSpy.isValid());
+
+  coreProcess.start(Settings::ProcessMode::Desktop);
+  QCOMPARE(coreProcess.processState(), deskflow::core::ProcessState::Started);
+
+  coreProcess.stop(Settings::ProcessMode::Desktop);
+  QTRY_COMPARE(coreProcess.processState(), deskflow::core::ProcessState::Stopped);
+}
+
+QTEST_MAIN(CoreProcessTests)

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -14,12 +14,15 @@
 #include <QDir>
 #include <QFile>
 #include <QSignalSpy>
+#include <QUuid>
 
 using namespace deskflow::gui;
 
 namespace {
 
 constexpr auto kIgnoreTerminateEnvironment = "DESKFLOW_CORE_PROCESS_TEST_IGNORE_TERMINATE";
+constexpr auto kIpcNameEnvironment = "DESKFLOW_CORE_PROCESS_TEST_IPC_NAME";
+constexpr auto kGracefulStopResultEnvironment = "DESKFLOW_CORE_PROCESS_TEST_GRACEFUL_STOP_RESULT";
 
 class ScopedEnvironmentVariable
 {
@@ -31,7 +34,7 @@ public:
   {
   }
 
-  bool set(const char *value)
+  bool set(const QByteArray &value)
   {
     return qputenv(m_name, value);
   }
@@ -86,6 +89,44 @@ void CoreProcessTests::stop_terminatesDesktopChild()
 
   coreProcess.stop(Settings::ProcessMode::Desktop);
   QTRY_COMPARE(coreProcess.processState(), deskflow::core::ProcessState::Stopped);
+}
+
+void CoreProcessTests::stop_sendsGracefulIpcStop()
+{
+  const auto childPath =
+      QDir(QCoreApplication::applicationDirPath()).filePath(
+          QStringLiteral("CoreProcessTestChild") + QStringLiteral(CORE_PROCESS_TEST_EXECUTABLE_SUFFIX));
+  QVERIFY(QFile::exists(childPath));
+
+  const auto resultPath = QDir(m_settingsPath).filePath(QStringLiteral("graceful-stop-result"));
+  QFile::remove(resultPath);
+  QVERIFY(!QFile::exists(resultPath));
+
+  ScopedEnvironmentVariable gracefulStopResult(kGracefulStopResultEnvironment);
+  QVERIFY(gracefulStopResult.set(QFile::encodeName(resultPath)));
+  const auto ipcName = QStringLiteral("core-process-test-%1").arg(QUuid::createUuid().toString(QUuid::Id128));
+  ScopedEnvironmentVariable testIpcName(kIpcNameEnvironment);
+  QVERIFY(testIpcName.set(ipcName.toUtf8()));
+
+  ServerConfig config;
+  CoreProcess coreProcess(config, childPath, ipcName);
+  coreProcess.setMode(Settings::CoreMode::Client);
+
+  QSignalSpy connectionStateChangedSpy(&coreProcess, &CoreProcess::connectionStateChanged);
+  QVERIFY(connectionStateChangedSpy.isValid());
+
+  coreProcess.start(Settings::ProcessMode::Desktop);
+  QCOMPARE(coreProcess.processState(), deskflow::core::ProcessState::Started);
+  QTRY_COMPARE(coreProcess.connectionState(), deskflow::core::ConnectionState::Connected);
+  QVERIFY(!connectionStateChangedSpy.isEmpty());
+
+  coreProcess.stop(Settings::ProcessMode::Desktop);
+  QTRY_VERIFY(QFile::exists(resultPath));
+  QTRY_COMPARE(coreProcess.processState(), deskflow::core::ProcessState::Stopped);
+
+  QFile resultFile(resultPath);
+  QVERIFY(resultFile.open(QIODevice::ReadOnly));
+  QCOMPARE(resultFile.readAll(), QByteArray("graceful-stop"));
 }
 
 void CoreProcessTests::stop_killsDesktopChildIgnoringTerminate()

--- a/src/unittests/gui/core/CoreProcessTests.cpp
+++ b/src/unittests/gui/core/CoreProcessTests.cpp
@@ -77,8 +77,9 @@ void CoreProcessTests::stop_terminatesDesktopChild()
       QStringLiteral("CoreProcessTestChild") + QStringLiteral(CORE_PROCESS_TEST_EXECUTABLE_SUFFIX));
   QVERIFY(QFile::exists(childPath));
 
+  const auto ipcName = QStringLiteral("core-process-test-%1").arg(QUuid::createUuid().toString(QUuid::Id128));
   ServerConfig config;
-  CoreProcess coreProcess(config, childPath);
+  CoreProcess coreProcess(config, childPath, ipcName);
   coreProcess.setMode(Settings::CoreMode::Client);
 
   QSignalSpy processStateChangedSpy(&coreProcess, &CoreProcess::processStateChanged);
@@ -142,8 +143,9 @@ void CoreProcessTests::stop_killsDesktopChildIgnoringTerminate()
           QStringLiteral("CoreProcessTestChild") + QStringLiteral(CORE_PROCESS_TEST_EXECUTABLE_SUFFIX));
   QVERIFY(QFile::exists(childPath));
 
+  const auto ipcName = QStringLiteral("core-process-test-%1").arg(QUuid::createUuid().toString(QUuid::Id128));
   ServerConfig config;
-  CoreProcess coreProcess(config, childPath);
+  CoreProcess coreProcess(config, childPath, ipcName);
   coreProcess.setMode(Settings::CoreMode::Client);
 
   QSignalSpy logLineSpy(&coreProcess, &CoreProcess::logLine);

--- a/src/unittests/gui/core/CoreProcessTests.h
+++ b/src/unittests/gui/core/CoreProcessTests.h
@@ -1,0 +1,23 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <QTest>
+
+class CoreProcessTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void initTestCase();
+  void stop_terminatesDesktopChild();
+
+private:
+  inline static const QString m_settingsPath = QStringLiteral("tmp/CoreProcessTests");
+  inline static const QString m_settingsFile = QStringLiteral("%1/Deskflow.conf").arg(m_settingsPath);
+  inline static const QString m_stateFile = QStringLiteral("%1/Deskflow.state").arg(m_settingsPath);
+};

--- a/src/unittests/gui/core/CoreProcessTests.h
+++ b/src/unittests/gui/core/CoreProcessTests.h
@@ -15,6 +15,7 @@ class CoreProcessTests : public QObject
 private Q_SLOTS:
   void initTestCase();
   void stop_terminatesDesktopChild();
+  void stop_sendsGracefulIpcStop();
   void stop_killsDesktopChildIgnoringTerminate();
 
 private:

--- a/src/unittests/gui/core/CoreProcessTests.h
+++ b/src/unittests/gui/core/CoreProcessTests.h
@@ -15,6 +15,7 @@ class CoreProcessTests : public QObject
 private Q_SLOTS:
   void initTestCase();
   void stop_terminatesDesktopChild();
+  void stop_killsDesktopChildIgnoringTerminate();
 
 private:
   inline static const QString m_settingsPath = QStringLiteral("tmp/CoreProcessTests");


### PR DESCRIPTION
## Description

In desktop process mode on macOS, quitting the GUI can leave the `deskflow-core` child process orphaned. The orphan keeps the core IPC socket and the server listening port alive, which can corrupt or block the next launch.

This change stops the desktop core from the quit path itself and hardens `CoreProcess::cleanup()` so a live child is stopped even when the tracked state is not exactly `Started`.

### What changed / why

- Stop the core synchronously in `MainWindow::closeEvent()` before accepting a real quit.
- Also connect `QCoreApplication::aboutToQuit` to `CoreProcess::cleanup()` for non-destructor quit paths.
- Change `CoreProcess::cleanup()` to stop any live desktop child (`isRunning` or `hasLiveChild`), not only the exact `Started` state.
- Make foreground desktop shutdown bounded: ask the core to stop over IPC, then terminate, then kill if needed.
- Detach the process as a last resort so `~QProcess` can never block GUI shutdown indefinitely.
- Add a unit test suite for the desktop child shutdown behavior.

The macOS-specific part matters because an OS-initiated quit (`[NSApp terminate:]`) can call `exit()` without unwinding the C++ stack. Relying on `MainWindow::~MainWindow()` to run `CoreProcess::cleanup()` is therefore not sufficient.

## AI tools used for this PR

GPT-5.6 (Sol) / Opus 4.8 was used to help debugging and iterating on some fixes (various commits) as I was progressing testing edge-cases. I was developing/fixing/testing and required real e2e verifications, being tedious but required, as needed to act normally with the app for many times (Quit, Start, Force Quit, Start, etc). All e2e tests done by me, but capturing Verbose logs to be helpful for AIs.

## Fixed/related issues

No relevant existing upstream issue was found from read-only searches for `macos quit`, `core process orphan`, `macos quit deskflow-core`, or similar terms so I needed to create https://github.com/deskflow/deskflow/issues/9999.

## How has this been tested?

The branch adds `src/unittests/gui/core/CoreProcessTests.*`, covering:

- `stop_terminatesDesktopChild`
- `stop_sendsGracefulIpcStop`
- `stop_killsDesktopChildIgnoringTerminate`

Before submitting upstream, run the targeted test suite from the clean rebased branch, for example with the project's normal CMake/CTest workflow and a selector for `CoreProcessTests`.

I am using these changes locally (built) to be able to use  Deskflow w/o issues in my mac.

Rebased to have latest changes from upstream.