### PR TITLE
fix(mac): prevent tray crash on macOS 27

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -687,6 +687,9 @@ void MainWindow::setupTrayIcon()
   );
   trayMenu->insertSeparator(m_actionMinimize);
   trayMenu->insertSeparator(m_actionTrayQuit);
+#ifdef Q_OS_MACOS
+  installMacOS27TrayWorkaround();
+#endif
   m_trayIcon->setContextMenu(trayMenu);
 
   setTrayIcon();

--- a/src/lib/gui/OSXHelpers.h
+++ b/src/lib/gui/OSXHelpers.h
@@ -16,4 +16,5 @@ bool showOSXNotification(const QString &title, const QString &body);
 bool isOSXInterfaceStyleDark();
 void forceAppActive();
 void macOSNativeHide();
+void installMacOS27TrayWorkaround();
 void installQuitHandler(std::function<bool()> shouldQuit);

--- a/src/lib/gui/OSXHelpers.mm
+++ b/src/lib/gui/OSXHelpers.mm
@@ -115,6 +115,28 @@ void macOSNativeHide()
   [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
 }
 
+static void ignoreStatusItemMenuActivation(id, SEL, NSNotification *)
+{
+}
+
+void installMacOS27TrayWorkaround()
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 2)
+  // QTBUG-147449: macOS 27 drives status items with gesture recognizers,
+  // so NSApp.currentEvent can be a non-mouse event when a tray menu opens.
+  // Qt <= 6.11.1 unconditionally reads clickCount and aborts the process.
+  // Deskflow does not consume tray activation signals on macOS, so suppress
+  // only Qt's private menu-tracking callback until the upstream fix ships.
+  if (![NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:{27, 0, 0}])
+    return;
+
+  const auto delegateClass = objc_getClass("QStatusItemDelegate");
+  const auto selector = @selector(statusItemMenuBeganTracking:);
+  if (const auto method = class_getInstanceMethod(delegateClass, selector); method != nullptr)
+    method_setImplementation(method, reinterpret_cast<IMP>(ignoreStatusItemMenuActivation));
+#endif
+}
+
 static NSApplicationTerminateReply deskflow_applicationShouldTerminate(id self, SEL _cmd, NSApplication *sender)
 {
   // Don't intercept a system shutdown (or logoff/restart)


### PR DESCRIPTION
## Summary

- prevent Deskflow from aborting when its tray menu opens on macOS 27
- scope the workaround to macOS 27 and Qt versions older than 6.11.2
- suppress only Qt's private tray menu activation callback; Deskflow does not consume tray activation signals on macOS, so the tray menu behavior is preserved

## Root cause

On macOS 27, status items are driven by gesture recognizers. By the time Qt handles the status-item callback, `NSApp.currentEvent` can be a non-mouse `NSEvent`. Qt 6.11.1 still asks that event for `clickCount`, which raises `NSInternalInconsistencyException` and aborts Deskflow.

Qt fixed this upstream in qt/qtbase@65020b43cdd2c923c42ac4bc894c967ac90a0477 (QTBUG-147449), with picks requested for 6.11, 6.12, and 6.8. This guarded workaround covers current affected Deskflow builds and compiles out once building with Qt 6.11.2 or newer.

This differs from the workaround proposed in #9957: it does not swizzle global `NSEvent` accessors. It replaces only `QStatusItemDelegate`'s unused `statusItemMenuBeganTracking:` implementation on affected systems.

Refs #9835.

## Validation

- reproduced the crash on macOS 27 with unmodified Deskflow master: one tray click aborted with `NSInternalInconsistencyException` from `-[NSEvent clickCount]` via `QStatusItemDelegate statusItemMenuBeganTracking:`
- replayed the same captured tray coordinate seven times against the patched packaged app; it stayed alive and the menu remained functional
- built successfully with Xcode 27 beta and Qt 6.11.1
- all 26 unit tests passed
- packaged app passed deep strict code-signature verification and contained no Homebrew or user-path dynamic-library references
