### PR TITLE
build(arch): adjust for libgcc package name

### DIFF
--- a/deploy/linux/arch/PKGBUILD.in
+++ b/deploy/linux/arch/PKGBUILD.in
@@ -13,14 +13,15 @@ license=(LicenseRef-GPL-2.0-only-WITH-OpenSSL-Exception)
 conflicts=('synergy-git' 'synergy-1.6' 'synergy1-bin' 'synergy2-bin' 'synergy3-bin' 'synergy3-beta-bin' 'synergy3-stable-bin' 'barrier' 'barrier-git' 'barrier-headless' 'barrier-headless-git' 'input-leap' 'input-leap-git' 'input-leap-headless-git' 'input-leap-headless' 'waynergy' 'waynergy-git' 'qsynergy' 'slim-synergy' 'quicksynergy' 'deskflow')
 provides=("$_basename")
 depends=(
-  gcc-libs
   glibc
   hicolor-icon-theme
   libei
+  libgcc
   libglvnd
   libice
   libportal
   libsm
+  libstdc++
   libx11
   libxext
   libxi


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 gcc-libs is wrong on arch should be libgcc and libstdc++
this was fixed in deskflow-git (aur) and deskflow (arch extras)
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Align to distro packages
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
CI