### PR TITLE
refactor: ensure tabwidgets start at index 0

### DIFF
--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -34,6 +34,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
       m_screenSetupModel(m_serverConfig.screens(), m_columns, m_rows)
 {
   ui->setupUi(this);
+  ui->tabWidget->setCurrentIndex(0);
 
   loadFromConfig();
 

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -31,6 +31,7 @@ SettingsDialog::SettingsDialog(QWidget *parent, const ServerConfig &serverConfig
 {
 
   ui->setupUi(this);
+  ui->tabWidget->setCurrentIndex(0);
 
   // these are enabled by the control next to them
   ui->lineCommandEnter->setEnabled(false);


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Ensure both our tab widgets start at index 0 under normal conditions
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
 None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
`.ui` files can inject the current tab index if carelessly edited
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally