### PR TITLE
feat(wayland): server-side clipboard via a RemoteDesktop portal sidecar

### DIFF
--- a/src/lib/base/EventTypes.h
+++ b/src/lib/base/EventTypes.h
@@ -238,5 +238,10 @@ enum class EventTypes : uint32_t
 
   /// Stop libei
   EISessionClosed,
+
+  /// The portal session that carries input cannot also carry the clipboard, so
+  /// the screen has to open a session that can. Posted by PortalInputCapture on
+  /// its glib thread, handled by EiScreen on the event queue thread.
+  PortalClipboardUnavailable,
 };
 } // namespace deskflow

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -545,14 +545,17 @@ void ServerProxy::setClipboard()
   // parse
   ClipboardID id;
   uint32_t seq;
+  const auto maximumSize = m_client->getMaximumClipboardReceiveSizeBytes();
 
-  auto r = ClipboardChunk::assemble(
-      m_stream, m_clipboardDataCached, id, seq, m_clipboardChunkState, m_client->getMaximumClipboardReceiveSizeBytes()
-  );
+  auto r = ClipboardChunk::assemble(m_stream, m_clipboardDataCached, id, seq, m_clipboardChunkState, maximumSize, true);
 
   if (r == TransferState::Started) {
     size_t size = ClipboardChunk::getExpectedSize(m_clipboardChunkState);
-    LOG_DEBUG("receiving clipboard %d size=%zu", id, size);
+    if (ClipboardChunk::isDiscarding(m_clipboardChunkState)) {
+      LOG_WARN("dropping oversize clipboard from server (size %zu > limit %zu), staying connected", size, maximumSize);
+    } else {
+      LOG_DEBUG("receiving clipboard %d size=%zu", id, size);
+    }
   } else if (r == TransferState::Finished) {
     LOG_DEBUG("received clipboard %d size=%zu", id, m_clipboardDataCached.size());
 

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -121,6 +121,11 @@ public:
     inline static const auto SwitchDoubleTap = QStringLiteral("server/switchDoubleTap");
     inline static const auto Win32KeepForeground = QStringLiteral("server/win32KeepForeground");
     inline static const auto XdpRestoreToken = QStringLiteral("server/xdpRestoreToken");
+    // Restore token for the server's clipboard-only remote desktop session.
+    // Deliberately distinct from XdpRestoreToken (the input capture session on
+    // the same machine) and from Client::XdpRestoreToken (the client's remote
+    // desktop session), because one machine can be configured as both.
+    inline static const auto XdpClipboardRestoreToken = QStringLiteral("server/xdpClipboardRestoreToken");
   };
 
   struct Screen
@@ -310,6 +315,7 @@ private:
     , Settings::Server::SwitchDoubleTap
     , Settings::Server::Win32KeepForeground
     , Settings::Server::XdpRestoreToken
+    , Settings::Server::XdpClipboardRestoreToken
   };
 
   // When checking the default values this list contains the ones that default to false.

--- a/src/lib/deskflow/ClipboardChunk.cpp
+++ b/src/lib/deskflow/ClipboardChunk.cpp
@@ -78,7 +78,7 @@ ClipboardChunk *ClipboardChunk::end(ClipboardID id, uint32_t sequence)
 
 TransferState ClipboardChunk::assemble(
     deskflow::IStream *stream, std::string &dataCached, ClipboardID &id, uint32_t &sequence,
-    ClipboardChunkAssemblyState &state, size_t maxDataSize
+    ClipboardChunkAssemblyState &state, size_t maxDataSize, bool discardOversized
 )
 {
   using enum TransferState;
@@ -111,15 +111,18 @@ TransferState ClipboardChunk::assemble(
 
     clearCachedData(dataCached);
     state.expectedSize = static_cast<size_t>(expected);
+    state.receivedSize = 0;
     state.active = true;
+    state.discarding = state.expectedSize > maxDataSize;
 
-    if (state.expectedSize > maxDataSize) {
+    if (state.discarding && !discardOversized) {
       LOG_ERR("clipboard size exceeds limit, size: %zu, limit: %zu", state.expectedSize, maxDataSize);
       reset();
       return Error;
     }
 
-    LOG_DEBUG("start receiving clipboard data, expected size=%zu", state.expectedSize);
+    if (!state.discarding)
+      LOG_DEBUG("start receiving clipboard data, expected size=%zu", state.expectedSize);
     return Started;
   } else if (mark == ChunkType::DataChunk) {
     if (!state.active) {
@@ -128,16 +131,18 @@ TransferState ClipboardChunk::assemble(
       return Error;
     }
 
-    if (wouldExceed(dataCached.size(), data.size(), state.expectedSize)) {
+    if (wouldExceed(state.receivedSize, data.size(), state.expectedSize)) {
       LOG_ERR(
-          "clipboard size exceeds declared, size: %zu, declared: %zu", dataCached.size() + data.size(),
+          "clipboard size exceeds declared, size: %zu, declared: %zu", state.receivedSize + data.size(),
           state.expectedSize
       );
       reset();
       return Error;
     }
 
-    dataCached.append(data);
+    state.receivedSize += data.size();
+    if (!state.discarding)
+      dataCached.append(data);
     return TransferState::InProgress;
   } else if (mark == ChunkType::DataEnd) {
     if (!state.active) {
@@ -148,10 +153,15 @@ TransferState ClipboardChunk::assemble(
 
     state.active = false;
 
-    if (state.expectedSize != dataCached.size()) {
-      LOG_ERR("corrupted clipboard data, expected size=%zu actual size=%zu", state.expectedSize, dataCached.size());
+    if (state.expectedSize != state.receivedSize) {
+      LOG_ERR("corrupted clipboard data, expected size=%zu actual size=%zu", state.expectedSize, state.receivedSize);
       reset();
       return Error;
+    }
+
+    if (state.discarding) {
+      reset();
+      return Skipped;
     }
     return Finished;
   }

--- a/src/lib/deskflow/ClipboardChunk.h
+++ b/src/lib/deskflow/ClipboardChunk.h
@@ -22,7 +22,9 @@ class IStream;
 struct ClipboardChunkAssemblyState
 {
   size_t expectedSize = 0;
+  size_t receivedSize = 0;
   bool active = false;
+  bool discarding = false;
 };
 
 class ClipboardChunk : public Chunk
@@ -36,7 +38,7 @@ public:
 
   static TransferState assemble(
       deskflow::IStream *stream, std::string &dataCached, ClipboardID &id, uint32_t &sequence,
-      ClipboardChunkAssemblyState &state, size_t maxDataSize
+      ClipboardChunkAssemblyState &state, size_t maxDataSize, bool discardOversized = false
   );
 
   static void send(deskflow::IStream *stream, void *data);
@@ -44,5 +46,10 @@ public:
   static size_t getExpectedSize(const ClipboardChunkAssemblyState &state)
   {
     return state.expectedSize;
+  }
+
+  static bool isDiscarding(const ClipboardChunkAssemblyState &state)
+  {
+    return state.discarding;
   }
 };

--- a/src/lib/deskflow/ProtocolTypes.h
+++ b/src/lib/deskflow/ProtocolTypes.h
@@ -175,6 +175,7 @@ enum class TransferState : uint8_t
   Started,    ///< Reception started
   InProgress, ///< Reception in progress
   Finished,   ///< Reception completed successfully
+  Skipped,    ///< Reception completed without retaining the data
   Error       ///< Reception failed with error
 };
 

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -164,6 +164,8 @@ elseif(UNIX)
         list(APPEND PLATFORM_SOURCES
           PortalClipboard.cpp
           PortalClipboard.h
+          PortalServerClipboard.cpp
+          PortalServerClipboard.h
         )
       endif()
     endif()

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -20,6 +20,9 @@
 #include "platform/EiKeyState.h"
 #include "platform/PortalInputCapture.h"
 #include "platform/PortalRemoteDesktop.h"
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+#include "platform/PortalServerClipboard.h"
+#endif
 
 #include <algorithm>
 #include <cmath>
@@ -47,6 +50,12 @@ EiScreen::EiScreen(bool isPrimary, IEventQueue *events, bool usePortal)
 {
   initEi();
   m_keyState = new EiKeyState(this, events);
+
+  // One clipboard cache per screen, for every backend. The portal sessions that
+  // fill it get torn down and recreated while the screen lives on, so the cache
+  // cannot belong to any of them.
+  m_clipboard = new EiClipboard(kClipboardClipboard);
+
   // install event handlers
   m_events->addHandler(EventTypes::System, m_events->getSystemTarget(), [this](const auto &e) {
     handleSystemEvent(e);
@@ -57,15 +66,22 @@ EiScreen::EiScreen(bool isPrimary, IEventQueue *events, bool usePortal)
       handleConnectedToEisEvent(e);
     });
     if (isPrimary) {
+      // A primary screen relays input over an input capture session. That
+      // session can only carry the clipboard from input capture version 2
+      // onwards, and xdg-desktop-portal-gnome does not offer one on it at all.
+      // So wait for the session to report what it got, and only then open a
+      // clipboard-only remote desktop session alongside it. Doing it lazily
+      // rather than unconditionally means a future portal that does grant an
+      // input capture clipboard gets no second session and no second dialog.
+      m_events->addHandler(EventTypes::PortalClipboardUnavailable, getEventTarget(), [this](const auto &) {
+        handlePortalClipboardUnavailable();
+      });
       m_portalInputCapture = new PortalInputCapture(this, m_events);
-      // Portal input capture manages its own clipboard
     } else {
       m_events->addHandler(EventTypes::EISessionClosed, getEventTarget(), [this](const auto &) {
         handlePortalSessionClosed();
       });
       m_portalRemoteDesktop = new PortalRemoteDesktop(this, m_events);
-      // Create clipboard for remote desktop (secondary screen)
-      m_clipboard = new EiClipboard(kClipboardClipboard);
     }
   } else {
     // Note: socket backend does not support reconnections
@@ -73,8 +89,6 @@ EiScreen::EiScreen(bool isPrimary, IEventQueue *events, bool usePortal)
       LOG_ERR("ei init error: %s", strerror(-rc));
       throw std::runtime_error("failed to init ei context");
     }
-    // Create clipboard for socket backend
-    m_clipboard = new EiClipboard(kClipboardClipboard);
   }
 
   // disable sleep if the flag is set
@@ -87,16 +101,56 @@ EiScreen::~EiScreen()
 {
   m_events->adoptBuffer(nullptr);
   m_events->removeHandler(EventTypes::System, m_events->getSystemTarget());
+  // Deregister before anything below is torn down: a PortalClipboardUnavailable
+  // still sitting in the queue must not re-enter a half-destroyed screen and
+  // build a fresh portal session on the way out. Safe to call when it was never
+  // registered.
+  m_events->removeHandler(EventTypes::PortalClipboardUnavailable, getEventTarget());
 
   cancelIdleEmulationTimer();
 
   cleanupEi();
 
   delete m_keyState;
-  delete m_clipboard;
 
+  // Every portal object runs a glib thread that reads and writes m_clipboard,
+  // and every one of their destructors joins that thread. They all have to be
+  // gone before the cache they use is freed.
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  delete m_portalServerClipboard;
+  m_portalServerClipboard = nullptr;
+#endif
   delete m_portalRemoteDesktop;
   delete m_portalInputCapture;
+
+  delete m_clipboard;
+}
+
+bool EiScreen::serverClipboardPortalReady() const
+{
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  return m_portalServerClipboard != nullptr && m_portalServerClipboard->isReady();
+#else
+  return false;
+#endif
+}
+
+void EiScreen::handlePortalClipboardUnavailable()
+{
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  // Runs on the event queue thread, which is the same thread ~EiScreen runs on,
+  // so m_portalServerClipboard is only ever touched from one thread.
+  if (m_portalServerClipboard) {
+    return;
+  }
+
+  if (!PortalServerClipboard::isEnabled()) {
+    return;
+  }
+
+  LOG_DEBUG("input capture session carries no clipboard, opening a clipboard-only remote desktop session");
+  m_portalServerClipboard = new PortalServerClipboard(this);
+#endif
 }
 
 void EiScreen::eiLogEvent(ei_log_priority priority, const char *message) const
@@ -172,17 +226,11 @@ void *EiScreen::getEventTarget() const
 
 bool EiScreen::getClipboard(ClipboardID id, IClipboard *clipboard) const
 {
-  // If using portal input capture, get clipboard from there
-  if (m_portalInputCapture) {
-    const auto sourceClipboard = m_portalInputCapture->getClipboard(id);
-    if (!sourceClipboard) {
-      return false;
-    }
-    return IClipboard::copy(clipboard, sourceClipboard);
-  }
-
-  // Otherwise use our own clipboard
-  if (!m_clipboard) {
+  // Wayland has no equivalent of the X11 primary selection, so the portal only
+  // ever hands us the system clipboard. Serving any other id out of this one
+  // cache lets a peer that does have a primary selection - a macOS or Windows
+  // client - round-trip its id 1 through it and clobber it.
+  if (!clipboard || !m_clipboard || id != m_clipboard->getID()) {
     return false;
   }
 
@@ -445,31 +493,32 @@ void EiScreen::leave()
 
 bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 {
-  if (!clipboard) {
+  // See getClipboard(): only the system clipboard exists on this backend.
+  if (!clipboard || !m_clipboard || id != m_clipboard->getID()) {
     return false;
   }
 
-  // If using portal input capture, set clipboard there
-  if (m_portalInputCapture) {
-    IClipboard *targetClipboard = m_portalInputCapture->getClipboard(id);
-    if (!targetClipboard) {
-      return false;
-    }
-    return IClipboard::copy(targetClipboard, clipboard);
-  }
-
-  // Otherwise use our own clipboard
-  if (!m_clipboard) {
+  if (!IClipboard::copy(m_clipboard, clipboard)) {
     return false;
   }
 
-  bool ok = IClipboard::copy(m_clipboard, clipboard);
+  // Tell the compositor we now own the local selection, so that a local paste
+  // can reach the bytes a remote peer just sent us. Only a remote desktop
+  // portal session can do that. On a secondary screen that is the session we
+  // already relay input over. On a primary screen it is the clipboard-only
+  // sidecar, and while that is not ready this is simply a no-op.
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  if (serverClipboardPortalReady()) {
+    m_portalServerClipboard->claimClipboard();
+    return true;
+  }
+#endif
 
-  if (ok && m_portalRemoteDesktop && id == kClipboardClipboard) {
+  if (m_portalRemoteDesktop) {
     m_portalRemoteDesktop->claimClipboard();
   }
 
-  return ok;
+  return true;
 }
 
 void EiScreen::checkClipboards()

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -29,6 +29,7 @@ namespace deskflow {
 class EiKeyState;
 class PortalRemoteDesktop;
 class PortalInputCapture;
+class PortalServerClipboard;
 class EiClipboard;
 
 using ClipboardInfo = IScreen::ClipboardInfo;
@@ -84,7 +85,13 @@ public:
   // Send clipboard event (needed by PortalInputCapture)
   void sendClipboardEvent(EventTypes type, ClipboardID id) const;
 
-  // Local clipboard cache (used by PortalRemoteDesktop to land selection reads)
+  //! The screen's one clipboard cache
+  /*!
+  Owned by the screen rather than by any portal session: sessions are torn down
+  and recreated while the screen lives on (see EI_EVENT_DISCONNECT), and the
+  cached selection has to survive that. Portal sessions read and write it
+  through PortalClipboard.
+  */
   EiClipboard *getClipboardCache() const
   {
     return m_clipboard;
@@ -124,6 +131,12 @@ private:
 
   void handleConnectedToEisEvent(const Event &event);
   void handlePortalSessionClosed();
+  void handlePortalClipboardUnavailable();
+
+  /// True only once the optional server-side clipboard portal session is live.
+  /// While this is false the server simply does not share its clipboard, and
+  /// input capture is unaffected either way.
+  bool serverClipboardPortalReady() const;
   void ensureEmulating() const;
   void stopEmulating() const;
   void cancelIdleEmulationTimer() const;
@@ -188,6 +201,12 @@ private:
 
   PortalRemoteDesktop *m_portalRemoteDesktop = nullptr;
   PortalInputCapture *m_portalInputCapture = nullptr;
+
+  // Server only, and only once the input capture session has reported that it
+  // carries no clipboard: a clipboard-only remote desktop session that fills
+  // m_clipboard while m_portalInputCapture keeps doing the input. It owns no
+  // part of the input path.
+  PortalServerClipboard *m_portalServerClipboard = nullptr;
 
   struct HotKeyItem
   {

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -12,7 +12,6 @@
 #include "base/Log.h"
 #include "base/TMethodJob.h"
 #include "deskflow/ClipboardTypes.h"
-#include "platform/EiClipboard.h"
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
 #include "platform/PortalClipboard.h"
@@ -175,9 +174,8 @@ PortalInputCapture::PortalInputCapture(EiScreen *screen, IEventQueue *events)
       m_portalVersion(0),
       m_portal{xdp_portal_new()}
 {
-  // Create clipboard for primary clipboard ID
-  m_clipboard = new EiClipboard(kClipboardClipboard);
-
+  // No clipboard cache of our own. EiScreen owns the one cache, so it survives
+  // this object being destroyed and recreated on an EIS disconnect.
   m_glibMainLoop = g_main_loop_new(nullptr, true);
 
   auto tMethodJob = new TMethodJob<PortalInputCapture>(this, &PortalInputCapture::glibThread);
@@ -222,17 +220,15 @@ PortalInputCapture::~PortalInputCapture()
   }
   m_barriers.clear();
   g_object_unref(m_portal);
-
-  delete m_clipboard;
 }
 
-EiClipboard *PortalInputCapture::getClipboard(ClipboardID id) const
+bool PortalInputCapture::isClipboardEnabled() const
 {
-  // Currently only supporting primary clipboard
-  if (id == kClipboardClipboard) {
-    return m_clipboard;
-  }
-  return nullptr;
+#ifdef HAVE_LIBPORTAL_CLIPBOARD
+  return m_session != nullptr && xdp_session_is_clipboard_enabled(xdp_input_capture_session_get_session(m_session));
+#else
+  return false;
+#endif
 }
 
 gboolean PortalInputCapture::timeoutHandler() const
@@ -253,7 +249,7 @@ void PortalInputCapture::handleSessionClosed(XdpSession *session)
 void PortalInputCapture::claimClipboardOwnership([[maybe_unused]] XdpSession *session) const
 {
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
-  PortalClipboard::claimOwnership(m_clipboard, session);
+  PortalClipboard::claimOwnership(m_screen->getClipboardCache(), session);
 #endif
 }
 
@@ -269,7 +265,7 @@ void PortalInputCapture::readClipboardSelection(XdpSession *session) const
     return;
   }
 
-  if (PortalClipboard::readSelectionIntoCache(m_clipboard, session, mimeTypes, maxBytes))
+  if (PortalClipboard::readSelectionIntoCache(m_screen->getClipboardCache(), session, mimeTypes, maxBytes))
     m_screen->sendClipboardEvent(EventTypes::ClipboardGrabbed, kClipboardClipboard);
 #else
   (void)session;
@@ -283,7 +279,7 @@ void PortalInputCapture::handleSelectionTransfer(XdpSession *session, const char
     LOG_DEBUG("skipping clipboard selection transfer, clipboard is active");
     return;
   }
-  PortalClipboard::serveSelectionTransfer(m_clipboard, session, mimeType, serial);
+  PortalClipboard::serveSelectionTransfer(m_screen->getClipboardCache(), session, mimeType, serial);
 #else
   (void)session;
   (void)mimeType;
@@ -297,18 +293,30 @@ void PortalInputCapture::setupSession(XdpInputCaptureSession *session)
   XdpSession *parentSession = xdp_input_capture_session_get_session(session);
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
-  if (!xdp_session_is_clipboard_enabled(parentSession) && m_portalVersion > 1) {
-    // Restored sessions can pre-date clipboard support, leaving the channel
-    // disabled even though we requested it. Drop the saved token and recreate
-    // the session from scratch so the user gets a fresh permission dialog.
-    LOG_WARN("clipboard not enabled on session, discarding restore token to force a fresh session");
+  if (!xdp_session_is_clipboard_enabled(parentSession)) {
+    if (m_portalVersion > 1 && !m_discardedClipboardToken) {
+      // Restored sessions can pre-date clipboard support, leaving the channel
+      // disabled even though we requested it. Drop the saved token and recreate
+      // the session from scratch so the user gets a fresh permission dialog.
+      // Worth doing exactly once: a portal that simply never grants a clipboard
+      // would otherwise have us rebuilding the session forever, popping a
+      // consent dialog every time round.
+      LOG_WARN("clipboard not enabled on session, discarding restore token to force a fresh session");
+      m_discardedClipboardToken = true;
 #ifdef HAVE_LIBPORTAL_INPUTCAPTURE_RESTORE
-    Settings::setValue(Settings::Server::XdpRestoreToken, QString());
+      Settings::setValue(Settings::Server::XdpRestoreToken, QString());
 #endif
-    g_object_unref(m_session);
-    m_session = nullptr;
-    g_idle_add([](gpointer data) { return static_cast<PortalInputCapture *>(data)->initSession(); }, this);
-    return;
+      g_object_unref(m_session);
+      m_session = nullptr;
+      g_idle_add([](gpointer data) { return static_cast<PortalInputCapture *>(data)->initSession(); }, this);
+      return;
+    }
+
+    // The clipboard cannot ride on this session. Say so, so the screen can open
+    // a session that does carry one. Input capture continues either way; this
+    // is a notification, not a failure.
+    LOG_DEBUG("input capture portal version %d provides no clipboard on this session", m_portalVersion);
+    m_events->addEvent(Event(EventTypes::PortalClipboardUnavailable, m_screen->getEventTarget()));
   }
 #endif
 
@@ -736,9 +744,23 @@ void PortalInputCapture::handleActivated(
   m_isActive = true;
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
-  if (m_session) {
+  // Only touch the clipboard here if the portal actually put one on THIS
+  // session. Two reasons, both load-bearing.
+  //
+  // 1. The unconditional ClipboardGrabbed that used to sit on the next line
+  //    fired on every barrier crossing, before anything had been read. On a
+  //    session with no clipboard the cache is always empty, so the server
+  //    marshalled a 4-byte zero-format clipboard and broadcast it to every
+  //    client, wiping them. That is the bug this patch exists to fix.
+  // 2. The reads below are synchronous D-Bus calls. Screen switching is the hot
+  //    path of the whole application and must not block on them.
+  //
+  // When this session has no clipboard, PortalServerClipboard holds a separate
+  // remote desktop session that keeps the screen's cache up to date from the
+  // portal's own signals, and posts ClipboardGrabbed itself when there is
+  // something real to send.
+  if (isClipboardEnabled()) {
     LOG_DEBUG("reading clipboard selection on activation");
-    m_screen->sendClipboardEvent(EventTypes::ClipboardGrabbed, kClipboardClipboard);
 
     XdpSession *session = xdp_input_capture_session_get_session(m_session);
     const char **mimeTypes = xdp_session_get_selection_mime_types(session);
@@ -753,8 +775,6 @@ void PortalInputCapture::handleActivated(
 
     claimClipboardOwnership(session);
     LOG_DEBUG("activation clipboard handling complete");
-  } else {
-    LOG_WARN("input capture activated without a session, skipping clipboard read");
   }
 #endif
 }

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -24,16 +24,21 @@
 
 namespace deskflow {
 
-class EiClipboard;
-
 class PortalInputCapture
 {
 public:
   PortalInputCapture(EiScreen *screen, IEventQueue *events);
   ~PortalInputCapture();
 
-  // Get the clipboard for the specified ID
-  EiClipboard *getClipboard(ClipboardID id) const;
+  //! Whether the portal actually put a clipboard channel on this session
+  /*!
+  The input capture portal only offers one from version 2 onwards, and only if
+  the compositor implements it. xdg-desktop-portal-gnome does not: it accepts
+  RequestClipboard on remote desktop sessions only. When this returns false this
+  class does no clipboard work at all, and EiScreen opens a separate
+  clipboard-only remote desktop session instead.
+  */
+  bool isClipboardEnabled() const;
   void enable();
   void disable();
   void release();
@@ -167,11 +172,12 @@ private:
   bool m_enabled = false;
   bool m_isActive = false;
   std::uint32_t m_activationId = 0;
+  /// Guards against looping forever on a portal that keeps handing us a session
+  /// with no clipboard: the restore token is discarded at most once.
+  bool m_discardedClipboardToken = false;
 
   std::vector<XdpInputCapturePointerBarrier *> m_barriers;
   std::vector<BarrierInfo> m_barrierInfo;
-
-  EiClipboard *m_clipboard = nullptr;
 };
 
 } // namespace deskflow

--- a/src/lib/platform/PortalServerClipboard.cpp
+++ b/src/lib/platform/PortalServerClipboard.cpp
@@ -1,0 +1,443 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "platform/PortalServerClipboard.h"
+
+#include "base/Log.h"
+#include "base/TMethodJob.h"
+#include "common/Settings.h"
+#include "platform/EiScreen.h"
+#include "platform/PortalClipboard.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace deskflow {
+
+namespace {
+
+bool envIsOff(const char *value)
+{
+  return g_ascii_strcasecmp(value, "0") == 0 || g_ascii_strcasecmp(value, "false") == 0 ||
+         g_ascii_strcasecmp(value, "off") == 0 || g_ascii_strcasecmp(value, "no") == 0;
+}
+
+} // namespace
+
+bool PortalServerClipboard::isEnabled()
+{
+  const char *value = std::getenv("DESKFLOW_SERVER_CLIPBOARD_PORTAL");
+  if (value == nullptr || *value == '\0')
+    return true;
+
+  if (envIsOff(value)) {
+    LOG_INFO("server clipboard portal disabled by DESKFLOW_SERVER_CLIPBOARD_PORTAL");
+    return false;
+  }
+
+  return true;
+}
+
+PortalServerClipboard::DeviceMode PortalServerClipboard::deviceMode()
+{
+  const char *value = std::getenv("DESKFLOW_SERVER_CLIPBOARD_DEVICES");
+  if (value != nullptr && g_ascii_strcasecmp(value, "none") == 0)
+    return DeviceMode::None;
+  return DeviceMode::Input;
+}
+
+PortalServerClipboard::PortalServerClipboard(EiScreen *screen) : m_screen{screen}
+{
+  // A private main context, so this object's D-Bus dispatch never contends with
+  // the input-capture glib loop for the global default context.
+  m_glibContext = g_main_context_new();
+  m_glibMainLoop = g_main_loop_new(m_glibContext, true);
+  m_cancellable = g_cancellable_new();
+
+  auto *tMethodJob = new TMethodJob<PortalServerClipboard>(this, &PortalServerClipboard::glibThread);
+  m_glibThread = new Thread(tMethodJob);
+
+  scheduleInit(0);
+}
+
+PortalServerClipboard::~PortalServerClipboard()
+{
+  m_shuttingDown.store(true, std::memory_order_release);
+  m_ready.store(false, std::memory_order_release);
+
+  // Cancel any in-flight portal call before we stop iterating, so its GTask
+  // completes instead of sitting on the bus.
+  if (m_cancellable)
+    g_cancellable_cancel(m_cancellable);
+
+  if (m_glibMainLoop && g_main_loop_is_running(m_glibMainLoop))
+    g_main_loop_quit(m_glibMainLoop);
+
+  if (m_glibContext)
+    g_main_context_wakeup(m_glibContext);
+
+  if (m_glibThread) {
+    m_glibThread->cancel();
+    m_glibThread->wait();
+    delete m_glibThread;
+    m_glibThread = nullptr;
+  }
+
+  // The glib thread is joined; taking the claim lock here waits out any
+  // claimClipboard() call the event thread started before m_ready went false.
+  {
+    std::scoped_lock lock{m_claimMutex};
+
+    disconnectSignals();
+
+    if (m_session) {
+      g_object_unref(m_session);
+      m_session = nullptr;
+    }
+    if (m_portal) {
+      g_object_unref(m_portal);
+      m_portal = nullptr;
+    }
+    if (m_cancellable) {
+      g_object_unref(m_cancellable);
+      m_cancellable = nullptr;
+    }
+    if (m_glibMainLoop) {
+      g_main_loop_unref(m_glibMainLoop);
+      m_glibMainLoop = nullptr;
+    }
+    if (m_glibContext) {
+      g_main_context_unref(m_glibContext);
+      m_glibContext = nullptr;
+    }
+  }
+
+  free(m_sessionRestoreToken);
+  m_sessionRestoreToken = nullptr;
+}
+
+void PortalServerClipboard::disconnectSignals()
+{
+  if (!m_session)
+    return;
+
+  if (m_sessionClosedSignalId) {
+    g_signal_handler_disconnect(m_session, m_sessionClosedSignalId);
+    m_sessionClosedSignalId = 0;
+  }
+  if (m_selectionTransferSignalId) {
+    g_signal_handler_disconnect(m_session, m_selectionTransferSignalId);
+    m_selectionTransferSignalId = 0;
+  }
+  if (m_selectionOwnerChangedSignalId) {
+    g_signal_handler_disconnect(m_session, m_selectionOwnerChangedSignalId);
+    m_selectionOwnerChangedSignalId = 0;
+  }
+}
+
+void PortalServerClipboard::glibThread(const void *)
+{
+  // Push before anything creates the XdpPortal: GDBus binds signal dispatch to
+  // whatever context is thread-default at subscribe time, and every subscribe
+  // this object makes happens from inside this loop.
+  g_main_context_push_thread_default(m_glibContext);
+
+  while (g_main_loop_is_running(m_glibMainLoop)) {
+    Thread::testCancel();
+    g_main_context_iteration(m_glibContext, true);
+  }
+
+  g_main_context_pop_thread_default(m_glibContext);
+}
+
+void PortalServerClipboard::scheduleInit(unsigned int delayMs)
+{
+  if (m_shuttingDown.load(std::memory_order_acquire) || m_gaveUp)
+    return;
+
+  GSource *source = delayMs > 0 ? g_timeout_source_new(delayMs) : g_idle_source_new();
+  g_source_set_callback(
+      source,
+      [](gpointer data) -> gboolean {
+        return static_cast<PortalServerClipboard *>(data)->initSession();
+      },
+      this, nullptr
+  );
+  g_source_attach(source, m_glibContext);
+  g_source_unref(source);
+}
+
+void PortalServerClipboard::giveUp(const char *why)
+{
+  m_gaveUp = true;
+  m_ready.store(false, std::memory_order_release);
+  LOG_WARN(
+      "server clipboard portal unavailable (%s); clipboard sharing from this server is disabled, "
+      "input capture is unaffected",
+      why
+  );
+}
+
+void PortalServerClipboard::failAndRetry(const char *why)
+{
+  m_ready.store(false, std::memory_order_release);
+
+  if (m_shuttingDown.load(std::memory_order_acquire))
+    return;
+
+  if (m_initAttempts >= kMaxInitAttempts) {
+    giveUp(why);
+    return;
+  }
+
+  unsigned int delay = kFirstRetryDelayMs;
+  for (unsigned int i = 0; i < m_consecutiveFailures && delay < kMaxRetryDelayMs; ++i)
+    delay *= 2;
+  if (delay > kMaxRetryDelayMs)
+    delay = kMaxRetryDelayMs;
+
+  ++m_consecutiveFailures;
+  LOG_DEBUG("server clipboard portal retry in %u ms (%s)", delay, why);
+  scheduleInit(delay);
+}
+
+gboolean PortalServerClipboard::initSession()
+{
+  if (m_shuttingDown.load(std::memory_order_acquire) || m_gaveUp)
+    return false; // don't reschedule
+
+  if (m_initAttempts >= kMaxInitAttempts) {
+    giveUp("retry limit reached");
+    return false;
+  }
+  ++m_initAttempts;
+
+  if (!m_portal) {
+    g_autoptr(GError) portalError = nullptr;
+    // Deliberately not xdp_portal_new(): that abort()s the process when the
+    // session bus is missing, which would take the KVM down with it.
+    m_portal = xdp_portal_initable_new(&portalError);
+    if (!m_portal) {
+      giveUp(portalError ? portalError->message : "cannot reach the session bus");
+      return false;
+    }
+  }
+
+  if (auto sessionToken = Settings::value(Settings::Server::XdpClipboardRestoreToken).toByteArray();
+      !sessionToken.isEmpty()) {
+    free(m_sessionRestoreToken);
+    m_sessionRestoreToken = strdup(sessionToken.data());
+  }
+
+  const auto devices = deviceMode() == DeviceMode::None
+                           ? XDP_DEVICE_NONE
+                           : static_cast<XdpDeviceType>(XDP_DEVICE_POINTER | XDP_DEVICE_KEYBOARD);
+
+  LOG_DEBUG(
+      "setting up server clipboard portal session (attempt %u, devices=0x%x, restore token %s)", m_initAttempts,
+      static_cast<unsigned int>(devices), m_sessionRestoreToken ? "present" : "none"
+  );
+
+  xdp_portal_create_remote_desktop_session_full(
+      m_portal, devices, XDP_OUTPUT_NONE, XDP_REMOTE_DESKTOP_FLAG_NONE, XDP_CURSOR_MODE_HIDDEN,
+      XDP_PERSIST_MODE_PERSISTENT, m_sessionRestoreToken, m_cancellable,
+      [](GObject *obj, GAsyncResult *res, gpointer data) {
+        static_cast<PortalServerClipboard *>(data)->handleInitSession(obj, res);
+      },
+      this
+  );
+
+  return false; // don't reschedule
+}
+
+void PortalServerClipboard::handleInitSession(GObject *object, GAsyncResult *res)
+{
+  g_autoptr(GError) error = nullptr;
+
+  auto *session = xdp_portal_create_remote_desktop_session_finish(XDP_PORTAL(object), res, &error);
+  if (!session) {
+    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+      // Either we are shutting down, or the user dismissed the portal dialog.
+      // Neither is worth hammering the portal over.
+      if (!m_shuttingDown.load(std::memory_order_acquire))
+        giveUp("session request was cancelled or denied");
+      return;
+    }
+    failAndRetry(error ? error->message : "failed to create session");
+    return;
+  }
+
+  if (m_shuttingDown.load(std::memory_order_acquire)) {
+    g_object_unref(session);
+    return;
+  }
+
+  m_session = session;
+
+  m_sessionClosedSignalId =
+      g_signal_connect(G_OBJECT(session), "closed", G_CALLBACK(handleSessionClosedCallback), this);
+
+  // Must happen before Start: the portal reports clipboard_enabled in the Start
+  // reply, and RequestClipboard is only honoured on a session in initial state.
+  xdp_session_request_clipboard(session);
+  m_selectionTransferSignalId =
+      g_signal_connect(G_OBJECT(session), "selection-transfer", G_CALLBACK(selectionTransferCallback), this);
+  m_selectionOwnerChangedSignalId =
+      g_signal_connect(G_OBJECT(session), "selection-owner-changed", G_CALLBACK(selectionOwnerChangedCallback), this);
+
+  LOG_DEBUG("server clipboard portal session starting");
+  xdp_session_start(
+      session,
+      nullptr, // parent
+      m_cancellable,
+      [](GObject *obj, GAsyncResult *result, gpointer data) {
+        static_cast<PortalServerClipboard *>(data)->handleSessionStarted(obj, result);
+      },
+      this
+  );
+}
+
+void PortalServerClipboard::handleSessionStarted(GObject *object, GAsyncResult *res)
+{
+  g_autoptr(GError) error = nullptr;
+  auto *session = XDP_SESSION(object);
+
+  if (!xdp_session_start_finish(session, res, &error)) {
+    disconnectSignals();
+    g_clear_object(&m_session);
+    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+      if (!m_shuttingDown.load(std::memory_order_acquire))
+        giveUp("session start was cancelled or denied");
+      return;
+    }
+    failAndRetry(error ? error->message : "failed to start session");
+    return;
+  }
+
+  if (m_shuttingDown.load(std::memory_order_acquire))
+    return;
+
+  if (!xdp_session_is_clipboard_enabled(session)) {
+    disconnectSignals();
+    g_clear_object(&m_session);
+
+    if (m_discardedTokenOnce) {
+      giveUp("compositor started the session without a clipboard");
+      return;
+    }
+
+    // A restore token minted before clipboard support can come back without a
+    // clipboard. Drop it once and ask for a fresh session.
+    LOG_DEBUG("server clipboard portal session has no clipboard, discarding restore token and retrying once");
+    m_discardedTokenOnce = true;
+    Settings::setValue(Settings::Server::XdpClipboardRestoreToken, QString());
+    free(m_sessionRestoreToken);
+    m_sessionRestoreToken = nullptr;
+    scheduleInit(kFirstRetryDelayMs);
+    return;
+  }
+
+  free(m_sessionRestoreToken);
+  m_sessionRestoreToken = xdp_session_get_restore_token(session);
+  if (m_sessionRestoreToken)
+    Settings::setValue(Settings::Server::XdpClipboardRestoreToken, QString(m_sessionRestoreToken));
+
+  // Deliberately NOT calling xdp_session_connect_to_eis() here. This session
+  // exists only to carry the clipboard; the server's ei context is a receiver
+  // already bound to the input-capture socket, and handing it a second fd would
+  // break input capture.
+
+  m_consecutiveFailures = 0;
+  m_ready.store(true, std::memory_order_release);
+  LOG_INFO("server clipboard portal session ready, clipboard enabled");
+
+  // Publish whatever the screen is already holding (for example a clipboard a
+  // client pushed while the session was still coming up).
+  claimClipboard();
+}
+
+void PortalServerClipboard::handleSessionClosed(XdpSession *session)
+{
+  m_ready.store(false, std::memory_order_release);
+
+  if (m_sessionClosedSignalId) {
+    g_signal_handler_disconnect(session, m_sessionClosedSignalId);
+    m_sessionClosedSignalId = 0;
+  }
+  if (m_selectionTransferSignalId) {
+    g_signal_handler_disconnect(session, m_selectionTransferSignalId);
+    m_selectionTransferSignalId = 0;
+  }
+  if (m_selectionOwnerChangedSignalId) {
+    g_signal_handler_disconnect(session, m_selectionOwnerChangedSignalId);
+    m_selectionOwnerChangedSignalId = 0;
+  }
+
+  // Note: no EISessionClosed and no Quit. Input capture owns its own session and
+  // must not notice this at all.
+  LOG_DEBUG("server clipboard portal session closed, will retry");
+
+  g_clear_object(&m_session);
+
+  if (m_shuttingDown.load(std::memory_order_acquire) || m_gaveUp)
+    return;
+
+  if (m_initAttempts >= kMaxInitAttempts) {
+    giveUp("session kept closing");
+    return;
+  }
+  scheduleInit(kSessionClosedRetryDelayMs);
+}
+
+void PortalServerClipboard::claimClipboard() const
+{
+  std::scoped_lock lock{m_claimMutex};
+
+  if (!isReady() || m_glibContext == nullptr)
+    return;
+
+  // m_session is created and destroyed on the glib thread only, so do the work
+  // there. When we are already on that thread (the post-Start claim) glib runs
+  // this inline.
+  g_main_context_invoke(
+      m_glibContext,
+      [](gpointer data) -> gboolean {
+        static_cast<PortalServerClipboard *>(data)->claimClipboardOnGlibThread();
+        return G_SOURCE_REMOVE;
+      },
+      const_cast<PortalServerClipboard *>(this)
+  );
+}
+
+void PortalServerClipboard::claimClipboardOnGlibThread()
+{
+  if (m_shuttingDown.load(std::memory_order_acquire) || !m_session)
+    return;
+
+  if (!xdp_session_is_clipboard_enabled(m_session))
+    return;
+
+  PortalClipboard::claimOwnership(m_screen->getClipboardCache(), m_session);
+}
+
+void PortalServerClipboard::handleSelectionTransfer(XdpSession *session, const char *mimeType, uint32_t serial) const
+{
+  PortalClipboard::serveSelectionTransfer(m_screen->getClipboardCache(), session, mimeType, serial);
+}
+
+void PortalServerClipboard::handleSelectionOwnerChanged(XdpSession *session, char **mimeTypes, gboolean isOwner) const
+{
+  if (isOwner) {
+    LOG_DEBUG("server clipboard portal selection owner changed, we own it, ignoring");
+    return;
+  }
+
+  const qint64 maxBytes = static_cast<qint64>(m_screen->maximumClipboardSize()) * 1024;
+  if (PortalClipboard::readSelectionIntoCache(m_screen->getClipboardCache(), session, mimeTypes, maxBytes))
+    m_screen->sendClipboardEvent(EventTypes::ClipboardGrabbed, kClipboardClipboard);
+}
+
+} // namespace deskflow

--- a/src/lib/platform/PortalServerClipboard.h
+++ b/src/lib/platform/PortalServerClipboard.h
@@ -1,0 +1,173 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include "mt/Thread.h"
+
+#include <atomic>
+#include <glib.h>
+#include <libportal/portal.h>
+#include <mutex>
+
+namespace deskflow {
+
+class EiScreen;
+
+//! Clipboard-only RemoteDesktop portal session for the deskflow server.
+/*!
+The server drives input through an InputCapture portal session. On GNOME that
+session can never carry a clipboard: xdg-desktop-portal-gnome only accepts
+org.freedesktop.portal.Clipboard.RequestClipboard on a RemoteDesktop session,
+and at InputCapture portal version 1 libportal does not even ask. The result is
+a server that reads an always-empty clipboard and broadcasts it to its clients.
+
+This class opens a *second*, completely independent portal session whose only
+job is to carry the clipboard. It reuses the already-proven PortalClipboard
+helpers, which are session-type agnostic.
+
+Everything here is strictly additive and strictly optional. The safety
+properties are structural, not incidental:
+
+  - It holds no IEventQueue pointer, so it is not able to post EventTypes::Quit
+    or EventTypes::EISessionClosed. A denied, failed or closed clipboard session
+    can never terminate the server or tear down the EI context.
+  - It never calls xdp_session_connect_to_eis() and never posts
+    EventTypes::EIConnected, so it can never reach
+    EiScreen::handleConnectedToEisEvent() and clobber the EIS backend fd that
+    input capture owns.
+  - It runs its own GMainContext on its own thread, pushed as the thread-default
+    before the XdpPortal is created, so its D-Bus signal dispatch does not
+    contend with the input-capture glib loop on the global default context.
+  - It uses xdp_portal_initable_new() rather than xdp_portal_new(), which
+    abort()s the process when the session bus is unavailable.
+  - It uses its own settings key for its restore token, so it cannot clobber the
+    input-capture token or a client's remote-desktop token.
+  - Retries are bounded and backed off; after the cap it gives up permanently
+    and stays quiet.
+  - isReady() stays false until the portal has actually granted a session *and*
+    reported clipboard_enabled. Every caller falls back to the stock code path
+    while it is false, so a failure is indistinguishable from not building this
+    class at all.
+*/
+class PortalServerClipboard
+{
+public:
+  explicit PortalServerClipboard(EiScreen *screen);
+  ~PortalServerClipboard();
+
+  PortalServerClipboard(const PortalServerClipboard &) = delete;
+  PortalServerClipboard &operator=(const PortalServerClipboard &) = delete;
+
+  //! True once the portal granted a session whose clipboard is enabled.
+  /*!
+  Safe to call from any thread. While this is false the screen must keep using
+  the stock clipboard paths.
+  */
+  bool isReady() const
+  {
+    return m_ready.load(std::memory_order_acquire);
+  }
+
+  //! Advertise the screen's clipboard cache as the local selection.
+  /*!
+  Callable from the event thread. The work is bounced onto this object's own
+  glib thread, because the portal session handle is only ever created and
+  destroyed there.
+  */
+  void claimClipboard() const;
+
+  //! Kill switch, read once at construction time.
+  /*!
+  Returns false when DESKFLOW_SERVER_CLIPBOARD_PORTAL is set to 0/false/off/no.
+  Anything else (including unset) enables the feature.
+  */
+  static bool isEnabled();
+
+private:
+  void glibThread(const void *);
+  void scheduleInit(unsigned int delayMs);
+  void giveUp(const char *why);
+  void failAndRetry(const char *why);
+
+  gboolean initSession();
+  void claimClipboardOnGlibThread();
+  void handleInitSession(GObject *object, GAsyncResult *res);
+  void handleSessionStarted(GObject *object, GAsyncResult *res);
+  void handleSessionClosed(XdpSession *session);
+  void handleSelectionTransfer(XdpSession *session, const char *mimeType, uint32_t serial) const;
+  void handleSelectionOwnerChanged(XdpSession *session, char **mimeTypes, gboolean isOwner) const;
+  void disconnectSignals();
+
+  static void handleSessionClosedCallback(XdpSession *session, gpointer data)
+  {
+    static_cast<PortalServerClipboard *>(data)->handleSessionClosed(session);
+  }
+
+  static void selectionTransferCallback(XdpSession *session, const char *mimeType, uint32_t serial, gpointer data)
+  {
+    static_cast<PortalServerClipboard *>(data)->handleSelectionTransfer(session, mimeType, serial);
+  }
+
+  static void selectionOwnerChangedCallback(XdpSession *session, char **mimeTypes, gboolean isOwner, gpointer data)
+  {
+    static_cast<PortalServerClipboard *>(data)->handleSelectionOwnerChanged(session, mimeTypes, isOwner);
+  }
+
+  //! Devices asked for in the portal dialog.
+  /*!
+  Defaults to Input (pointer + keyboard), which is byte for byte the request the
+  deskflow *client* already makes successfully on this compositor. Set
+  DESKFLOW_SERVER_CLIPBOARD_DEVICES=none to ask for no devices at all, which is
+  a lighter touch on the seat but is not a path any shipping deskflow code
+  exercises.
+  */
+  enum class DeviceMode : std::uint8_t
+  {
+    Input,
+    None
+  };
+  static DeviceMode deviceMode();
+
+  // Total init attempts across the whole process lifetime. Hard bound so a
+  // compositor that keeps refusing or closing the session cannot produce an
+  // endless stream of portal dialogs or log spam.
+  static constexpr unsigned int kMaxInitAttempts = 12;
+  static constexpr unsigned int kFirstRetryDelayMs = 2000;
+  static constexpr unsigned int kMaxRetryDelayMs = 60000;
+  static constexpr unsigned int kSessionClosedRetryDelayMs = 5000;
+
+  EiScreen *m_screen = nullptr;
+
+  Thread *m_glibThread = nullptr;
+  GMainContext *m_glibContext = nullptr;
+  GMainLoop *m_glibMainLoop = nullptr;
+  GCancellable *m_cancellable = nullptr;
+
+  XdpPortal *m_portal = nullptr;
+  XdpSession *m_session = nullptr;
+  char *m_sessionRestoreToken = nullptr;
+
+  gulong m_sessionClosedSignalId = 0;
+  gulong m_selectionTransferSignalId = 0;
+  gulong m_selectionOwnerChangedSignalId = 0;
+
+  // Written on the glib thread, read from the event thread.
+  std::atomic<bool> m_ready{false};
+  std::atomic<bool> m_shuttingDown{false};
+
+  // Serialises claimClipboard() against teardown so the event thread can never
+  // hand work to a main context that the destructor has already unreffed.
+  mutable std::mutex m_claimMutex;
+
+  // glib-thread only.
+  unsigned int m_initAttempts = 0;
+  unsigned int m_consecutiveFailures = 0;
+  bool m_gaveUp = false;
+  bool m_discardedTokenOnce = false;
+};
+
+} // namespace deskflow

--- a/src/unittests/deskflow/ClipboardChunksTests.cpp
+++ b/src/unittests/deskflow/ClipboardChunksTests.cpp
@@ -285,4 +285,73 @@ void ClipboardChunksTests::assembleRejectsExpectedSizeBeyondLimit()
   QVERIFY(!state.active);
 }
 
+void ClipboardChunksTests::assembleDiscardsExpectedSizeBeyondLimit()
+{
+  MemoryStream stream;
+  stream.push(encodeClipboardMsg(0, 7, ChunkType::DataStart, "8"));
+  stream.push(encodeClipboardMsg(0, 7, ChunkType::DataChunk, "ABC"));
+  stream.push(encodeClipboardMsg(0, 7, ChunkType::DataChunk, "DEFGH"));
+  stream.push(encodeClipboardMsg(0, 7, ChunkType::DataEnd, ""));
+  stream.push(encodeClipboardMsg(1, 8, ChunkType::DataStart, "2"));
+  stream.push(encodeClipboardMsg(1, 8, ChunkType::DataChunk, "OK"));
+  stream.push(encodeClipboardMsg(1, 8, ChunkType::DataEnd, ""));
+
+  std::string cached;
+  ClipboardID id = kClipboardEnd;
+  uint32_t seq = 0;
+  ClipboardChunkAssemblyState state;
+
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::Started);
+  QCOMPARE(ClipboardChunk::getExpectedSize(state), static_cast<size_t>(8));
+  QVERIFY(ClipboardChunk::isDiscarding(state));
+
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::InProgress);
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::InProgress);
+  QVERIFY(cached.empty());
+
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::Skipped);
+  QCOMPARE(ClipboardChunk::getExpectedSize(state), static_cast<size_t>(0));
+  QVERIFY(!state.active);
+  QVERIFY(!ClipboardChunk::isDiscarding(state));
+
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::Started);
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::InProgress);
+  QCOMPARE(ClipboardChunk::assemble(&stream, cached, id, seq, state, 4, true), TransferState::Finished);
+  QCOMPARE(cached, std::string("OK"));
+  QCOMPARE(id, static_cast<ClipboardID>(1));
+  QCOMPARE(seq, static_cast<uint32_t>(8));
+}
+
+void ClipboardChunksTests::assembleRejectsMalformedDiscardedData()
+{
+  std::string cached;
+  ClipboardID id = kClipboardEnd;
+  uint32_t seq = 0;
+  ClipboardChunkAssemblyState state;
+
+  MemoryStream oversizedStream;
+  oversizedStream.push(encodeClipboardMsg(0, 7, ChunkType::DataStart, "8"));
+  oversizedStream.push(encodeClipboardMsg(0, 7, ChunkType::DataChunk, "123456789"));
+
+  QCOMPARE(ClipboardChunk::assemble(&oversizedStream, cached, id, seq, state, 4, true), TransferState::Started);
+  QCOMPARE(ClipboardChunk::assemble(&oversizedStream, cached, id, seq, state, 4, true), TransferState::Error);
+  QVERIFY(cached.empty());
+  QCOMPARE(ClipboardChunk::getExpectedSize(state), static_cast<size_t>(0));
+  QVERIFY(!state.active);
+  QVERIFY(!ClipboardChunk::isDiscarding(state));
+
+  MemoryStream undersizedStream;
+  undersizedStream.push(encodeClipboardMsg(0, 7, ChunkType::DataStart, "8"));
+  undersizedStream.push(encodeClipboardMsg(0, 7, ChunkType::DataChunk, "1234567"));
+  undersizedStream.push(encodeClipboardMsg(0, 7, ChunkType::DataEnd, ""));
+
+  QCOMPARE(ClipboardChunk::assemble(&undersizedStream, cached, id, seq, state, 4, true), TransferState::Started);
+  QCOMPARE(ClipboardChunk::assemble(&undersizedStream, cached, id, seq, state, 4, true), TransferState::InProgress);
+  QCOMPARE(ClipboardChunk::assemble(&undersizedStream, cached, id, seq, state, 4, true), TransferState::Error);
+  QVERIFY(cached.empty());
+  QCOMPARE(ClipboardChunk::getExpectedSize(state), static_cast<size_t>(0));
+  QVERIFY(!state.active);
+  QVERIFY(!ClipboardChunk::isDiscarding(state));
+}
+
 QTEST_MAIN(ClipboardChunksTests)

--- a/src/unittests/deskflow/ClipboardChunksTests.h
+++ b/src/unittests/deskflow/ClipboardChunksTests.h
@@ -20,6 +20,8 @@ private Q_SLOTS:
   void assembleAllowsDataAtExpectedSizeAndLimit();
   void assembleRejectsDataBeyondExpectedSize();
   void assembleRejectsExpectedSizeBeyondLimit();
+  void assembleDiscardsExpectedSizeBeyondLimit();
+  void assembleRejectsMalformedDiscardedData();
 
 private:
   Log m_log;


### PR DESCRIPTION
## Description

On GNOME 50 (and any compositor that offers only the InputCapture portal at **version 1**) the Wayland **server** has no clipboard, even after #9431 landed and when built against libportal 0.10.

Root cause is structural rather than a bug in the portal clipboard code:

- `EiScreen` constructs `PortalInputCapture` for the server and `PortalRemoteDesktop` only for the client (`src/lib/platform/EiScreen.cpp`).
- At InputCapture portal **version 1**, `PortalInputCapture::initSession()` takes the legacy session path and never calls `xdp_session_request_clipboard()`.
- `xdg-desktop-portal-gnome` additionally refuses clipboard on non-RemoteDesktop sessions, so even InputCapture v2 would not be sufficient there.

Net effect on a GNOME server: on activation it logs `no current clipboard selection` → `clipboard cache empty, nothing to claim`, then broadcasts an empty clipboard to its clients on every screen crossing (overwriting theirs).

**This PR** adds `PortalServerClipboard`. When the input-capture session reports that it carries no clipboard, `EiScreen` lazily opens a second, **clipboard-only RemoteDesktop portal session** alongside input capture — the exact portal the client side already uses successfully. The session is opened `PERSISTENT`, and its restore token is stored in a new `server/xdpClipboardRestoreToken` setting (kept distinct from the input-capture token and the client token, since one machine can be both server and client). Input capture is untouched, and the sidecar is created lazily only when the input-capture session lacks clipboard — so a future portal that *does* grant an input-capture clipboard gets no second session and no second consent dialog. If the RemoteDesktop session is unavailable or denied, the KVM behaves exactly as it does today.

Scope note: this restores the server's ability to **read and share its own clipboard**. Cross-platform image/format negotiation (e.g. BMP vs PNG) is a separate, pre-existing concern tracked elsewhere and is not addressed here; text is what I verified end to end.

## AI tools used for this PR

Disclosed in full. The patch was AI-assisted, then built and verified by a human (me) on real hardware:

- **Claude (Anthropic, "Fable" / Claude 5 family)** — mapped the relevant code paths, produced and synthesized the patch across several agents, and ran an adversarial code-review pass (three independent reviewers checking: does it actually fix the read, does it break input capture, would a maintainer merge it).
- **Codex (OpenAI, GPT-5.x)** — independent second-opinion agents that analyzed the same source and produced an alternate build for cross-checking.
- **Human** — I built it against libportal 0.10 in a clean Ubuntu 26.04 container, deployed it to my own machines, and verified the full loop (see testing below). I've reviewed the diff.

Happy to answer for any part of it, and to add unit tests / adjust to your Code Style before this is considered for merge — I didn't want to guess at your test harness conventions without a maintainer signalling this is a direction you want.

## Fixed/related issues

related: #8031
related: #9929
related: #7600

## How has this been tested?

Real full-loop test on hardware (not a build-only check):

- **Environment:** Ubuntu 26.04 / GNOME Shell 50.1 / Wayland, as the Deskflow **server**; clients = a second Ubuntu 26.04 / GNOME 50 / Wayland box and a macOS (Apple Silicon) box. Built from master + this patch against a bundled libportal 0.10 (`xdp_session_request_clipboard` present).
- **Before:** across 96 activations the server logged `no current clipboard selection` every time — 0 successful local reads — and sent empty (4-byte) clipboards to clients.
- **After:** on first activation the server logs `input capture session carries no clipboard, opening a clipboard-only remote desktop session`, then `clipboard read local selection, formats: 1`. Text copied on the GNOME server now pastes on both the Linux and macOS clients; text copied on a client pastes on the GNOME server. Consent is a one-time RemoteDesktop dialog; the restore token persists it across restarts (verified `server/xdpClipboardRestoreToken` is written and re-used with no re-prompt).
- Input capture / screen switching continued to work throughout (18+ crossings logged after the change).

**Not yet tested / out of scope:** KDE Plasma as server, Windows/macOS as server, image-format round-trips, and automated unit tests (offered above).
