### PR TITLE
fix: handle top-down DIB images in clipboard bitmap converter

### DIFF
--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -1,6 +1,7 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2004 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -72,6 +73,7 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   BITMAPINFOHEADER info;
   LONG w = bitmap->bmiHeader.biWidth;
   LONG h = bitmap->bmiHeader.biHeight;
+  const LONG absHeight = (h < 0) ? -h : h;
   info.biSize = sizeof(BITMAPINFOHEADER);
   info.biWidth = w;
   info.biHeight = h;
@@ -85,6 +87,12 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   info.biClrImportant = 0;
   HDC dc = GetDC(nullptr);
   HBITMAP dst = CreateDIBSection(dc, (BITMAPINFO *)&info, DIB_RGB_COLORS, &raw, nullptr, 0);
+  if (dst == nullptr || raw == nullptr) {
+    LOG_WARN("failed to allocate destination bitmap for clipboard image");
+    ReleaseDC(nullptr, dc);
+    GlobalUnlock(data);
+    return std::string();
+  }
 
   // find the start of the pixel data
   const char *srcBits = (const char *)bitmap + bitmap->bmiHeader.biSize;
@@ -103,14 +111,14 @@ std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
   // copy source image to destination image
   HDC dstDC = CreateCompatibleDC(dc);
   HGDIOBJ oldBitmap = SelectObject(dstDC, dst);
-  SetDIBitsToDevice(dstDC, 0, 0, w, h, 0, 0, 0, h, srcBits, bitmap, DIB_RGB_COLORS);
+  SetDIBitsToDevice(dstDC, 0, 0, w, absHeight, 0, 0, 0, absHeight, srcBits, bitmap, DIB_RGB_COLORS);
   SelectObject(dstDC, oldBitmap);
   DeleteDC(dstDC);
   GdiFlush();
 
   // extract data
   std::string image((const char *)&info, info.biSize);
-  image.append((const char *)raw, 4 * w * h);
+  image.append((const char *)raw, static_cast<size_t>(4) * static_cast<size_t>(w) * static_cast<size_t>(absHeight));
 
   // clean up GDI
   DeleteObject(dst);


### PR DESCRIPTION
## Description
A `BITMAPINFOHEADER` with negative `biHeight` (top-down DIB, legal per spec — produced by macOS/Retina clipboards and many screenshot tools) caused `std::length_error` crash in `toIClipboard()`. The signed product `4 * w * h` went negative and wrapped to a huge `size_t` in `string::append`, exceeding `max_size()`.

Changes in `MSWindowsClipboardBitmapConverter.cpp`:
- Compute `absHeight = abs(h)` and use it for the `SetDIBitsToDevice` scanline count and the pixel buffer size
- Use `static_cast<size_t>` arithmetic to prevent signed-to-unsigned overflow in the append call
- Add null check for `CreateDIBSection` to prevent a secondary crash if bitmap allocation fails

## AI tools used for this PR
opencode/mimo-v2.5 was used to help draft the code change. I reviewed and verified the logic myself.

## Fixed/related issues
fixes: #9869
Also related: #7329, #8597, #8625 (all reported the same `string too long` crash with negative biHeight)

## How has this been tested?
This is a Windows-only code path (`MSWindowsClipboardBitmapConverter`). I do not have a Windows + MSVC build environment available to compile/test locally. The fix is straightforward arithmetic (`abs()`) and the root cause is well-understood from the crash logs and DIB spec. Happy to iterate if a maintainer can test on Windows.