### PR TITLE
refactor: no need to call setAppId for gui as the App does it on its own

### DIFF
--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -52,7 +52,8 @@ int main(int argc, char *argv[])
 #endif
 
 #if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
-  deskflow::platform::setAppId();
+  if (QT_VERSION < QT_VERSION_CHECK(6, 10, 0))
+    deskflow::platform::setAppId();
 #endif
 
   QCoreApplication::setApplicationName(kAppName);


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Only call `setAppId` in deskflow-gui when we are using a Qt version < 6.10
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Removes the warning on start up `WARNING: Failed to register with host portal QDBusError("org.freedesktop.portal.Error.Failed", "Could not register app ID: Connection already associated with an 
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local test