### PR TITLE
fix(mac): properly handle system initiated quit events

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -163,6 +163,11 @@ MainWindow::MainWindow()
   applyConfig();
   m_statusBar->setSecurityIcon(TlsUtility::isEnabled());
   restoreWindow();
+
+#ifdef Q_OS_MACOS
+  // Route native quits (Cmd+Q / Apple menu Quit / Dock "Quit") to the usual close-to-tray decision instead.
+  installQuitHandler([this] { return !maybeHideToTray(); });
+#endif
 }
 MainWindow::~MainWindow()
 {
@@ -898,16 +903,25 @@ void MainWindow::handlePeerFingerprint(const QString &fingerprint)
   }
 }
 
+bool MainWindow::maybeHideToTray()
+{
+  if (!Settings::value(Settings::Gui::CloseToTray).toBool()) {
+    return false;
+  }
+
+  if (Settings::value(Settings::Gui::CloseReminder).toBool()) {
+    messages::showCloseReminder(this);
+    Settings::setValue(Settings::Gui::CloseReminder, false);
+  }
+  Settings::setValue(Settings::Gui::WindowGeometry, geometry());
+  qDebug() << "hiding to tray";
+  hide();
+  return true;
+}
+
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-  if (Settings::value(Settings::Gui::CloseToTray).toBool() && event->spontaneous()) {
-    if (Settings::value(Settings::Gui::CloseReminder).toBool()) {
-      messages::showCloseReminder(this);
-      Settings::setValue(Settings::Gui::CloseReminder, false);
-    }
-    Settings::setValue(Settings::Gui::WindowGeometry, geometry());
-    qDebug() << "hiding to tray";
-    hide();
+  if (event->spontaneous() && maybeHideToTray()) {
     event->ignore();
     return;
   }

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -122,6 +122,7 @@ private:
   void handlePeerFingerprint(const QString &fingerprint);
   void handleMissingKeyboardLayouts(const QString &layouts);
   void closeEvent(QCloseEvent *event) override;
+  bool maybeHideToTray();
   void secureSocket(bool secureSocket);
   void connectSlots();
   void handleLogLine(const QString &line);

--- a/src/lib/gui/OSXHelpers.h
+++ b/src/lib/gui/OSXHelpers.h
@@ -8,9 +8,12 @@
 
 #include <QString>
 
+#include <functional>
+
 void requestOSXNotificationPermission();
 bool isOSXDevelopmentBuild();
 bool showOSXNotification(const QString &title, const QString &body);
 bool isOSXInterfaceStyleDark();
 void forceAppActive();
 void macOSNativeHide();
+void installQuitHandler(std::function<bool()> shouldQuit);

--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -13,11 +13,18 @@
 #import <UserNotifications/UNNotificationContent.h>
 #import <UserNotifications/UNNotificationTrigger.h>
 #import <UserNotifications/UNUserNotificationCenter.h>
+#import <objc/runtime.h>
 
 #import <QtGlobal>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace {
+std::function<bool()> s_shouldQuit;
+IMP s_originalShouldTerminate = nullptr;
+BOOL s_isSystemShuttingDown = NO;
+} // namespace
 
 void requestOSXNotificationPermission()
 {
@@ -106,4 +113,45 @@ void macOSNativeHide()
 {
   [NSApp hide:nil];
   [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+static NSApplicationTerminateReply deskflow_applicationShouldTerminate(id self, SEL _cmd, NSApplication *sender)
+{
+  // Don't intercept a system shutdown (or logoff/restart)
+  if (!s_isSystemShuttingDown && s_shouldQuit && !s_shouldQuit()) {
+    return NSTerminateCancel;
+  }
+
+  // Execute Qt's applicationShouldTerminate
+  if (s_originalShouldTerminate) {
+    using ShouldTerminateFn = NSApplicationTerminateReply (*)(id, SEL, NSApplication *);
+    return reinterpret_cast<ShouldTerminateFn>(s_originalShouldTerminate)(self, _cmd, sender);
+  }
+
+  return NSTerminateNow;
+}
+
+void installQuitHandler(std::function<bool()> shouldQuit)
+{
+  s_shouldQuit = std::move(shouldQuit);
+
+  Class cls = [[NSApp delegate] class];
+  SEL selector = @selector(applicationShouldTerminate:);
+
+  Method method = class_getInstanceMethod(cls, selector);
+  if (method) {
+    s_originalShouldTerminate = method_getImplementation(method);
+    method_setImplementation(method, (IMP)deskflow_applicationShouldTerminate);
+  } else {
+    class_addMethod(cls, selector, (IMP)deskflow_applicationShouldTerminate, "l@:@");
+  }
+
+  // shutdown is also triggered for logout/restart
+  [[[NSWorkspace sharedWorkspace] notificationCenter] addObserverForName:NSWorkspaceWillPowerOffNotification
+                                                                  object:nil
+                                                                   queue:[NSOperationQueue mainQueue]
+                                                              usingBlock:^(NSNotification *note) {
+                                                                Q_UNUSED(note)
+                                                                s_isSystemShuttingDown = YES;
+                                                              }];
 }


### PR DESCRIPTION
## Description
Intercepts and correct handle quit requests coming from the system on mac OS (Upon dock clicking, for example).

If deskflow is configured to go to the tray, it will do so even if the system requests the deskflow app to quits.
Special treatment is given for shutdown requests (which includes logoff/restarts as well).

This also ensures that the proper Qt preparation to quit runs. 

## AI tools used for this PR
Claude Code (Opus 5) on guidance and suggestions.
Code was manually written.

## Fixed/related issues
replaces: #10000
fixes: #9999 

## How has this been tested?
Tested on macOS Tahoe 26.5.2 (25F84) as server
