### PR TITLE
fix: prevent stuck keys on x11 client

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1903,6 +1903,11 @@ void XWindowsScreen::refreshKeyboard(XEvent *event)
     }
   }
 
+  // a later key up after the refresh doesn't properly release modifiers
+  if (!m_isPrimary) {
+    m_keyState->fakeAllKeysUp();
+  }
+
   // keyboard mapping changed
 #if HAVE_XKB_EXTENSION
   if (m_xkb && event->type == m_xkbEventBase) {


### PR DESCRIPTION
## Description
Releases the keys before the x11 keyboard map can refresh to avoid having the up fail

## AI tools used for this PR
Codex 5.6 Terra in vscode extension

I used it to:

    investigate the debug and verbose logs
    add more debug logs in relevant places since verbose made it unusable,
    search & explain the codebase
    write code
    build the flatpak and windows portable versions so I can actually test it out

## Fixed/related issues
fixes: https://github.com/deskflow/deskflow/issues/9011
But the issue might be better split per host as the code is different so the fix is probably different too 

## How has this been tested?
This was tested in combination with this pull request https://github.com/deskflow/deskflow/pull/10041 

It would be great if someone on an x11 or wayland host can get some verbose logs of the time this issue happens. Or maybe we could add some debug logs in this PR temporarily so the CI can be used for testing?
