### PR TITLE
fix: prevent modifier keys from being stuck (Windows)

### DIFF
--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -10,6 +10,9 @@
 #include "base/Log.h"
 #include "deskflow/ScreenException.h"
 
+#include <cstring>
+#include <mutex>
+
 #ifndef WM_MOUSEHWHEEL
 #define WM_MOUSEHWHEEL 0x020E
 #endif
@@ -34,6 +37,8 @@ static WPARAM g_deadRelease = 0;
 static LPARAM g_deadLParam = 0;
 static BYTE g_deadKeyState[256] = {0};
 static BYTE g_keyState[256] = {0};
+static bool g_keyStateValid = false;
+static std::mutex g_keyStateMutex;
 static DWORD g_hookThread = 0;
 static bool g_fakeServerInput = false;
 static BOOL g_isPrimary = TRUE;
@@ -142,6 +147,15 @@ void MSWindowsHook::setMode(EHookMode mode)
   g_mode = mode;
 }
 
+bool MSWindowsHook::getPhysicalKeyState(BYTE keys[256])
+{
+  std::lock_guard<std::mutex> lock(g_keyStateMutex);
+  if (g_keyStateValid) {
+    std::memcpy(keys, g_keyState, sizeof(g_keyState));
+  }
+  return g_keyStateValid;
+}
+
 static void keyboardGetState(BYTE keys[256], DWORD vkCode, bool kf_up)
 {
   // we have to use GetAsyncKeyState() rather than GetKeyState() because
@@ -151,6 +165,8 @@ static void keyboardGetState(BYTE keys[256], DWORD vkCode, bool kf_up)
   if (vkCode < 0 || vkCode >= 256) {
     return;
   }
+
+  std::lock_guard<std::mutex> lock(g_keyStateMutex);
 
   // Keep track of key state on our own in case GetAsyncKeyState() fails
   g_keyState[vkCode] = kf_up ? 0 : 0x80;
@@ -179,6 +195,7 @@ static void keyboardGetState(BYTE keys[256], DWORD vkCode, bool kf_up)
 
   key = GetKeyState(VK_CAPITAL);
   keys[VK_CAPITAL] = (BYTE)(((key < 0) ? 0x80 : 0) | (key & 1));
+  g_keyStateValid = true;
 }
 
 static WPARAM makeKeyMsg(UINT virtKey, WCHAR wc, bool noAltGr)
@@ -240,16 +257,16 @@ static bool keyboardHookHandler(WPARAM wParam, LPARAM lParam)
   // tell server about event
   PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam, lParam);
 
-  // ignore dead key release
+  // we need the keyboard state for ToAscii()
+  BYTE keys[256];
+  keyboardGetState(keys, vkCode, kf_up);
+
+  // Update the physical state before ignoring a dead key release so it cannot remain down in the resync snapshot.
   if ((g_deadVirtKey == wParam || g_deadRelease == wParam) && (lParam & 0x80000000u) != 0) {
     g_deadRelease = 0;
     PostThreadMessage(g_threadID, DESKFLOW_MSG_DEBUG, wParam | 0x04000000, lParam);
     return false;
   }
-
-  // we need the keyboard state for ToAscii()
-  BYTE keys[256];
-  keyboardGetState(keys, vkCode, kf_up);
 
   // ToAscii() maps ctrl+letter to the corresponding control code
   // and ctrl+backspace to delete.  we don't want those translations
@@ -670,6 +687,10 @@ int MSWindowsHook::uninstall()
     UnhookWindowsHookEx(g_getMessage);
     g_getMessage = nullptr;
   }
+
+  std::lock_guard<std::mutex> lock(g_keyStateMutex);
+  std::memset(g_keyState, 0, sizeof(g_keyState));
+  g_keyStateValid = false;
 
   return 1;
 }

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -62,6 +62,9 @@ public:
 
   void setMode(EHookMode mode);
 
+  //! Copy the hook's physical key state; false until it has observed an event.
+  static bool getPhysicalKeyState(BYTE keys[256]);
+
   static EHookResult install();
 
   static int uninstall();

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -13,6 +13,7 @@
 #include "common/Constants.h"
 #include "platform/MSWindowsDesks.h"
 #include "platform/MSWindowsHandle.h"
+#include "platform/MSWindowsHook.h"
 
 // extended mouse buttons
 #if !defined(VK_XBUTTON1)
@@ -844,7 +845,8 @@ int32_t MSWindowsKeyState::pollActiveGroup() const
 void MSWindowsKeyState::pollPressedKeys(KeyButtonSet &pressedKeys) const
 {
   BYTE keyState[256];
-  if (!GetKeyboardState(keyState)) {
+  // The caller's GetKeyboardState queue can lag the low-level hook during a screen switch.
+  if (!MSWindowsHook::getPhysicalKeyState(keyState) && !GetKeyboardState(keyState)) {
     LOG_WARN("keyboard state is unexpected");
     LOG_DEBUG("function 'GetKeyboardState' returned false on 'pollPressedKeys'");
     return;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -1119,7 +1119,13 @@ bool MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
     // process key
     KeyModifierMask mask;
     KeyID key = m_keyState->mapKeyFromEvent(wParam, lParam, &mask);
-    button = static_cast<KeyButton>((lParam & 0x01ff0000u) >> 16);
+    const KeyButton mappedButton = static_cast<KeyButton>((lParam & 0x01ff0000u) >> 16);
+    if (mappedButton != 0) {
+      // Ctrl+Alt+Del emulation deliberately substitutes its button in lParam.
+      // Otherwise retain the virtual-key fallback above for malformed input
+      // that has no scan code, so its key-up matches the key-down on clients.
+      button = mappedButton;
+    }
     if (key != kKeyNone) {
       // do it
       m_keyState->sendKeyEvent(

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -1087,7 +1087,9 @@ bool MSWindowsScreen::onKey(WPARAM wParam, LPARAM lParam)
   }
 
   // stop sending modifier keys over and over again
-  if (isModifierRepeat(oldState, state, wParam)) {
+  // but allow up to be sent if the previous state was down
+  // to prevent stuck modifier keys on the client
+  if (down && wasDown && isModifierRepeat(oldState, state, wParam)) {
     return true;
   }
 


### PR DESCRIPTION
## Description

How to reproduce
- Hold LCTRL down on the client and move your mouse offscreen
- Release lctrl when you're on your host and click once
- Return to the client screen with your mouse
- CTRL is still down, up was never received, or it was received but for the wrong key, or it was received but then another down came in 

The modifier keys got stuck for several reasons, basically a bunch of stuck keys in different places:


1. a modifier up on Windows was discarded in a defensive fix 
2. some malformed windows events with scan code 0 figured out the button but then sent button id 0 anyway
3. GetKeyboardState() lagged behind the actual physical state somehow and reported ctrl as being down after the windows hook changed it to up

The PR guards for down repeat events specifically so up can still get through in 1), preserves the figured out button in 2) and gets the physical state from the windows hook with a lock for safety to handle 3)

I haven't seen or written C++ since high school, so I don't know if there are better solutions to these, but after many hours of testing I needed all 3 solutions to fully make it stop happening.

All fixes were made after logs confirmed them happening, though some were rare to happen

## AI tools used for this PR

Codex 5.6 Terra in vscode extension

I used it to:
- investigate the debug and verbose logs 
- add more debug logs in relevant places since verbose made it unusable, 
- search & explain the codebase
- write code
- build the flatpak and windows portable versions so I can actually test it out 

## Fixed/related issues



## How has this been tested?

With blood, sweat, tears, and an entire day lost. I have tested this for many hours with different combinations of fixes.

Just to sanity check, I switched to the unfixed version again and it immediately happened. I could consistently reproduce it with the steps above.
