### PR TITLE
fix(macos): null-check the input source languages before counting them

### DIFF
--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -77,7 +77,7 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
       layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceLanguages);
     }
     char temporaryCString[128] = {0};
-    for (CFIndex index = 0; index < CFArrayGetCount(layoutLanguages) && layoutLanguages; index++) {
+    for (CFIndex index = 0; layoutLanguages && index < CFArrayGetCount(layoutLanguages); index++) {
       auto languageCode = (CFStringRef)CFArrayGetValueAtIndex(layoutLanguages, index);
       if (!languageCode || !CFStringGetCString(languageCode, temporaryCString, 128, kCFStringEncodingUTF8)) {
         continue;
@@ -163,7 +163,7 @@ std::string AppUtilUnix::getCurrentLanguageCode()
       layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(source.get(), kTISPropertyInputSourceLanguages);
   }
   char temporaryCString[128] = {0};
-  for (CFIndex index = 0; index < CFArrayGetCount(layoutLanguages) && layoutLanguages; index++) {
+  for (CFIndex index = 0; layoutLanguages && index < CFArrayGetCount(layoutLanguages); index++) {
     auto languageCode = (CFStringRef)CFArrayGetValueAtIndex(layoutLanguages, index);
     if (!languageCode || !CFStringGetCString(languageCode, temporaryCString, 128, kCFStringEncodingUTF8)) {
       continue;


### PR DESCRIPTION
## Description

`layoutLanguages` comes from `TISGetInputSourceProperty()`, which returns `NULL` for an input source that carries no `kTISPropertyInputSourceLanguages` value. In `getCurrentLanguageCode()` it also stays `NULL` when `TISCopyCurrentKeyboardInputSource()` returns nothing, because the assignment sits behind `if (source)`.

Both loops evaluate `CFArrayGetCount(layoutLanguages)` *before* the `&& layoutLanguages` guard in the same condition, so the guard is dead code and `CFArrayGetCount()` dereferences the null pointer first. This swaps the operands at both sites. No behaviour change when the array is present.

## AI tools used for this PR

While working on other feature for my system, found this issue upstream, and Opus helped debugging and wrapping this quick side PR.

## Fixed/related issues

Fixes https://github.com/deskflow/deskflow/issues/10008

## How has this been tested?

- Built `deskflow-core` from this branch on macOS (Apple Silicon, Qt 6).
- Ran the Mac as the server for a Linux client and confirmed layout synchronisation on client connect still reports the expected languages, i.e. the loops still iterate normally when the array is non-null.
- The null path is the one that used to crash; it now exits the loop immediately.
