### PR TITLE
fix(wayland): Corrects the cursor coordinates mappings at primary desktop

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -481,8 +481,8 @@ std::pair<double, double> PortalInputCapture::mapPortalReleasePosition(double x,
     return {x, y};
   }
 
-  auto mappedX = scaleCoordinateBetweenRanges(x, screenLeft, screenRight, portalBounds.left, portalBounds.right);
-  auto mappedY = scaleCoordinateBetweenRanges(y, screenTop, screenBottom, portalBounds.top, portalBounds.bottom);
+  auto mappedX = static_cast<std::int32_t>(std::lround(x));
+  auto mappedY = static_cast<std::int32_t>(std::lround(y));
 
   if (BarrierInfo releaseBarrier;
       getClosestReleaseBarrier(x, y, screenLeft, screenTop, screenRight, screenBottom, portalBounds, releaseBarrier)) {


### PR DESCRIPTION
Remapping the cursor coordinates to the portal edge size makes the mouse position being relative to the edge size, in a multi-monitor environment this edge can be in only one of the monitors and the cursor coordinates got wrong.

## Description

This change uses the full height and the full width of the combined monitors to set the mouse cursor position, cropped by the portal edge size.

## Fixed/related issues
fixes: #9990 

## How has this been tested?

The test was done by compiling the Deskflow tree of this PR, packaging, upgrading and restarting the Deskflow on three machines of my environment, namely: Client 1, Server and Client 4. Server is the important part as the wrong mouse position only happens at server. Client 2, Client 3 and Client 5 are kept with Deskflow 1.26.0.

After that, the test was made moving the mouse between the different desktop and screens, with the mouse showing in the correct coordinates.

### My testing environment

### Geometry

|  Client 1  |  Client 2  |  Server   |  Client 3  |  Client 4  |
|-----------|-----------|-----------|-----------|-----------|
| Plasma X11 | CDE X11 | Plasma Wayland | Windows | Plasma Wayland |
| Monitor 2 | Monitor 1 | Monitor 2 | Monitor 2 | Monitor 2 |
| Monitor 1 |           | Monitor 1 | Montior 1 | Monitor 1 |

1. I named the main monitor at each desktop as *Monitor 1*.
2. There is also a sixth desktop (*Client 5*) on top of *Client 2*, but that will make the table hard to make (and understand).
3. With the exception of *Client 3*, all desktops are Slackware Linux hosts running Slackware Current
4. All the desktops are connected by the first row and all *Monitor 2* are bigger than *Monitor 1*
5. _Client 1_ and _Client 3_ are using the Deskflow 1.26.0, the others are all with today's continuous build.

### Configuration
```
section: links
        Client_1:
                right(0,20) = Client_5(60,100)
                right(24,53) = Client_2(0,47)
        Client_2:
                right(0,94) = Server(12,63)
                left(0,47) = Client_1(24,53)
                up(0,100) = Client_5(0,100)
        Client_5:
                right(90,100) = Server(0,4)
                left(60,100) = Client_1(0,20)
                down(0,100) = Client_2(0,100)
        Server:
                left(0,4) = Client_5(90,100)
                left(12,63) = Client_2(0,94)
                right(0,50) = Client_3(41,78)
        Client_3:
                left(41,78) = Server(0,50)
                right(42,78) = Client_4(0,58)
        Client_4:
                left(0,58) = Client_3(42,78)
```
