### PR TITLE
Add read only messages

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -246,6 +246,8 @@ NetworkProtocol Settings::networkProtocol()
 
 void Settings::save(bool emitSaving)
 {
+  if (!isWritable())
+    qWarning().noquote() << "settings not saved, file is read-only:" << settingsFile();
   if (emitSaving)
     Q_EMIT instance()->serverSettingsChanged();
   instance()->m_settings->sync();

--- a/src/lib/gui/Messages.cpp
+++ b/src/lib/gui/Messages.cpp
@@ -205,6 +205,17 @@ bool showNewClientPrompt(QWidget *parent, const QString &clientName)
   return message.buttonRole(message.clickedButton()) == QMessageBox::AcceptRole;
 }
 
+void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath)
+{
+  const auto title = QObject::tr("%1 Read-only settings").arg(kAppName);
+  const auto message = QObject::tr(
+                           "<p>Settings are read-only because you only have read access "
+                           "to the file:</p><p>%1</p>"
+  )
+                           .arg(QDir::toNativeSeparators(systemSettingsPath));
+  QMessageBox::information(parent, title, message);
+}
+
 bool showUpdateCheckOption(QWidget *parent)
 {
   QMessageBox message(parent);

--- a/src/lib/gui/Messages.h
+++ b/src/lib/gui/Messages.h
@@ -27,6 +27,8 @@ void showCloseReminder(QWidget *parent);
 
 bool showNewClientPrompt(QWidget *parent, const QString &clientName);
 
+void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
+
 bool showUpdateCheckOption(QWidget *parent);
 
 bool showDaemonOffline(QWidget *parent);

--- a/src/lib/gui/dialogs/ClientConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ClientConfigDialog.cpp
@@ -7,6 +7,7 @@
 #include "ClientConfigDialog.h"
 #include "ui_ClientConfigDialog.h"
 
+#include "Messages.h"
 #include "common/Settings.h"
 
 #include <QPushButton>
@@ -32,6 +33,12 @@ void ClientConfigDialog::changeEvent(QEvent *e)
     ui->retranslateUi(this);
     updateText();
   }
+}
+
+void ClientConfigDialog::showEvent(QShowEvent *event)
+{
+  QDialog::showEvent(event);
+  Q_EMIT shown();
 }
 
 void ClientConfigDialog::updateText() const
@@ -60,6 +67,7 @@ void ClientConfigDialog::initConnections() const
   connect(ui->sbYScrollScale, &QDoubleSpinBox::valueChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->cbXScrollInvert, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->sbXScrollScale, &QDoubleSpinBox::valueChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
+  connect(this, &ClientConfigDialog::shown, this, &ClientConfigDialog::showReadOnlyMessage, Qt::QueuedConnection);
 }
 
 bool ClientConfigDialog::isModified() const
@@ -121,4 +129,11 @@ void ClientConfigDialog::save()
   Settings::setValue(Settings::Client::InvertXScroll, ui->cbXScrollInvert->isChecked());
   Settings::setValue(Settings::Client::XScrollScale, ui->sbXScrollScale->value());
   QDialog::accept();
+}
+
+void ClientConfigDialog::showReadOnlyMessage()
+{
+  if (Settings::isWritable())
+    return;
+  deskflow::gui::messages::showReadOnlySettings(this, Settings::settingsFile());
 }

--- a/src/lib/gui/dialogs/ClientConfigDialog.h
+++ b/src/lib/gui/dialogs/ClientConfigDialog.h
@@ -27,7 +27,12 @@ public:
 protected:
   void changeEvent(QEvent *e) override;
 
+Q_SIGNALS:
+  void shown();
+
 private:
+  void showEvent(QShowEvent *event) override;
+
   /**
    * @brief updateText update widget text
    */
@@ -71,6 +76,8 @@ private:
    * @brief save to settings and then calls QDialog::accept
    */
   void save();
+
+  void showReadOnlyMessage();
 
   Ui::ClientConfigDialog *ui = nullptr;
 };

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ServerConfigDialog.h"
+#include "Messages.h"
 #include "ui_ServerConfigDialog.h"
 
 #include "common/Constants.h"
@@ -498,6 +499,21 @@ void ServerConfigDialog::initConnections() const
   );
   connect(ui->cbDisableLockToComputer, &QCheckBox::toggled, this, &ServerConfigDialog::toggleLockToComputer);
   connect(&m_screenSetupModel, &ScreenSetupModel::screensChanged, this, &ServerConfigDialog::onChange);
+  connect(this, &ServerConfigDialog::shown, this, &ServerConfigDialog::showReadOnlyMessage, Qt::QueuedConnection);
+}
+
+void ServerConfigDialog::showEvent(QShowEvent *event)
+{
+  QDialog::showEvent(event);
+  Q_EMIT shown();
+}
+
+void ServerConfigDialog::showReadOnlyMessage()
+{
+  const QFile file = QFile(Settings::serverConfigFile());
+  if (!file.isWritable())
+    return;
+  deskflow::gui::messages::showReadOnlySettings(this, Settings::serverConfigFile());
 }
 
 bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -510,10 +510,13 @@ void ServerConfigDialog::showEvent(QShowEvent *event)
 
 void ServerConfigDialog::showReadOnlyMessage()
 {
-  const QFile file = QFile(Settings::serverConfigFile());
-  if (!file.isWritable())
+
+  if (const auto file = QFile(Settings::serverConfigFile()); file.isWritable() && Settings::isWritable())
     return;
-  deskflow::gui::messages::showReadOnlySettings(this, Settings::serverConfigFile());
+
+  deskflow::gui::messages::showReadOnlySettings(
+      this, QStringLiteral("%1 and %2").arg(Settings::serverConfigFile(), Settings::settingsFile())
+  );
 }
 
 bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -29,6 +29,9 @@ public:
   ~ServerConfigDialog() override;
   bool addClient(const QString &clientName);
 
+Q_SIGNALS:
+  void shown();
+
 public Q_SLOTS:
   void accept() override;
   void reject() override;
@@ -92,6 +95,8 @@ protected:
 private:
   void loadFromConfig();
   void initConnections() const;
+  void showEvent(QShowEvent *event) override;
+  void showReadOnlyMessage();
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";
   int m_columns;

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -13,6 +13,7 @@
 
 #include "common/I18N.h"
 #include "common/Settings.h"
+#include "gui/Messages.h"
 #include "gui/TlsUtility.h"
 #include "gui/core/NetworkMonitor.h"
 
@@ -198,11 +199,7 @@ void SettingsDialog::showReadOnlyMessage()
 {
   if (Settings::isWritable())
     return;
-  QMessageBox::information(
-      this, tr("%1 Read-only settings").arg(kAppName),
-      tr("<p>Settings are read-only because you only have read access to the file:</p><p>%1</p>")
-          .arg(QDir::toNativeSeparators(Settings::settingsFile()))
-  );
+  messages::showReadOnlySettings(this, Settings::settingsFile());
 }
 
 void SettingsDialog::resetAllSettings()

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -701,6 +701,14 @@ Además, verifique que puede %1 el archivo de configuración del servidor: %2</t
         <translation type="unfinished">Un nuevo cliente llamado &apos;%1&apos; quiere conectarse</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation type="unfinished">%1 Configuración de solo lectura</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation type="unfinished">&lt;p&gt;Las configuraciones son de solo lectura porque solo tiene acceso de lectura al archivo:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation type="unfinished">No, gracias</translation>
     </message>
@@ -1158,14 +1166,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Configuración de solo lectura</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Las configuraciones son de solo lectura porque solo tiene acceso de lectura al archivo:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -701,6 +701,14 @@ Inoltre, verifica di poter %1 il file di configurazione del server: %2</translat
         <translation>Un nuovo client chiamato &quot;%1&quot; vuole connettersi</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation>%1 Impostazioni di sola lettura</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Le impostazioni sono di sola lettura perché hai solo accesso in lettura al file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation>No, grazie</translation>
     </message>
@@ -1158,14 +1166,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Impostazioni di sola lettura</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Le impostazioni sono di sola lettura perché hai solo accesso in lettura al file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -703,6 +703,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>新しいクライアント &apos;%1&apos; が接続を求めています</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation>%1 読み取り専用設定</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;p&gt;以下のファイルへの書き込み権限がないため、設定は読み取り専用です:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation>不要です</translation>
     </message>
@@ -1184,14 +1192,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 読み取り専用設定</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;以下のファイルへの書き込み権限がないため、設定は読み取り専用です:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -701,6 +701,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>새 클라이언트 &apos;%1&apos;이(가) 연결을 요청합니다</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation>%1 읽기 전용 설정</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;p&gt;다음 파일에 대한 쓰기 권한이 없어 설정이 읽기 전용입니다:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation>아니요</translation>
     </message>
@@ -1182,14 +1190,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 읽기 전용 설정</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;다음 파일에 대한 쓰기 권한이 없어 설정이 읽기 전용입니다:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -701,6 +701,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>Новый клиент &apos;%1&apos; хочет подключиться</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation>%1 Настройки только для чтения</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Настройки доступны только для чтения, так как у вас есть доступ только на чтение к файлу:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation>Нет, спасибо</translation>
     </message>
@@ -1180,14 +1188,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Настройки только для чтения</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Настройки доступны только для чтения, так как у вас есть доступ только на чтение к файлу:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -703,6 +703,14 @@ Additionally, check you are able to %1 the server config file: %2</source>
         <translation>名为“%1”的新客户端请求连接</translation>
     </message>
     <message>
+        <source>%1 Read-only settings</source>
+        <translation>%1 只读设置</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;p&gt;设置是只读的，因为您对该文件只有读取权限：&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
         <source>No thanks</source>
         <translation>不，谢谢</translation>
     </message>
@@ -1184,14 +1192,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 只读设置</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;设置是只读的，因为您对该文件只有读取权限：&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Revert #10034 
 - Use `deskflow::gui::message::showReadOnlyMessage` in Client Config Dialog 
 - Use `deskflow::gui::message::showReadOnlyMessage` in Server Settings Dialog 
 - Settings Warn on save if not writable
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #10047
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally