### PR TITLE
fix(win): improve module name retrieval in findLoadedModule function

### DIFF
--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -15,6 +15,7 @@
 
 #include <Psapi.h>
 
+#include <algorithm>
 #include <array>
 #include <filesystem>
 #include <stdexcept>
@@ -409,15 +410,16 @@ HMODULE ArchMiscWindows::findLoadedModule(std::array<const char *, 2> moduleName
     abort();
   }
 
-  std::string loadedModuleName;
-  for (size_t i = 0; i < (cbNeeded / sizeof(HMODULE)); ++i) {
-    if (!GetModuleBaseNameA(hProcess, hModules[i], loadedModuleName.data(), sizeof(loadedModuleName))) {
+  const auto moduleCount = std::min<size_t>(cbNeeded / sizeof(HMODULE), hModules.size());
+  std::array<char, MAX_PATH> loadedModuleName;
+  for (size_t i = 0; i < moduleCount; ++i) {
+    if (!GetModuleBaseNameA(hProcess, hModules[i], loadedModuleName.data(), MAX_PATH)) {
       LOG_WARN("could not get base name of loaded module %d", i);
       continue;
     }
 
     for (const auto &moduleName : moduleNames) {
-      if (_stricmp((loadedModuleName.data()), moduleName) == 0) {
+      if (_stricmp(loadedModuleName.data(), moduleName) == 0) {
         return hModules[i];
       }
     }


### PR DESCRIPTION
## Description

`findLoadedModule` passed an empty `std::string`'s `data()` to `GetModuleBaseNameA` with
`sizeof(std::string)` (32) as the length, but the SSO buffer is 16, so long DLL names smashed the
stack. Now uses `std::array<char, MAX_PATH>`. Also clamped the loop bound, `cbNeeded` can exceed
the array.

## AI tools used for this PR

Claude Code (Claude Opus 5) - confirmed the bug, found the OOB read, wrote the fix.

## Fixed/related issues

fixes: #10021

## How has this been tested?

Smoke test on Windows
