### PR TITLE
Better readonly settings

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -12,6 +12,7 @@
 
 #include <QCoreApplication>
 #include <QFile>
+#include <QFileSystemWatcher>
 #include <QRect>
 #include <QRegularExpression>
 #include <QStandardPaths>
@@ -32,7 +33,9 @@ void Settings::setSettingsFile(const QString &settingsFile)
   if (instance()->m_settings)
     instance()->m_settings->deleteLater();
 
+  instance()->m_settingsWatcher->removePath(instance()->m_settings->fileName());
   instance()->m_settings = new QSettings(settingsFile, QSettings::IniFormat, instance());
+  instance()->m_settingsWatcher->addPath(settingsFile);
   instance()->m_settingsProxy->load(settingsFile);
   qInfo().noquote() << "settings file changed:" << instance()->m_settings->fileName();
 
@@ -40,6 +43,7 @@ void Settings::setSettingsFile(const QString &settingsFile)
   instance()->cleanSettings();
   instance()->cleanStateSettings();
   instance()->setupComputerName();
+  instance()->checkIfSettingsWritableChange();
 }
 
 void Settings::setStateFile(const QString &stateFile)
@@ -56,7 +60,7 @@ void Settings::setStateFile(const QString &stateFile)
   qInfo().noquote() << "state file changed:" << instance()->m_stateSettings->fileName();
 }
 
-Settings::Settings(QObject *parent) : QObject(parent)
+Settings::Settings(QObject *parent) : QObject(parent), m_settingsWatcher{new QFileSystemWatcher(this)}
 {
   QString fileToLoad;
 #ifdef Q_OS_WIN
@@ -76,6 +80,9 @@ Settings::Settings(QObject *parent) : QObject(parent)
     fileToLoad = UserSettingFile;
 
   m_settings = new QSettings(fileToLoad, QSettings::IniFormat, this);
+  m_settingsWritable = m_settings->isWritable();
+  m_settingsWatcher->addPath(m_settings->fileName());
+  connect(m_settingsWatcher, &QFileSystemWatcher::fileChanged, this, &Settings::checkIfSettingsWritableChange);
   m_settingsProxy = std::make_shared<QSettingsProxy>();
   m_settingsProxy->load(fileToLoad);
   qInfo().noquote() << "initial settings file:" << m_settings->fileName();
@@ -165,6 +172,15 @@ QString Settings::cleanComputerName(const QString &name)
     cleanName = cleanComputerName(cleanName);
   }
   return cleanName;
+}
+
+void Settings::checkIfSettingsWritableChange() const
+{
+  bool writable = m_settings->isWritable();
+  if (writable == m_settingsWritable)
+    return;
+  instance()->m_settingsWritable = writable;
+  Q_EMIT instance()->settingsWritableChanged(writable);
 }
 
 QVariant Settings::defaultValue(const QString &key)

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -174,11 +174,15 @@ QString Settings::cleanComputerName(const QString &name)
   return cleanName;
 }
 
-void Settings::checkIfSettingsWritableChange() const
+void Settings::checkIfSettingsWritableChange()
 {
-  bool writable = m_settings->isWritable();
+  if (!instance()->m_settingsWatcher->files().contains(Settings::settingsFile()))
+    m_settingsWatcher->addPath(Settings::settingsFile());
+
+  bool writable = Settings::isWritable();
   if (writable == m_settingsWritable)
     return;
+  qDebug() << QString("Setting are now %1").arg(writable ? "writable" : "readonly");
   instance()->m_settingsWritable = writable;
   Q_EMIT instance()->settingsWritableChanged(writable);
 }

--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -266,6 +266,8 @@ NetworkProtocol Settings::networkProtocol()
 
 void Settings::save(bool emitSaving)
 {
+  if (!Settings::isWritable())
+    qWarning().noquote() << "settings not saved, file is read-only:" << Settings::settingsFile();
   if (emitSaving)
     Q_EMIT instance()->serverSettingsChanged();
   instance()->m_settings->sync();

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -233,7 +233,7 @@ private:
    * @brief checkIfSettingsWritableChange
    * Checks if the changed settings is now read only
    */
-  void checkIfSettingsWritableChange() const;
+  void checkIfSettingsWritableChange();
 
   QSettings *m_settings = nullptr;
   QSettings *m_stateSettings = nullptr;

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -15,6 +15,7 @@
 #include "common/NetworkProtocol.h"
 #include "common/QSettingsProxy.h"
 
+class QFileSystemWatcher;
 class Settings : public QObject
 {
   Q_OBJECT
@@ -198,6 +199,7 @@ public:
 
 Q_SIGNALS:
   void settingsChanged(const QString key);
+  void settingsWritableChanged(bool writable);
   void serverSettingsChanged();
 
 private:
@@ -227,8 +229,16 @@ private:
    */
   static QString cleanComputerName(const QString &name);
 
+  /**
+   * @brief checkIfSettingsWritableChange
+   * Checks if the changed settings is now read only
+   */
+  void checkIfSettingsWritableChange() const;
+
   QSettings *m_settings = nullptr;
   QSettings *m_stateSettings = nullptr;
+  bool m_settingsWritable;
+  QFileSystemWatcher *m_settingsWatcher = nullptr;
   std::shared_ptr<QSettingsProxy> m_settingsProxy;
 
   // clang-format off

--- a/src/lib/gui/CMakeLists.txt
+++ b/src/lib/gui/CMakeLists.txt
@@ -120,6 +120,8 @@ add_library(${target} STATIC
   widgets/StatusBar.h
   widgets/TrashScreenWidget.cpp
   widgets/TrashScreenWidget.h
+  widgets/SettingsDialogButtonBox.cpp
+  widgets/SettingsDialogButtonBox.h
 )
 
 target_link_libraries(${target}

--- a/src/lib/gui/dialogs/ClientConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ClientConfigDialog.cpp
@@ -8,15 +8,20 @@
 #include "ui_ClientConfigDialog.h"
 
 #include "common/Settings.h"
+#include "gui/widgets/SettingsDialogButtonBox.h"
 
 #include <QPushButton>
 
-ClientConfigDialog::ClientConfigDialog(QWidget *parent) : QDialog(parent), ui(new Ui::ClientConfigDialog)
+ClientConfigDialog::ClientConfigDialog(QWidget *parent)
+    : QDialog(parent),
+      ui(new Ui::ClientConfigDialog),
+      m_buttonBox{new SettingsDialogButtonBox(this)}
 {
   ui->setupUi(this);
-  updateText();
+  layout()->addWidget(m_buttonBox);
   initConnections();
   load();
+  updateControls();
   setButtonBoxEnabledButtons();
 }
 
@@ -28,29 +33,27 @@ ClientConfigDialog::~ClientConfigDialog()
 void ClientConfigDialog::changeEvent(QEvent *e)
 {
   QDialog::changeEvent(e);
-  if (e->type() == QEvent::LanguageChange) {
+  if (e->type() == QEvent::LanguageChange)
     ui->retranslateUi(this);
-    updateText();
-  }
 }
 
-void ClientConfigDialog::updateText() const
+void ClientConfigDialog::updateControls() const
 {
-  ui->buttonBox->button(QDialogButtonBox::Save)->setToolTip(tr("Close and save changes"));
-  ui->buttonBox->button(QDialogButtonBox::Cancel)->setToolTip(tr("Close and forget changes"));
-  ui->buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset to stored values"));
-  ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setToolTip(tr("Reset to default values"));
+  const auto writable = Settings::isWritable();
+  ui->cbDynamicConnectTime->setEnabled(writable);
+  ui->cbLanguageSync->setEnabled(writable);
+  ui->cbXScrollInvert->setEnabled(writable);
+  ui->sbXScrollScale->setEnabled(writable);
+  ui->cbYScrollInvert->setEnabled(writable);
+  ui->sbYScrollScale->setEnabled(writable);
 }
 
 void ClientConfigDialog::initConnections() const
 {
-  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ClientConfigDialog::save);
-  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  connect(ui->buttonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &ClientConfigDialog::load);
-  connect(
-      ui->buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this,
-      &ClientConfigDialog::resetToDefault
-  );
+  connect(m_buttonBox, &SettingsDialogButtonBox::accepted, this, &ClientConfigDialog::save);
+  connect(m_buttonBox, &SettingsDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(m_buttonBox, &SettingsDialogButtonBox::reset, this, &ClientConfigDialog::load);
+  connect(m_buttonBox, &SettingsDialogButtonBox::restoreDefault, this, &ClientConfigDialog::resetToDefault);
 
   connect(
       ui->cbDynamicConnectTime, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons
@@ -60,6 +63,7 @@ void ClientConfigDialog::initConnections() const
   connect(ui->sbYScrollScale, &QDoubleSpinBox::valueChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->cbXScrollInvert, &QCheckBox::checkStateChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->sbXScrollScale, &QDoubleSpinBox::valueChanged, this, &ClientConfigDialog::setButtonBoxEnabledButtons);
+  connect(Settings::instance(), &Settings::settingsWritableChanged, this, &ClientConfigDialog::updateControls);
 }
 
 bool ClientConfigDialog::isModified() const
@@ -87,9 +91,9 @@ bool ClientConfigDialog::isDefault() const
 void ClientConfigDialog::setButtonBoxEnabledButtons() const
 {
   const bool modified = isModified();
-  ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(modified);
-  ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(modified);
-  ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(!isDefault());
+  m_buttonBox->enableSave(modified);
+  m_buttonBox->enableReset(modified);
+  m_buttonBox->enableRestoreDefaults(!isDefault());
 }
 
 void ClientConfigDialog::load()

--- a/src/lib/gui/dialogs/ClientConfigDialog.h
+++ b/src/lib/gui/dialogs/ClientConfigDialog.h
@@ -8,6 +8,8 @@
 
 #include <QDialog>
 
+class SettingsDialogButtonBox;
+
 namespace Ui {
 class ClientConfigDialog;
 }
@@ -29,9 +31,9 @@ protected:
 
 private:
   /**
-   * @brief updateText update widget text
+   * @brief updateControls update widget enable state
    */
-  void updateText() const;
+  void updateControls() const;
 
   /**
    * @brief initConnections
@@ -73,4 +75,5 @@ private:
   void save();
 
   Ui::ClientConfigDialog *ui = nullptr;
+  SettingsDialogButtonBox *m_buttonBox = nullptr;
 };

--- a/src/lib/gui/dialogs/ClientConfigDialog.ui
+++ b/src/lib/gui/dialogs/ClientConfigDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>391</width>
-    <height>176</height>
+    <width>482</width>
+    <height>197</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -162,16 +162,6 @@
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -56,7 +56,7 @@ bool ServerConfigDialog::addClient(const QString &clientName)
   return addComputer(clientName, true);
 }
 
-void ServerConfigDialog::accept()
+void ServerConfigDialog::save()
 {
   if (ui->groupExternalConfig->isChecked() && !QFile::exists(ui->lineConfigFile->text())) {
 
@@ -452,7 +452,7 @@ void ServerConfigDialog::loadFromConfig()
 
 void ServerConfigDialog::initConnections() const
 {
-  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ServerConfigDialog::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ServerConfigDialog::save);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
   connect(ui->lblRemoveScreen, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
   connect(ui->btnNewHotkey, &QPushButton::clicked, this, &ServerConfigDialog::addHotkey);

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -99,7 +99,7 @@ void ServerConfigDialog::accept()
   QDialog::accept();
 }
 
-void ServerConfigDialog::reject()
+void ServerConfigDialog::cancel()
 {
   serverConfig().setUseExternalConfig(m_originalServerConfigIsExternal);
   serverConfig().setConfigFile(m_originalServerConfigUsesExternalFile);
@@ -453,7 +453,7 @@ void ServerConfigDialog::loadFromConfig()
 void ServerConfigDialog::initConnections() const
 {
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ServerConfigDialog::accept);
-  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ServerConfigDialog::reject);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
   connect(ui->lblRemoveScreen, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
   connect(ui->btnNewHotkey, &QPushButton::clicked, this, &ServerConfigDialog::addHotkey);
   connect(ui->btnEditHotkey, &QPushButton::clicked, this, &ServerConfigDialog::editHotkey);

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/ActionDialog.h"
 #include "dialogs/HotkeyDialog.h"
 #include "dialogs/ScreenSettingsDialog.h"
+#include "gui/widgets/SettingsDialogButtonBox.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -31,10 +32,15 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
       m_originalServerConfigIsExternal(config.useExternalConfig()),
       m_originalServerConfigUsesExternalFile(config.configFile()),
       m_serverConfig(config),
-      m_screenSetupModel(m_serverConfig.screens(), m_columns, m_rows)
+      m_screenSetupModel(m_serverConfig.screens(), m_columns, m_rows),
+      m_buttonBox{new SettingsDialogButtonBox(this)}
 {
   ui->setupUi(this);
   ui->tabWidget->setCurrentIndex(0);
+  layout()->addWidget(m_buttonBox);
+
+  m_buttonBox->enableReset(false);
+  m_buttonBox->enableRestoreDefaults(false);
 
   loadFromConfig();
 
@@ -448,12 +454,13 @@ void ServerConfigDialog::loadFromConfig()
   } else {
     server->markAsServer();
   }
+  updateControls();
 }
 
 void ServerConfigDialog::initConnections() const
 {
-  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ServerConfigDialog::save);
-  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
+  connect(m_buttonBox, &SettingsDialogButtonBox::accepted, this, &ServerConfigDialog::save);
+  connect(m_buttonBox, &SettingsDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
   connect(ui->lblRemoveScreen, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
   connect(ui->btnNewHotkey, &QPushButton::clicked, this, &ServerConfigDialog::addHotkey);
   connect(ui->btnEditHotkey, &QPushButton::clicked, this, &ServerConfigDialog::editHotkey);
@@ -498,6 +505,26 @@ void ServerConfigDialog::initConnections() const
   );
   connect(ui->cbDisableLockToComputer, &QCheckBox::toggled, this, &ServerConfigDialog::toggleLockToComputer);
   connect(&m_screenSetupModel, &ScreenSetupModel::screensChanged, this, &ServerConfigDialog::onChange);
+  connect(Settings::instance(), &Settings::settingsWritableChanged, this, &ServerConfigDialog::updateControls);
+}
+
+void ServerConfigDialog::updateControls() const
+{
+  const bool writable = Settings::isWritable();
+  ui->cbDefaultLockToComputerState->setEnabled(writable);
+  ui->cbDisableLockToComputer->setEnabled(writable);
+  ui->cbEnableClipboard->setEnabled(writable);
+  ui->sbClipboardSizeLimit->setEnabled(writable);
+  ui->rbProtocolBarrier->setEnabled(writable);
+  ui->rbProtocolSynergy->setEnabled(writable);
+  ui->cbHeartbeat->setEnabled(writable);
+  ui->cbRelativeMouseMoves->setEnabled(writable);
+  ui->cbSwitchDelay->setEnabled(writable);
+  ui->cbWin32KeepForeground->setEnabled(writable);
+  ui->cbSwitchDoubleTap->setEnabled(writable);
+  ui->sbSwitchDoubleTap->setEnabled(writable && ui->cbSwitchDoubleTap->isChecked());
+  ui->sbSwitchDelay->setEnabled(writable && ui->cbSwitchDelay->isChecked());
+  ui->groupExternalConfig->setEnabled(writable);
 }
 
 bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
@@ -532,6 +559,5 @@ void ServerConfigDialog::onChange()
       m_win32keepForeground == Settings::value(Settings::Server::Win32KeepForeground).toBool() &&
       m_disableLockToComputer == Settings::value(Settings::Server::DisableLockToComputer).toBool() &&
       m_defaultLockToComputerState == Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
-  ui->buttonBox->button(QDialogButtonBox::Ok)
-      ->setEnabled(!isAppConfigDataEqual || !(m_originalServerConfig == m_serverConfig));
+  m_buttonBox->enableSave(!isAppConfigDataEqual || !(m_originalServerConfig == m_serverConfig));
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -14,6 +14,7 @@
 
 #include <QDialog>
 
+class SettingsDialogButtonBox;
 class QItemSelection;
 
 namespace Ui {
@@ -88,6 +89,7 @@ private:
   void cancel();
   void loadFromConfig();
   void initConnections() const;
+  void updateControls() const;
   void onChange();
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";
@@ -111,4 +113,5 @@ private:
   QString m_originalServerConfigUsesExternalFile;
   ServerConfig m_serverConfig;
   ScreenSetupModel m_screenSetupModel;
+  SettingsDialogButtonBox *m_buttonBox = nullptr;
 };

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -28,17 +28,13 @@ public:
   ServerConfigDialog(QWidget *parent, ServerConfig &config);
   ~ServerConfigDialog() override;
   bool addClient(const QString &clientName);
-
-public Q_SLOTS:
   void message(const QString &message)
   {
     m_message = message;
   }
 
-protected Q_SLOTS:
-  void onScreenRemoved();
-
 protected:
+  void onScreenRemoved();
   void addClient();
   bool addComputer(const QString &clientName, bool doSilent);
 
@@ -92,6 +88,7 @@ private:
   void cancel();
   void loadFromConfig();
   void initConnections() const;
+  void onChange();
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";
   int m_columns;
@@ -114,7 +111,4 @@ private:
   QString m_originalServerConfigUsesExternalFile;
   ServerConfig m_serverConfig;
   ScreenSetupModel m_screenSetupModel;
-
-private Q_SLOTS:
-  void onChange();
 };

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -30,8 +30,6 @@ public:
   bool addClient(const QString &clientName);
 
 public Q_SLOTS:
-  void accept() override;
-
   void message(const QString &message)
   {
     m_message = message;
@@ -90,6 +88,7 @@ protected:
   }
 
 private:
+  void save();
   void cancel();
   void loadFromConfig();
   void initConnections() const;

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -31,7 +31,7 @@ public:
 
 public Q_SLOTS:
   void accept() override;
-  void reject() override;
+
   void message(const QString &message)
   {
     m_message = message;
@@ -90,6 +90,7 @@ protected:
   }
 
 private:
+  void cancel();
   void loadFromConfig();
   void initConnections() const;
   std::unique_ptr<Ui::ServerConfigDialog> ui;

--- a/src/lib/gui/dialogs/ServerConfigDialog.ui
+++ b/src/lib/gui/dialogs/ServerConfigDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>724</width>
-    <height>586</height>
+    <height>609</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -879,16 +879,6 @@ Enabling this setting will disable the server config GUI.</string>
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -187,12 +187,6 @@ void SettingsDialog::setLogToFile(bool logToFile)
   ui->widgetLogFilename->setEnabled(logToFile);
 }
 
-void SettingsDialog::showEvent(QShowEvent *event)
-{
-  QDialog::showEvent(event);
-  Q_EMIT shown();
-}
-
 void SettingsDialog::resetAllSettings()
 {
   auto result = QMessageBox::question(
@@ -378,8 +372,14 @@ void SettingsDialog::updateControls()
   ui->comboInterface->setEnabled(writable);
   ui->comboLogLevel->setEnabled(writable);
   ui->groupLogToFile->setEnabled(writable);
+  ui->comboLanguage->setEnabled(writable);
+  ui->cbShowVersion->setEnabled(writable);
+  ui->cbGuiDebug->setEnabled(writable);
+  ui->rbIconColorful->setEnabled(writable);
+  ui->rbIconMono->setEnabled(writable);
   ui->rbAutoHide->setEnabled(writable);
   ui->rbShowOnStart->setEnabled(writable);
+  ui->btnClearAllSettings->setEnabled(writable);
   ui->cbAutoUpdate->setEnabled(writable);
   ui->cbPreventSleep->setEnabled(writable);
   ui->lineTlsCertPath->setEnabled(writable);

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -15,6 +15,7 @@
 #include "common/Settings.h"
 #include "gui/TlsUtility.h"
 #include "gui/core/NetworkMonitor.h"
+#include "gui/widgets/SettingsDialogButtonBox.h"
 
 #include <QComboBox>
 #include <QDir>
@@ -26,10 +27,12 @@ using namespace deskflow::gui;
 SettingsDialog::SettingsDialog(QWidget *parent, const ServerConfig &serverConfig)
     : QDialog(parent),
       ui{std::make_unique<Ui::SettingsDialog>()},
-      m_serverConfig(serverConfig)
+      m_serverConfig(serverConfig),
+      m_buttonBox{new SettingsDialogButtonBox(this)}
 {
 
   ui->setupUi(this);
+  layout()->addWidget(m_buttonBox);
   ui->tabWidget->setCurrentIndex(0);
 
   // these are enabled by the control next to them
@@ -93,15 +96,10 @@ void SettingsDialog::changeEvent(QEvent *e)
 
 void SettingsDialog::initConnections() const
 {
-  connect(this, &SettingsDialog::shown, this, &SettingsDialog::showReadOnlyMessage, Qt::QueuedConnection);
-
-  connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
-  connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  connect(ui->buttonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &SettingsDialog::loadFromConfig);
-  connect(
-      ui->buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this,
-      &SettingsDialog::resetToDefault
-  );
+  connect(m_buttonBox, &SettingsDialogButtonBox::accepted, this, &SettingsDialog::accept);
+  connect(m_buttonBox, &SettingsDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(m_buttonBox, &SettingsDialogButtonBox::reset, this, &SettingsDialog::loadFromConfig);
+  connect(m_buttonBox, &SettingsDialogButtonBox::restoreDefault, this, &SettingsDialog::resetToDefault);
 
   connect(ui->cbRunEnterCommand, &QCheckBox::toggled, ui->lineCommandEnter, &QLineEdit::setEnabled);
   connect(ui->cbRunExitCommand, &QCheckBox::toggled, ui->lineCommandExit, &QLineEdit::setEnabled);
@@ -144,6 +142,7 @@ void SettingsDialog::initConnections() const
   connect(ui->cbRunExitCommand, &QCheckBox::toggled, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->lineCommandEnter, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
   connect(ui->lineCommandExit, &QLineEdit::textChanged, this, &SettingsDialog::setButtonBoxEnabledButtons);
+  connect(Settings::instance(), &Settings::settingsWritableChanged, this, &SettingsDialog::updateControls);
 }
 
 void SettingsDialog::regenCertificates()
@@ -194,17 +193,6 @@ void SettingsDialog::showEvent(QShowEvent *event)
   Q_EMIT shown();
 }
 
-void SettingsDialog::showReadOnlyMessage()
-{
-  if (Settings::isWritable())
-    return;
-  QMessageBox::information(
-      this, tr("%1 Read-only settings").arg(kAppName),
-      tr("<p>Settings are read-only because you only have read access to the file:</p><p>%1</p>")
-          .arg(QDir::toNativeSeparators(Settings::settingsFile()))
-  );
-}
-
 void SettingsDialog::resetAllSettings()
 {
   auto result = QMessageBox::question(
@@ -234,10 +222,6 @@ void SettingsDialog::updateText()
       ui->comboLogLevel->setItemData(i, toolTips.at(i), Qt::ToolTipRole);
     }
   }
-  ui->buttonBox->button(QDialogButtonBox::Save)->setToolTip(tr("Close and save changes"));
-  ui->buttonBox->button(QDialogButtonBox::Cancel)->setToolTip(tr("Close and forget changes"));
-  ui->buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset to stored values"));
-  ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setToolTip(tr("Reset to default values"));
 }
 
 void SettingsDialog::accept()
@@ -389,8 +373,6 @@ void SettingsDialog::updateControls()
   const bool writable = Settings::isWritable();
   const bool serviceChecked = ui->groupService->isChecked();
   const bool logToFile = ui->groupLogToFile->isChecked();
-
-  ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(writable);
 
   ui->sbPort->setEnabled(writable);
   ui->comboInterface->setEnabled(writable);
@@ -551,9 +533,9 @@ void SettingsDialog::resetToDefault()
 void SettingsDialog::setButtonBoxEnabledButtons() const
 {
   const bool modified = isModified();
-  ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(modified);
-  ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(modified);
-  ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(!isDefault());
+  m_buttonBox->enableSave(modified);
+  m_buttonBox->enableReset(modified);
+  m_buttonBox->enableRestoreDefaults(!isDefault());
 }
 
 SettingsDialog::~SettingsDialog() = default;

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -27,7 +27,6 @@ public:
   ~SettingsDialog() override;
 
 Q_SIGNALS:
-  void shown();
   void requestRemoveAllSettings();
 
 protected:
@@ -40,7 +39,6 @@ private:
   void browseLogPath();
   void setLogToFile(bool logToFile);
   void accept() override;
-  void showEvent(QShowEvent *event) override;
   bool isClientMode() const;
   void updateTlsControls();
   void updateTlsControlsEnabled();

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -10,6 +10,8 @@
 #include <QDialog>
 
 #include "gui/config/ServerConfig.h"
+
+class SettingsDialogButtonBox;
 
 namespace Ui {
 class SettingsDialog;
@@ -42,7 +44,6 @@ private:
   bool isClientMode() const;
   void updateTlsControls();
   void updateTlsControlsEnabled();
-  void showReadOnlyMessage();
   void resetAllSettings();
   void updateText();
 
@@ -87,4 +88,5 @@ private:
   bool m_interfaceSetOnLoad = false;
   std::unique_ptr<Ui::SettingsDialog> ui;
   const ServerConfig &m_serverConfig;
+  SettingsDialogButtonBox *m_buttonBox = nullptr;
 };

--- a/src/lib/gui/dialogs/SettingsDialog.ui
+++ b/src/lib/gui/dialogs/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>490</width>
-    <height>366</height>
+    <height>326</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -862,16 +862,6 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/lib/gui/widgets/SettingsDialogButtonBox.cpp
+++ b/src/lib/gui/widgets/SettingsDialogButtonBox.cpp
@@ -1,0 +1,97 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "SettingsDialogButtonBox.h"
+#include "common/Settings.h"
+
+#include <QDialogButtonBox>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QPushButton>
+
+SettingsDialogButtonBox::SettingsDialogButtonBox(QWidget *parent)
+    : QWidget{parent},
+      m_buttonBox{new QDialogButtonBox(this)},
+      m_lblText{new QLabel(this)},
+      m_lblIcon{new QLabel(this)}
+{
+  m_lblIcon->setPixmap(QIcon::fromTheme(QIcon::ThemeIcon::DialogWarning).pixmap(24, 24));
+  m_buttonBox->addButton(QDialogButtonBox::Save);
+  m_buttonBox->addButton(QDialogButtonBox::Cancel);
+  m_buttonBox->addButton(QDialogButtonBox::Reset);
+  m_buttonBox->addButton(QDialogButtonBox::RestoreDefaults);
+  settingsWritableChanged(Settings::isWritable());
+
+  auto layout = new QHBoxLayout(this);
+  layout->addWidget(m_lblIcon);
+  layout->addWidget(m_lblText);
+  layout->addWidget(m_buttonBox);
+  setLayout(layout);
+
+  updateText();
+
+  connect(m_buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialogButtonBox::accepted);
+  connect(m_buttonBox, &QDialogButtonBox::rejected, this, &SettingsDialogButtonBox::rejected);
+  connect(m_buttonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &SettingsDialogButtonBox::reset);
+  connect(
+      m_buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this,
+      &SettingsDialogButtonBox::restoreDefault
+  );
+  connect(
+      Settings::instance(), &Settings::settingsWritableChanged, this, &SettingsDialogButtonBox::settingsWritableChanged
+  );
+}
+
+void SettingsDialogButtonBox::enableSave(bool enable) const
+{
+  m_buttonBox->button(QDialogButtonBox::Save)->setEnabled(enable);
+}
+
+void SettingsDialogButtonBox::enableReset(bool enable) const
+{
+  m_buttonBox->button(QDialogButtonBox::Reset)->setEnabled(enable);
+}
+
+void SettingsDialogButtonBox::enableRestoreDefaults(bool enable) const
+{
+  m_buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(enable);
+}
+
+void SettingsDialogButtonBox::changeEvent(QEvent *e)
+{
+  QWidget::changeEvent(e);
+  if (e->type() == QEvent::LanguageChange)
+    updateText();
+}
+
+void SettingsDialogButtonBox::updateText()
+{
+  m_lblText->setText(tr("Settings are read only"));
+  m_lblText->setToolTip(tr("%1 is not writable").arg(Settings::settingsFile()));
+
+  m_buttonBox->button(QDialogButtonBox::Save)->setToolTip(tr("Close and save changes"));
+  m_buttonBox->button(QDialogButtonBox::Cancel)->setToolTip(tr("Close and forget changes"));
+  m_buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset to stored values"));
+  m_buttonBox->button(QDialogButtonBox::RestoreDefaults)->setToolTip(tr("Reset to default values"));
+}
+
+void SettingsDialogButtonBox::settingsWritableChanged(bool writable)
+{
+  // Hide all first to prevent any change in overall width
+  m_lblIcon->setVisible(false);
+  m_lblText->setVisible(false);
+  m_buttonBox->button(QDialogButtonBox::Save)->setVisible(false);
+  m_buttonBox->button(QDialogButtonBox::Reset)->setVisible(false);
+  m_buttonBox->button(QDialogButtonBox::RestoreDefaults)->setVisible(false);
+
+  m_lblIcon->setVisible(!writable);
+  m_lblText->setVisible(!writable);
+  m_buttonBox->button(QDialogButtonBox::Save)->setVisible(writable);
+  m_buttonBox->button(QDialogButtonBox::Reset)->setVisible(writable);
+  m_buttonBox->button(QDialogButtonBox::RestoreDefaults)->setVisible(writable);
+}

--- a/src/lib/gui/widgets/SettingsDialogButtonBox.h
+++ b/src/lib/gui/widgets/SettingsDialogButtonBox.h
@@ -1,0 +1,37 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QDialogButtonBox;
+
+class SettingsDialogButtonBox : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit SettingsDialogButtonBox(QWidget *parent = nullptr);
+  void enableSave(bool enable) const;
+  void enableReset(bool enable) const;
+  void enableRestoreDefaults(bool enable) const;
+Q_SIGNALS:
+  void accepted();
+  void rejected();
+  void reset();
+  void restoreDefault();
+
+protected:
+  void changeEvent(QEvent *e) override;
+
+private:
+  void updateText();
+  void settingsWritableChanged(bool writable);
+  QDialogButtonBox *m_buttonBox = nullptr;
+  QLabel *m_lblText = nullptr;
+  QLabel *m_lblIcon = nullptr;
+};

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1160,14 +1160,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Configuración de solo lectura</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Las configuraciones son de solo lectura porque solo tiene acceso de lectura al archivo:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation type="unfinished">Mensajes obligatorios</translation>
     </message>
@@ -1190,22 +1182,6 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>Verbose debug output</source>
         <translation type="unfinished">Salida de depuración detallada</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Cerrar y guardar los cambios</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Cerrar y olvidar los cambios</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Restablecer los valores almacenados</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Restablecer valores predeterminados</translation>
     </message>
     <message>
         <source>TLS Certificate Regenerated</source>
@@ -1294,6 +1270,33 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">Eliminar todas las configuraciones</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">La configuración es de solo lectura</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1 no tiene permisos de escritura</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Cerrar y guardar los cambios</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Cerrar y olvidar los cambios</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Restablecer los valores almacenados</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Restablecer valores predeterminados</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -1141,7 +1141,7 @@ Al habilitar esta opción, se deshabilitará la interfaz gráfica de usuario (GU
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;¿Está seguro de que desea borrar toda la configuración y reiniciar %1?&lt;/p&gt; &lt;p&gt;Esta acción no se puede deshacer.&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_es.ts
+++ b/translations/deskflow_es.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Escala</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Cerrar y guardar los cambios</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Cerrar y olvidar los cambios</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Restablecer los valores almacenados</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Restablecer valores predeterminados</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Permite que el cliente reduzca la frecuencia con la que intenta reconectarse al servidor cuando los intentos de conexión fallan. El intervalo entre intentos de conexión comenzará en 1 segundo y podrá alcanzar un máximo de 5 minutos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1141,7 +1141,7 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;Sei sicuro di voler cancellare tutte le impostazioni e riavviare %1?&lt;/p&gt; &lt;p&gt;Questa operazione non può essere annullata.&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -1160,14 +1160,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Impostazioni di sola lettura</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Le impostazioni sono di sola lettura perché hai solo accesso in lettura al file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation>Messaggi richiesti</translation>
     </message>
@@ -1190,22 +1182,6 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>Verbose debug output</source>
         <translation>Output di debug dettagliato</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Chiudi e salva le modifiche</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Chiudi e dimentica le modifiche</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Ripristina i valori memorizzati</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Ripristina i valori predefiniti</translation>
     </message>
     <message>
         <source>TLS Certificate Regenerated</source>
@@ -1294,6 +1270,33 @@ L&apos;abilitazione di questa impostazione disabiliterà l&apos;interfaccia graf
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">Rimuovi tutte le impostazioni</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">Le impostazioni sono di sola lettura</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1 non è scrivibile</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Chiudi e salva le modifiche</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Chiudi e dimentica le modifiche</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Ripristina i valori memorizzati</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Ripristina i valori predefiniti</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_it.ts
+++ b/translations/deskflow_it.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Scala</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Chiudi e salva le modifiche</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Chiudi e dimentica le modifiche</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Ripristina i valori memorizzati</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Ripristina i valori predefiniti</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Consente al client di rallentare la frequenza dei tentativi di riconnessione al server quando i tentativi di connessione falliscono. Il ritardo tra i tentativi di connessione inizierà a intervalli di 1 secondo, fino a raggiungere un massimo di 5 minuti tra un tentativo e l&apos;altro.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation>倍率</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation>変更を保存して閉じる</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>変更を破棄して閉じる</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation>変更前の値にリセットする</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation>デフォルト値にリセットする</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;接続試行が失敗し続けている場合に、クライアントがサーバーへ再接続を試みる頻度を徐々に下げます。接続試行の間隔は当初1秒から開始され、最大で5分まで延長されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1167,7 +1167,7 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;すべての設定を消去して %1 を再起動してもよろしいですか？&lt;/p&gt; &lt;p&gt;この操作は元に戻せません。&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ja.ts
+++ b/translations/deskflow_ja.ts
@@ -1186,14 +1186,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 読み取り専用設定</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;以下のファイルへの書き込み権限がないため、設定は読み取り専用です:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation>必須のメッセージ</translation>
     </message>
@@ -1216,22 +1208,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Verbose debug output</source>
         <translation>詳細なデバッグ出力</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation>変更を保存して閉じる</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>変更を破棄して閉じる</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation>変更前の値にリセットする</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation>デフォルト値にリセットする</translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -1296,6 +1272,33 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">すべての設定を削除する</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">設定は読み取り専用です</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1 は書き込み可能ではありません</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">変更を保存して閉じる</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">変更を破棄して閉じる</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">変更前の値にリセットする</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">デフォルト値にリセットする</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1165,7 +1165,7 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;모든 설정을 지우고 %1을(를) 다시 시작하시겠습니까?&lt;/p&gt; &lt;p&gt;이 작업은 되돌릴 수 없습니다.&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">규모</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation>변경 사항 저장 후 닫기</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>저장하지 않고 닫기</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">저장된 값으로 재설정</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">기본값으로 재설정</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;연결 시도가 실패할 경우, 클라이언트가 서버 재연결 시도 주기를 늦추도록 허용합니다. 연결 시도 간 지연 시간은 1초 간격으로 시작되며, 최대 5분까지 늘어날 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ko.ts
+++ b/translations/deskflow_ko.ts
@@ -1184,14 +1184,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 읽기 전용 설정</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;다음 파일에 대한 쓰기 권한이 없어 설정이 읽기 전용입니다:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation>필수 메시지</translation>
     </message>
@@ -1214,22 +1206,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Verbose debug output</source>
         <translation>상세 디버그 출력</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation>변경 사항 저장 후 닫기</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>저장하지 않고 닫기</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">저장된 값으로 재설정</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">기본값으로 재설정</translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -1294,6 +1270,33 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">모든 설정 제거</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">설정은 읽기 전용입니다</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1은(는) 쓰기 가능하지 않습니다</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">변경 사항 저장 후 닫기</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">저장하지 않고 닫기</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">저장된 값으로 재설정</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">기본값으로 재설정</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1163,7 +1163,7 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;Вы уверены, что хотите сбросить все настройки и перезапустить %1?&lt;/p&gt; &lt;p&gt;Это действие нельзя отменить.&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Шкала</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Закрыть и сохранить изменения</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Закройте изменения и забудьте о них</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Сбросить до сохраненных значений</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Сбросить до значений по умолчанию</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Позволить клиенту замедлять частоту попыток повторного подключения к серверу в случае неудачных попыток соединения. Интервал между попытками подключения будет начинаться с 1 секунды и может достигать максимума в 5 минут.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_ru.ts
+++ b/translations/deskflow_ru.ts
@@ -1182,14 +1182,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 Настройки только для чтения</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;Настройки доступны только для чтения, так как у вас есть доступ только на чтение к файлу:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation>Обязательные сообщения</translation>
     </message>
@@ -1212,22 +1204,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Verbose debug output</source>
         <translation>Подробный вывод отладки</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">Закрыть и сохранить изменения</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation type="unfinished">Закройте изменения и забудьте о них</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">Сбросить до сохраненных значений</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">Сбросить до значений по умолчанию</translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -1292,6 +1268,33 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">Удалить все настройки</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">Настройки доступны только для чтения</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1 недоступен для записи</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">Закрыть и сохранить изменения</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">Закройте изменения и забудьте о них</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">Сбросить до сохраненных значений</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">Сбросить до значений по умолчанию</translation>
     </message>
 </context>
 <context>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1167,7 +1167,7 @@ Enabling this setting will disable the server config GUI.</source>
     </message>
     <message>
         <source>&lt;p&gt;Are you sure you want to clear all settings and restart %1?&lt;/p&gt; &lt;p&gt;This action cannot be undone.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&lt;p&gt;您确定要清除所有设置并重新启动 %1 吗？&lt;/p&gt; &lt;p&gt;此操作无法撤销。&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Required messages</source>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -166,22 +166,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">规模</translation>
     </message>
     <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">关闭并保存更改</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>关闭并放弃修改</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">重置为存储值</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">重置为默认值</translation>
-    </message>
-    <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow the client to slow the rate it attempts to reconnect to the server when connections attempts are failing. The delay between connection attempts will  start at 1 second intervals and can be a maxium of 5 minutes between connection attempts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;允许客户端在连接尝试失败时，降低其重连服务器的频率。连接尝试之间的间隔将从 1 秒开始，最长可达 5 分钟。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/translations/deskflow_zh_CN.ts
+++ b/translations/deskflow_zh_CN.ts
@@ -1186,14 +1186,6 @@ Enabling this setting will disable the server config GUI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 Read-only settings</source>
-        <translation type="unfinished">%1 只读设置</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Settings are read-only because you only have read access to the file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation type="unfinished">&lt;p&gt;设置是只读的，因为您对该文件只有读取权限：&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Required messages</source>
         <translation>必要消息</translation>
     </message>
@@ -1216,22 +1208,6 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Verbose debug output</source>
         <translation>详细调试输出</translation>
-    </message>
-    <message>
-        <source>Close and save changes</source>
-        <translation type="unfinished">关闭并保存更改</translation>
-    </message>
-    <message>
-        <source>Close and forget changes</source>
-        <translation>关闭并放弃修改</translation>
-    </message>
-    <message>
-        <source>Reset to stored values</source>
-        <translation type="unfinished">重置为存储值</translation>
-    </message>
-    <message>
-        <source>Reset to default values</source>
-        <translation type="unfinished">重置为默认值</translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -1296,6 +1272,33 @@ Enabling this setting will disable the server config GUI.</source>
     <message>
         <source>Remove all settings</source>
         <translation type="unfinished">移除所有设置</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialogButtonBox</name>
+    <message>
+        <source>Settings are read only</source>
+        <translation type="unfinished">设置仅为只读</translation>
+    </message>
+    <message>
+        <source>%1 is not writable</source>
+        <translation type="unfinished">%1 不可写入</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation type="unfinished">关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation type="unfinished">关闭并放弃修改</translation>
+    </message>
+    <message>
+        <source>Reset to stored values</source>
+        <translation type="unfinished">重置为存储值</translation>
+    </message>
+    <message>
+        <source>Reset to default values</source>
+        <translation type="unfinished">重置为默认值</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Provide a better more standard way to show non writable settings
 - Settings new signal emitting when the read only state of the setting file chages
 - New Settings Dialog button Box with info about read only state
 - Use SettingsDialogButtonBox in SettingsDialog and Client Config Dialog
 - Client Config Dialog enable / disable controls if not writable 
 - Add missing translation for the clear settings button
 - Add log if settings trying to save to a readonly file.
 - Basic report of readonly settings in server config dialog 
 - disable items on ServerConfigDialog advanced tab for readonly settings

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #10047 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally
open the settings and make the settings file (Deskflow.conf) readonly and back you should see the dialog react to the file being readonly