### PR TITLE
fix(mac): wake client display on remote entry

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -14,6 +14,7 @@
 
 #include <Carbon/Carbon.h>
 #include <IOKit/IOMessage.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
 #include <mach/mach_init.h>
 #include <mach/mach_interface.h>
 #include <mach/mach_port.h>
@@ -284,6 +285,7 @@ private:
   CondVar<bool> *m_pmThreadReady;
   CFRunLoopRef m_pmRunloop;
   io_connect_t m_pmRootPort;
+  IOPMAssertionID m_userActivityAssertionID = kIOPMNullAssertionID;
 
   // hot key stuff
   HotKeyMap m_hotKeys;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -802,13 +802,10 @@ void OSXScreen::enter()
     // reset buttons
     m_buttonState.reset();
 
-    // wakes the client screen
-    io_registry_entry_t entry =
-        IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
-
-    if (entry != MACH_PORT_NULL) {
-      IORegistryEntrySetCFProperty(entry, CFSTR("IORequestIdle"), kCFBooleanFalse);
-      IOObjectRelease(entry);
+    const auto result =
+        IOPMAssertionDeclareUserActivity(CFSTR("Deskflow client entry"), kIOPMUserActiveLocal, &m_userActivityAssertionID);
+    if (result != kIOReturnSuccess) {
+      LOG_WARN("failed to declare user activity: %d", result);
     }
 
     avoidSupression();


### PR DESCRIPTION

## Description
<!--- Describe what your changes do -->
Added support for waking the display on a client when the mouse enters for newer MacOS versions. 

Currently the `IORequestIdle=false` does not wake the display on my MacOS 26.6 machine when the mouse enters the screen, I have to move the mouse into the dark monitor and then press a keyboard key to wake it. 

This small change preserves that behavior and adds an `IOPMAssertionDeclareUserActivity` call  with `kIOPMUserActiveRemote`. 

I moved `IORequestIdle=false` into a new function OSXPowerManager::wakeDisplay() in so it can cleanly handle both calls. Now OSXScreen::enter() delegates display waking to OSXPowerManager::wakeDisplay() which handles the new API call and the legacy call. 

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
I used GPT 5.6 Sol to teach me about the repo and code base, and assist with implementation. 

I used Opus 5 and GPT 5.6 Terra to run multiple parallel review rounds to find issues and defects. 

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #10020

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->

Added unit tests, and I cut a local build from the production release with my changes in it and have been running it on my client and its been working reliably for me. 

Would be good to verify this still works on older MacOS machines before release if possible, but I tried to keep the change minimal and conservative so it should work. 