### PR TITLE
Move server external config to advanced tab

### DIFF
--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -42,11 +42,6 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->lblNewScreen->setPixmap(QIcon::fromTheme("video-display").pixmap(QSize(64, 64)));
   ui->btnBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
 
-  if (ui->groupExternalConfig->isChecked())
-    ui->tabWidget->setCurrentIndex(3);
-  else
-    ui->tabWidget->setCurrentIndex(0);
-
   if (!deskflow::platform::isWindows())
     ui->cbWin32KeepForeground->setVisible(false);
   initConnections();

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -42,9 +42,10 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->lblNewScreen->setPixmap(QIcon::fromTheme("video-display").pixmap(QSize(64, 64)));
   ui->btnBrowseConfigFile->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentOpen));
 
-  // force the first tab, since qt creator sets the active tab as the last one
-  // the developer was looking at, and it's easy to accidentally save that.
-  ui->tabWidget->setCurrentIndex(0);
+  if (ui->groupExternalConfig->isChecked())
+    ui->tabWidget->setCurrentIndex(3);
+  else
+    ui->tabWidget->setCurrentIndex(0);
 
   if (!deskflow::platform::isWindows())
     ui->cbWin32KeepForeground->setVisible(false);

--- a/src/lib/gui/dialogs/ServerConfigDialog.ui
+++ b/src/lib/gui/dialogs/ServerConfigDialog.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Server Configuration</string>
   </property>
-  <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <widget class="QWidget" name="tabComputers">
@@ -763,85 +763,18 @@
          </layout>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabConfigFile">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <attribute name="title">
-       <string>Config file</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="topMargin">
-        <number>20</number>
-       </property>
        <item>
-        <widget class="QLabel" name="label_5">
-         <property name="font">
-          <font>
-           <pointsize>18</pointsize>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Core server config file</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::TextFormat::PlainText</enum>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
+        <widget class="QGroupBox" name="groupExternalConfig">
+         <property name="toolTip">
           <string>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::TextFormat::MarkdownText</enum>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Maximum</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>30</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupExternalConfig">
          <property name="title">
           <string>Use a server config file</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -943,19 +876,6 @@ Enabling this setting will disable the server config GUI.</string>
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_1">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1068,14 +1068,6 @@ Además, verifique que puede %1 el archivo de configuración del servidor: %2</t
         <translation type="unfinished">Activar doble &amp;toque dentro</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation type="unfinished">Archivo de configuración</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation type="unfinished">Archivo de configuración del servidor principal</translation>
-    </message>
-    <message>
         <source>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</source>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1068,14 +1068,6 @@ Inoltre, verifica di poter %1 il file di configurazione del server: %2</translat
         <translation>Passa al doppio &amp;tap entro</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation>File di configurazione</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation>File di configurazione principale del server</translation>
-    </message>
-    <message>
         <source>Use a server config file</source>
         <translation>Utilizza un file di configurazione del server</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1070,14 +1070,6 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>指定時間内に画面端ダブルタップで移動(&amp;T)</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation>設定ファイル</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation>Coreサーバー設定ファイル</translation>
-    </message>
-    <message>
         <source>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</source>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1068,14 +1068,6 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>지정 시간 내 더블 탭으로 전환(&amp;T)</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation>설정 파일</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation>코어 서버 설정 파일</translation>
-    </message>
-    <message>
         <source>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</source>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1068,14 +1068,6 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>Переключать по двойному &amp;касанию за</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation>Файл конфигурации</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation>Файл конфигурации ядра сервера</translation>
-    </message>
-    <message>
         <source>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</source>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1070,14 +1070,6 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>在指定时间内双击切换(&amp;T)</translation>
     </message>
     <message>
-        <source>Config file</source>
-        <translation>配置文件</translation>
-    </message>
-    <message>
-        <source>Core server config file</source>
-        <translation>核心服务器配置文件</translation>
-    </message>
-    <message>
         <source>Use a server config file to create complex computer layouts that are not possible with the simple grid-based computer layout editor.
 
 Enabling this setting will disable the server config GUI.</source>


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
  - Moves the options for external config file to the server dialog's advanced tab 
     - Retain the note as a tooltip for the section. 
  - Removes the Config file tab
  - Remove the forced setting of servers tab widget to 0 allowing to be set to "Advanced" if the Computers tab is disabled. 

<img width="50%" height="50%" alt="Screenshot_20260805_221538" src="https://github.com/user-attachments/assets/b4f757d9-ddb3-4881-b606-8dca66e169be" />
<img width="50%" height="50%" alt="Screenshot_20260805_221719" src="https://github.com/user-attachments/assets/fad98b4b-39c3-4d67-bca1-1e0958bd5074" />

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Currently we open to the "Computers" tab if an external file is in use 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally