### PR TITLE
Avoid macOS 27 system tray crash

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -43,6 +43,7 @@
 #include <QMessageBox>
 #include <QNetworkAccessManager>
 #include <QNetworkInterface>
+#include <QOperatingSystemVersion>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
@@ -620,7 +621,7 @@ void MainWindow::serverConnectionConfigureClient(const QString &clientName)
 
 void MainWindow::open()
 {
-  if (!Settings::value(Settings::Gui::Autohide).toBool())
+  if (!Settings::value(Settings::Gui::Autohide).toBool() || !m_trayIconAvailable)
     showAndActivate();
   else if (deskflow::platform::isMac())
     // macOS to call hide after this function ends
@@ -681,6 +682,13 @@ void MainWindow::createMenuBar()
 
 void MainWindow::setupTrayIcon()
 {
+#if defined(Q_OS_MACOS)
+  if (QOperatingSystemVersion::current().majorVersion() == 27) {
+    qWarning() << "system tray is disabled on macOS 27 because Qt crashes while tracking its menu";
+    return;
+  }
+#endif
+
   auto trayMenu = new QMenu(this);
   trayMenu->addActions(
       {m_actionStartCore, m_actionRestartCore, m_actionStopCore, m_actionMinimize, m_actionRestore, m_actionTrayQuit}
@@ -691,6 +699,7 @@ void MainWindow::setupTrayIcon()
 
   setTrayIcon();
   m_trayIcon->show();
+  m_trayIconAvailable = true;
 }
 
 void MainWindow::applyConfig()
@@ -886,7 +895,7 @@ void MainWindow::handlePeerFingerprint(const QString &fingerprint)
 
 bool MainWindow::maybeHideToTray()
 {
-  if (!Settings::value(Settings::Gui::CloseToTray).toBool()) {
+  if (!m_trayIconAvailable || !Settings::value(Settings::Gui::CloseToTray).toBool()) {
     return false;
   }
 

--- a/src/lib/gui/MainWindow.h
+++ b/src/lib/gui/MainWindow.h
@@ -178,6 +178,7 @@ private:
   QSize m_expandedSize = QSize();
   QStringList m_checkedClients;
   QStringList m_checkedServers;
+  bool m_trayIconAvailable = false;
   QSystemTrayIcon *m_trayIcon = nullptr;
   QLocalServer *m_guiDupeChecker = nullptr;
   deskflow::gui::ipc::DaemonIpcClient *m_daemonIpcClient = nullptr;


### PR DESCRIPTION
## Summary

- avoid creating a system-tray status item on macOS 27, where opening its menu aborts the Qt Cocoa plugin
- keep Deskflow's main window visible when the tray is unavailable
- do not hide the main window into an unavailable tray

## Root cause

On macOS 27, the Qt Cocoa platform plugin can receive a non-mouse current event while tracking an `NSStatusItem` menu. It unconditionally reads `clickCount`, which raises an Objective-C exception and terminates the Deskflow GUI. The sharing core remains alive, but the user loses the Deskflow controls.

The Qt 6.12.0 package used for this reproduction still exhibited the crash, so this change avoids the unsafe status-item path only on macOS 27. A normal Deskflow window remains available for starting, stopping, and configuring the sharing core.

## Testing

- built `Deskflow` for Apple Silicon macOS 27 with Qt 6.12.0
- reproduced the pre-fix crash in `-[NSEvent clickCount]` from `libqcocoa.dylib`
- launched the signed, self-contained patched application and verified that both `Deskflow` and `deskflow-core` remained running
- ran the existing unit-test binaries with Qt 6.11.1 and Qt 6.12.0: 25 passed; `OSXKeyStateTests::fakePollShift` failed identically on macOS 27 before this change
- not tested on Intel macOS or GitHub Actions
