### PR TITLE
fix: use ASCII-capable layout when an input method is active on macOS

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -297,7 +297,26 @@ KeyButton OSXKeyState::mapKeyFromEvent(KeyIDs &ids, KeyModifierMask *maskOut, CG
   CFDataRef ref = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_tisMutex);
-    currentKeyboardLayout = AutoTISInputSourceRef(TISCopyCurrentKeyboardLayoutInputSource(), CFRelease);
+    // When an input method is active (Chinese, Japanese, Korean, ...) the
+    // current keyboard layout is the input method's companion layout, which
+    // maps the physical keys to marks such as Bopomofo rather than to Latin
+    // characters. Translating with it produces key IDs the client cannot type,
+    // so the keystroke is silently lost. The input method belongs to this
+    // computer only -- the client runs its own -- so translate with the
+    // ASCII-capable layout, which is what the physical keys are engraved with.
+    // Plain non-Latin layouts (Cyrillic, Greek, ...) are reported as keyboard
+    // layouts, not input modes, and keep their existing behaviour.
+    bool inputMethodActive = false;
+    if (AutoTISInputSourceRef currentInputSource(TISCopyCurrentKeyboardInputSource(), CFRelease); currentInputSource) {
+      auto type = (CFStringRef)TISGetInputSourceProperty(currentInputSource.get(), kTISPropertyInputSourceType);
+      inputMethodActive = (type != nullptr) && !CFEqual(type, kTISTypeKeyboardLayout);
+    }
+
+    currentKeyboardLayout = AutoTISInputSourceRef(
+        inputMethodActive ? TISCopyCurrentASCIICapableKeyboardLayoutInputSource()
+                          : TISCopyCurrentKeyboardLayoutInputSource(),
+        CFRelease
+    );
     if (currentKeyboardLayout)
       ref = (CFDataRef)TISGetInputSourceProperty(currentKeyboardLayout.get(), kTISPropertyUnicodeKeyLayoutData);
   }
@@ -332,7 +351,7 @@ KeyButton OSXKeyState::mapKeyFromEvent(KeyIDs &ids, KeyModifierMask *maskOut, CG
   }
 
   // translate via uchr resource
-  const UCKeyboardLayout *layout = (const UCKeyboardLayout *)CFDataGetBytePtr(ref);
+  const UCKeyboardLayout *layout = ref ? (const UCKeyboardLayout *)CFDataGetBytePtr(ref) : nullptr;
   const bool layoutValid = (layout != nullptr);
 
   if (layoutValid) {


### PR DESCRIPTION
## Description

While an input method is active on macOS, `TISCopyCurrentKeyboardLayoutInputSource()` returns the input method's *companion* keyboard layout. For CJK input methods that layout maps the physical keys to marks such as Bopomofo, so `UCKeyTranslate()` succeeds but produces key IDs the client cannot type. The keystroke is therefore silently lost — it is mistranslated rather than dropped.

Measured on macOS 26.6 with Traditional Chinese Zhuyin selected:

| API | returns | type | has uchr |
|---|---|---|---|
| `TISCopyCurrentKeyboardInputSource()` | `com.apple.inputmethod.TCIM.Zhuyin` | `TISTypeKeyboardInputMode` | no |
| `TISCopyCurrentKeyboardLayoutInputSource()` | `com.apple.keylayout.ZhuyinBopomofo` | `TISTypeKeyboardLayout` | **yes** |
| `TISCopyCurrentASCIICapableKeyboardLayoutInputSource()` | `com.apple.keylayout.ABC` | `TISTypeKeyboardLayout` | yes |

Because the Bopomofo layout does carry Unicode key layout data, existing null checks never trigger.

The input method belongs to the server only — the client runs its own — so `mapKeyFromEvent()` now translates with the ASCII-capable layout whenever the current input source is an input *mode* rather than a keyboard *layout*. That keeps the change narrow: plain non-Latin layouts (Cyrillic, Greek, ...) report `kTISTypeKeyboardLayout`, so their behaviour and their reliance on language sync are unchanged.

Also guards `CFDataGetBytePtr()` against a null `CFDataRef`, which is reachable whenever the selected layout carries no Unicode key layout data.

## AI tools used for this PR

Claude Opus 5, via Claude Code. It read the key-translation path, proposed an initial hypothesis (that keys were dropped because the layout had no `uchr` data), disproved that hypothesis by writing a small probe against the TIS APIs — which produced the table above — then wrote the patch and drafted this description.

I directed the investigation, decided on the approach, and did all testing on my own hardware. I have reviewed the diff and understand it.

## Fixed/related issues

Related: #6599

This addresses the macOS-server-with-input-method symptom reported in #8575, #9332 and #8899, which were closed as duplicates of #6599. It does not claim to close #6599, which covers keyboard language handling more broadly.

## How has this been tested?

Built from this branch and installed as the server on my own machine, then verified interactively.

- **Server:** macOS 26.6, Apple silicon, input sources ABC + Traditional Chinese Zhuyin
- **Client:** Windows 11, stock Deskflow 1.26.0, protocol v1.8 (unmodified)

Before the change, selecting Zhuyin on the server meant no keystroke at all reached the client; switching back to ABC restored typing. After the change, typing on the client works with either input source selected, and switching between them mid-session needs no action.

`ctest` passes 26/26, including `OSXKeyStateTests`. `clang-format` reports no changes.
