### PR TITLE
feat(wayland): moves mouse pointer to the center of screen when leaving

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -438,6 +438,7 @@ bool EiScreen::canLeave()
 void EiScreen::leave()
 {
   if (!m_isPrimary) {
+    fakeMouseMove(m_w / 2, m_h / 2);
     stopEmulating();
   }
 


### PR DESCRIPTION
## Blocked

- #8583

## Description
The mouse pointer is centralized on screen in X11 and Windows when it leaves the screen. In some situations (locked screen on X11 or an window at center of screen in Windows) the pointer is still visible, but when it disappears at edge of screen we got a good visual feedback that the mouse switched screens.

The same doesn´t  happens for Wayland clients, with the mouse pointer visible at its last position at edge of screen. This PR just makes the Wayland behaviour the same of X11 and Windows, with the mouse pointer going to the center of screen of the inactive screen when leaving one screen to another.

## AI tools used for this PR
None

## Fixed/related issues
This is related to #8583 , the mouse will not be hidden but, at least, it will disappear at screen edge.

## How has this been tested?
Yes, it is tested with both server and client using Plasma on Wayland and a deskflow package generated by this PR's tree.
