### PR TITLE
More updates to Server Config Dialog

### DIFF
--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -52,7 +52,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   if (!deskflow::platform::isWindows())
     ui->cbWin32KeepForeground->setVisible(false);
   initConnections();
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 ServerConfigDialog::~ServerConfigDialog() = default;
@@ -120,7 +120,7 @@ void ServerConfigDialog::addHotkey()
   if (dlg.exec() == QDialog::Accepted) {
     serverConfig().hotkeys().append(hotkey);
     ui->listHotkeys->addItem(hotkey.text());
-    onChange();
+    setButtonBoxEnabledButtons();
   }
 }
 
@@ -136,7 +136,7 @@ void ServerConfigDialog::editHotkey()
   HotkeyDialog dlg(this, hotkey);
   if (dlg.exec() == QDialog::Accepted) {
     ui->listHotkeys->currentItem()->setText(hotkey.text());
-    onChange();
+    setButtonBoxEnabledButtons();
   }
 }
 
@@ -151,7 +151,7 @@ void ServerConfigDialog::removeHotkey()
   serverConfig().hotkeys().removeAt(row);
   ui->listActions->clear();
   delete ui->listHotkeys->item(row);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::listHotkeysSelectionChanged(const QItemSelection &selected, const QItemSelection &)
@@ -183,7 +183,7 @@ void ServerConfigDialog::addAction()
   if (dlg.exec() == QDialog::Accepted) {
     hotkey.actions().append(action);
     ui->listActions->addItem(action.text());
-    onChange();
+    setButtonBoxEnabledButtons();
   }
 }
 
@@ -206,7 +206,7 @@ void ServerConfigDialog::editAction()
   ActionDialog dlg(this, serverConfig(), hotkey, action);
   if (dlg.exec() == QDialog::Accepted) {
     ui->listActions->currentItem()->setText(action.text());
-    onChange();
+    setButtonBoxEnabledButtons();
   }
 }
 
@@ -227,7 +227,7 @@ void ServerConfigDialog::removeAction()
 
   hotkey.actions().removeAt(actionRow);
   delete ui->listActions->currentItem();
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleClipboard(bool enabled)
@@ -242,7 +242,7 @@ void ServerConfigDialog::toggleClipboard(bool enabled)
     m_clipboardSize = Settings::defaultValue(Settings::Server::ClipboardSize).toUInt();
     ui->sbClipboardSizeLimit->setValue(m_clipboardSize ? m_clipboardSize : 1);
   }
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::setClipboardLimit(int limit)
@@ -251,14 +251,14 @@ void ServerConfigDialog::setClipboardLimit(int limit)
     return;
 
   m_clipboardSize = limit;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleHeartbeat(bool enabled)
 {
   m_enableHeartbeat = enabled;
   ui->sbHeartbeat->setEnabled(enabled);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::setHeartbeat(int rate)
@@ -266,7 +266,7 @@ void ServerConfigDialog::setHeartbeat(int rate)
   if (rate == m_heartbeatRate)
     return;
   m_heartbeatRate = rate;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleRelativeMouseMoves(bool enabled)
@@ -274,13 +274,13 @@ void ServerConfigDialog::toggleRelativeMouseMoves(bool enabled)
   if (m_relativeMouseMoves == enabled)
     return;
   m_relativeMouseMoves = enabled;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleProtocol()
 {
   m_protocol = ui->rbProtocolBarrier->isChecked() ? NetworkProtocol::Barrier : NetworkProtocol::Synergy;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::listActionsSelectionChanged(const QItemSelection &selected, const QItemSelection &)
@@ -294,7 +294,7 @@ void ServerConfigDialog::toggleSwitchDoubleTap(bool enable)
 {
   m_enableSwitchDoubleTap = enable;
   ui->sbSwitchDoubleTap->setEnabled(enable);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::setSwitchDoubleTap(int within)
@@ -302,14 +302,14 @@ void ServerConfigDialog::setSwitchDoubleTap(int within)
   if (m_switchDoubleTap == within)
     return;
   m_switchDoubleTap = within;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleSwitchDelay(bool enable)
 {
   m_enableSwitchDelay = enable;
   ui->sbSwitchDelay->setEnabled(enable);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::setSwitchDelay(int delay)
@@ -317,7 +317,7 @@ void ServerConfigDialog::setSwitchDelay(int delay)
   if (m_switchDelay == delay)
     return;
   m_switchDelay = delay;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleDefaultLockToComputerState(bool state)
@@ -325,7 +325,7 @@ void ServerConfigDialog::toggleDefaultLockToComputerState(bool state)
   if (m_defaultLockToComputerState == state)
     return;
   m_defaultLockToComputerState = state;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleLockToComputer(bool disabled)
@@ -333,7 +333,7 @@ void ServerConfigDialog::toggleLockToComputer(bool disabled)
   if (m_disableLockToComputer == disabled)
     return;
   m_disableLockToComputer = disabled;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleWin32Foreground(bool enabled)
@@ -341,7 +341,7 @@ void ServerConfigDialog::toggleWin32Foreground(bool enabled)
   if (m_win32keepForeground == enabled)
     return;
   m_win32keepForeground = enabled;
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::addClient()
@@ -352,7 +352,7 @@ void ServerConfigDialog::addClient()
 void ServerConfigDialog::onScreenRemoved()
 {
   ui->lblNewScreen->setEnabled(true);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 void ServerConfigDialog::toggleExternalConfig(bool checked)
@@ -361,7 +361,7 @@ void ServerConfigDialog::toggleExternalConfig(bool checked)
   ui->tabWidget->setTabEnabled(0, !checked);
   ui->tabWidget->setTabEnabled(1, !checked);
   serverConfig().setUseExternalConfig(checked);
-  onChange();
+  setButtonBoxEnabledButtons();
 }
 
 bool ServerConfigDialog::browseConfigFile()
@@ -376,7 +376,7 @@ bool ServerConfigDialog::browseConfigFile()
   if (!fileName.isEmpty()) {
     ui->lineConfigFile->setText(fileName);
     serverConfig().setConfigFile(ui->lineConfigFile->text());
-    onChange();
+    setButtonBoxEnabledButtons();
     return true;
   }
 
@@ -504,7 +504,9 @@ void ServerConfigDialog::initConnections() const
       ui->cbDefaultLockToComputerState, &QCheckBox::toggled, this, &ServerConfigDialog::toggleDefaultLockToComputerState
   );
   connect(ui->cbDisableLockToComputer, &QCheckBox::toggled, this, &ServerConfigDialog::toggleLockToComputer);
-  connect(&m_screenSetupModel, &ScreenSetupModel::screensChanged, this, &ServerConfigDialog::onChange);
+  connect(
+      &m_screenSetupModel, &ScreenSetupModel::screensChanged, this, &ServerConfigDialog::setButtonBoxEnabledButtons
+  );
   connect(Settings::instance(), &Settings::settingsWritableChanged, this, &ServerConfigDialog::updateControls);
 }
 
@@ -560,7 +562,7 @@ bool ServerConfigDialog::isGeneralConfigModified() const
          m_defaultLockToComputerState != Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
 }
 
-void ServerConfigDialog::onChange()
+void ServerConfigDialog::setButtonBoxEnabledButtons() const
 {
   const bool writable = Settings::isWritable();
   m_buttonBox->enableSave(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -39,9 +39,9 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->tabWidget->setCurrentIndex(0);
   layout()->addWidget(m_buttonBox);
 
-  m_buttonBox->enableReset(false);
   m_buttonBox->enableRestoreDefaults(false);
 
+  setOriginalServerConfig(serverConfig());
   loadFromConfig();
 
   ui->lblRemoveScreen->setPixmap(QIcon::fromTheme("user-trash").pixmap(QSize(64, 64)));
@@ -457,10 +457,23 @@ void ServerConfigDialog::loadFromConfig()
   updateControls();
 }
 
+void ServerConfigDialog::resetFromSettings()
+{
+  m_serverConfig = m_originalServerConfig;
+  m_serverConfig.setConfigFile(m_originalServerConfigUsesExternalFile);
+  m_serverConfig.setUseExternalConfig(m_originalServerConfigIsExternal);
+  loadFromConfig();
+  if (ui->tabWidget->currentWidget() == ui->tabComputers) {
+    ui->screenSetupView->reset();
+    ui->screenSetupView->update();
+  }
+}
+
 void ServerConfigDialog::initConnections() const
 {
   connect(m_buttonBox, &SettingsDialogButtonBox::accepted, this, &ServerConfigDialog::save);
   connect(m_buttonBox, &SettingsDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
+  connect(m_buttonBox, &SettingsDialogButtonBox::reset, this, &ServerConfigDialog::resetFromSettings);
   connect(ui->lblRemoveScreen, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
   connect(ui->btnNewHotkey, &QPushButton::clicked, this, &ServerConfigDialog::addHotkey);
   connect(ui->btnEditHotkey, &QPushButton::clicked, this, &ServerConfigDialog::editHotkey);
@@ -527,6 +540,7 @@ void ServerConfigDialog::updateControls() const
   ui->sbSwitchDoubleTap->setEnabled(writable && ui->cbSwitchDoubleTap->isChecked());
   ui->sbSwitchDelay->setEnabled(writable && ui->cbSwitchDelay->isChecked());
   ui->groupExternalConfig->setEnabled(writable);
+  setButtonBoxEnabledButtons();
 }
 
 bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
@@ -566,4 +580,5 @@ void ServerConfigDialog::setButtonBoxEnabledButtons() const
 {
   const bool writable = Settings::isWritable();
   m_buttonBox->enableSave(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));
+  m_buttonBox->enableReset(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -541,23 +541,27 @@ bool ServerConfigDialog::addComputer(const QString &clientName, bool doSilent)
   return isAccepted;
 }
 
+bool ServerConfigDialog::isGeneralConfigModified() const
+{
+  return m_originalServerConfigIsExternal != Settings::value(Settings::Server::ExternalConfig).toBool() ||
+         m_originalServerConfigUsesExternalFile != Settings::value(Settings::Server::ExternalConfigFile).toString() ||
+         m_protocol != Settings::networkProtocol() ||
+         m_enableClipboard != Settings::value(Settings::Server::EnableClipboard).toBool() ||
+         m_clipboardSize != Settings::value(Settings::Server::ClipboardSize).toUInt() ||
+         m_enableHeartbeat != Settings::value(Settings::Server::EnableHeatbeat).toBool() ||
+         m_heartbeatRate != Settings::value(Settings::Server::Heartbeat).toInt() ||
+         m_enableSwitchDelay != Settings::value(Settings::Server::EnableSwitchDelay).toBool() ||
+         m_switchDelay != Settings::value(Settings::Server::SwitchDelay).toInt() ||
+         m_enableSwitchDoubleTap != Settings::value(Settings::Server::EnableSwitchDoubleTap).toBool() ||
+         m_switchDoubleTap != Settings::value(Settings::Server::SwitchDoubleTap).toInt() ||
+         m_relativeMouseMoves != Settings::value(Settings::Server::RelativeMouseMoves).toBool() ||
+         m_win32keepForeground != Settings::value(Settings::Server::Win32KeepForeground).toBool() ||
+         m_disableLockToComputer != Settings::value(Settings::Server::DisableLockToComputer).toBool() ||
+         m_defaultLockToComputerState != Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
+}
+
 void ServerConfigDialog::onChange()
 {
-  bool isAppConfigDataEqual =
-      m_originalServerConfigIsExternal == serverConfig().useExternalConfig() &&
-      m_originalServerConfigUsesExternalFile == serverConfig().configFile() &&
-      m_protocol == Settings::networkProtocol() &&
-      m_enableClipboard == Settings::value(Settings::Server::EnableClipboard).toBool() &&
-      m_clipboardSize == Settings::value(Settings::Server::ClipboardSize).toUInt() &&
-      m_enableHeartbeat == Settings::value(Settings::Server::EnableHeatbeat).toBool() &&
-      m_heartbeatRate == Settings::value(Settings::Server::Heartbeat).toInt() &&
-      m_enableSwitchDelay == Settings::value(Settings::Server::EnableSwitchDelay).toBool() &&
-      m_switchDelay == Settings::value(Settings::Server::SwitchDelay).toInt() &&
-      m_enableSwitchDoubleTap == Settings::value(Settings::Server::EnableSwitchDoubleTap).toBool() &&
-      m_switchDoubleTap == Settings::value(Settings::Server::SwitchDoubleTap).toInt() &&
-      m_relativeMouseMoves == Settings::value(Settings::Server::RelativeMouseMoves).toBool() &&
-      m_win32keepForeground == Settings::value(Settings::Server::Win32KeepForeground).toBool() &&
-      m_disableLockToComputer == Settings::value(Settings::Server::DisableLockToComputer).toBool() &&
-      m_defaultLockToComputerState == Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
-  m_buttonBox->enableSave(!isAppConfigDataEqual || !(m_originalServerConfig == m_serverConfig));
+  const bool writable = Settings::isWritable();
+  m_buttonBox->enableSave(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -41,7 +41,6 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
 
   m_buttonBox->enableRestoreDefaults(false);
 
-  setOriginalServerConfig(serverConfig());
   loadFromConfig();
 
   ui->lblRemoveScreen->setPixmap(QIcon::fromTheme("user-trash").pixmap(QSize(64, 64)));
@@ -52,7 +51,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   if (!deskflow::platform::isWindows())
     ui->cbWin32KeepForeground->setVisible(false);
   initConnections();
-  setButtonBoxEnabledButtons();
+  updateControls();
 }
 
 ServerConfigDialog::~ServerConfigDialog() = default;
@@ -74,7 +73,6 @@ void ServerConfigDialog::save()
       return;
     }
   }
-
   // now that the dialog has been accepted, copy the new server config to the
   // original one, which is a reference to the one in MainWindow.
   setOriginalServerConfig(serverConfig());
@@ -91,6 +89,8 @@ void ServerConfigDialog::save()
   Settings::setValue(Settings::Server::SwitchDoubleTap, m_switchDoubleTap);
   Settings::setValue(Settings::Server::RelativeMouseMoves, m_relativeMouseMoves);
   Settings::setValue(Settings::Server::Win32KeepForeground, m_win32keepForeground);
+  Settings::setValue(Settings::Server::ExternalConfig, ui->groupExternalConfig->isChecked());
+  Settings::setValue(Settings::Server::ExternalConfigFile, ui->lineConfigFile->text());
 
   QStringList screenNames;
   const auto screenList = m_screenSetupModel.m_Screens;
@@ -109,7 +109,6 @@ void ServerConfigDialog::cancel()
 {
   serverConfig().setUseExternalConfig(m_originalServerConfigIsExternal);
   serverConfig().setConfigFile(m_originalServerConfigUsesExternalFile);
-
   QDialog::reject();
 }
 
@@ -375,8 +374,7 @@ bool ServerConfigDialog::browseConfigFile()
 
   if (!fileName.isEmpty()) {
     ui->lineConfigFile->setText(fileName);
-    serverConfig().setConfigFile(ui->lineConfigFile->text());
-    setButtonBoxEnabledButtons();
+    setServerConfig();
     return true;
   }
 
@@ -508,6 +506,7 @@ void ServerConfigDialog::initConnections() const
   connect(ui->cbEnableClipboard, &QCheckBox::toggled, this, &ServerConfigDialog::toggleClipboard);
   connect(ui->btnBrowseConfigFile, &QPushButton::clicked, this, &ServerConfigDialog::browseConfigFile);
   connect(ui->groupExternalConfig, &QGroupBox::toggled, this, &ServerConfigDialog::toggleExternalConfig);
+  connect(ui->lineConfigFile, &QLineEdit::textChanged, this, &ServerConfigDialog::setServerConfig);
 
   connect(
       ui->sbClipboardSizeLimit, QOverload<int>::of(&QSpinBox::valueChanged), this,
@@ -540,6 +539,17 @@ void ServerConfigDialog::updateControls() const
   ui->sbSwitchDoubleTap->setEnabled(writable && ui->cbSwitchDoubleTap->isChecked());
   ui->sbSwitchDelay->setEnabled(writable && ui->cbSwitchDelay->isChecked());
   ui->groupExternalConfig->setEnabled(writable);
+  setButtonBoxEnabledButtons();
+}
+
+void ServerConfigDialog::setServerConfig()
+{
+  const auto configFile = ui->lineConfigFile->text();
+  if (!QFile::exists(configFile)) {
+    m_buttonBox->enableSave(false);
+    return;
+  }
+  serverConfig().setConfigFile(configFile);
   setButtonBoxEnabledButtons();
 }
 

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -39,8 +39,6 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   ui->tabWidget->setCurrentIndex(0);
   layout()->addWidget(m_buttonBox);
 
-  m_buttonBox->enableRestoreDefaults(false);
-
   loadFromConfig();
 
   ui->lblRemoveScreen->setPixmap(QIcon::fromTheme("user-trash").pixmap(QSize(64, 64)));
@@ -51,7 +49,6 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent, ServerConfig &config)
   if (!deskflow::platform::isWindows())
     ui->cbWin32KeepForeground->setVisible(false);
   initConnections();
-  updateControls();
 }
 
 ServerConfigDialog::~ServerConfigDialog() = default;
@@ -384,55 +381,23 @@ bool ServerConfigDialog::browseConfigFile()
 void ServerConfigDialog::loadFromConfig()
 {
   m_protocol = Settings::networkProtocol();
-  ui->rbProtocolSynergy->setChecked(m_protocol == NetworkProtocol::Synergy);
-  ui->rbProtocolBarrier->setChecked(m_protocol == NetworkProtocol::Barrier);
+  m_enableHeartbeat = Settings::value(Settings::Server::EnableHeatbeat).toBool();
+  m_heartbeatRate = Settings::value(Settings::Server::Heartbeat).toInt();
+  m_relativeMouseMoves = Settings::value(Settings::Server::RelativeMouseMoves).toBool();
+  m_win32keepForeground = Settings::value(Settings::Server::Win32KeepForeground).toBool();
+  m_enableSwitchDelay = Settings::value(Settings::Server::EnableSwitchDelay).toBool();
+  m_switchDelay = Settings::value(Settings::Server::SwitchDelay).toInt();
+  m_enableSwitchDoubleTap = Settings::value(Settings::Server::EnableSwitchDoubleTap).toBool();
+  m_switchDoubleTap = Settings::value(Settings::Server::SwitchDoubleTap).toInt();
+  m_defaultLockToComputerState = Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
+  m_disableLockToComputer = Settings::value(Settings::Server::DisableLockToComputer).toBool();
+  m_enableClipboard = Settings::value(Settings::Server::EnableClipboard).toBool();
+  m_clipboardSize = Settings::value(Settings::Server::ClipboardSize).toUInt();
 
   ui->lineConfigFile->setText(serverConfig().configFile());
-
-  m_enableHeartbeat = Settings::value(Settings::Server::EnableHeatbeat).toBool();
-  ui->cbHeartbeat->setChecked(m_enableHeartbeat);
-  ui->sbHeartbeat->setEnabled(ui->cbHeartbeat->isChecked());
-
-  m_heartbeatRate = Settings::value(Settings::Server::Heartbeat).toInt();
-  ui->sbHeartbeat->setValue(m_heartbeatRate);
-
-  m_relativeMouseMoves = Settings::value(Settings::Server::RelativeMouseMoves).toBool();
-  ui->cbRelativeMouseMoves->setChecked(m_relativeMouseMoves);
-
-  m_win32keepForeground = Settings::value(Settings::Server::Win32KeepForeground).toBool();
-  ui->cbWin32KeepForeground->setChecked(m_win32keepForeground);
-
-  m_enableSwitchDelay = Settings::value(Settings::Server::EnableSwitchDelay).toBool();
-  ui->cbSwitchDelay->setChecked(m_enableSwitchDelay);
-  ui->sbSwitchDelay->setEnabled(ui->cbSwitchDelay->isChecked());
-
-  m_switchDelay = Settings::value(Settings::Server::SwitchDelay).toInt();
-  ui->sbSwitchDelay->setValue(m_switchDelay);
-
-  m_enableSwitchDoubleTap = Settings::value(Settings::Server::EnableSwitchDoubleTap).toBool();
-  ui->cbSwitchDoubleTap->setChecked(m_enableSwitchDoubleTap);
-  ui->sbSwitchDoubleTap->setEnabled(ui->cbSwitchDoubleTap->isChecked());
-
-  m_switchDoubleTap = Settings::value(Settings::Server::SwitchDoubleTap).toInt();
-  ui->sbSwitchDoubleTap->setValue(m_switchDoubleTap);
-
   ui->groupExternalConfig->setChecked(serverConfig().useExternalConfig());
 
-  ui->widgetExternalConfigControls->setEnabled(ui->groupExternalConfig->isChecked());
-  toggleExternalConfig(ui->groupExternalConfig->isChecked());
-
-  m_defaultLockToComputerState = Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
-  ui->cbDefaultLockToComputerState->setChecked(m_defaultLockToComputerState);
-
-  m_disableLockToComputer = Settings::value(Settings::Server::DisableLockToComputer).toBool();
-  ui->cbDisableLockToComputer->setChecked(m_disableLockToComputer);
-
-  m_enableClipboard = Settings::value(Settings::Server::EnableClipboard).toBool();
-  ui->cbEnableClipboard->setChecked(m_enableClipboard);
-  ui->sbClipboardSizeLimit->setEnabled(m_enableClipboard);
-
-  m_clipboardSize = Settings::value(Settings::Server::ClipboardSize).toUInt();
-  ui->sbClipboardSizeLimit->setValue(m_clipboardSize);
+  refreshControls();
 
   ui->listHotkeys->clear();
   for (const Hotkey &hotkey : std::as_const(serverConfig().hotkeys()))
@@ -467,11 +432,37 @@ void ServerConfigDialog::resetFromSettings()
   }
 }
 
+void ServerConfigDialog::refreshControls()
+{
+  ui->rbProtocolSynergy->setChecked(m_protocol == NetworkProtocol::Synergy);
+  ui->rbProtocolBarrier->setChecked(m_protocol == NetworkProtocol::Barrier);
+  ui->cbHeartbeat->setChecked(m_enableHeartbeat);
+  ui->sbHeartbeat->setEnabled(ui->cbHeartbeat->isChecked());
+  ui->sbHeartbeat->setValue(m_heartbeatRate);
+  ui->cbRelativeMouseMoves->setChecked(m_relativeMouseMoves);
+  ui->cbWin32KeepForeground->setChecked(m_win32keepForeground);
+  ui->cbSwitchDelay->setChecked(m_enableSwitchDelay);
+  ui->sbSwitchDelay->setEnabled(ui->cbSwitchDelay->isChecked());
+  ui->sbSwitchDelay->setValue(m_switchDelay);
+  ui->cbSwitchDoubleTap->setChecked(m_enableSwitchDoubleTap);
+  ui->sbSwitchDoubleTap->setEnabled(ui->cbSwitchDoubleTap->isChecked());
+  ui->sbSwitchDoubleTap->setValue(m_switchDoubleTap);
+  ui->widgetExternalConfigControls->setEnabled(ui->groupExternalConfig->isChecked());
+  toggleExternalConfig(ui->groupExternalConfig->isChecked());
+  ui->cbDefaultLockToComputerState->setChecked(m_defaultLockToComputerState);
+  ui->cbDisableLockToComputer->setChecked(m_disableLockToComputer);
+  ui->cbEnableClipboard->setChecked(m_enableClipboard);
+  ui->sbClipboardSizeLimit->setEnabled(m_enableClipboard);
+  ui->sbClipboardSizeLimit->setValue(m_clipboardSize);
+}
+
 void ServerConfigDialog::initConnections() const
 {
   connect(m_buttonBox, &SettingsDialogButtonBox::accepted, this, &ServerConfigDialog::save);
   connect(m_buttonBox, &SettingsDialogButtonBox::rejected, this, &ServerConfigDialog::cancel);
   connect(m_buttonBox, &SettingsDialogButtonBox::reset, this, &ServerConfigDialog::resetFromSettings);
+  connect(m_buttonBox, &SettingsDialogButtonBox::restoreDefault, this, &ServerConfigDialog::restoreFromDefaults);
+  connect(ui->tabWidget, &QTabWidget::currentChanged, this, &ServerConfigDialog::setButtonBoxEnabledButtons);
   connect(ui->lblRemoveScreen, &TrashScreenWidget::screenRemoved, this, &ServerConfigDialog::onScreenRemoved);
   connect(ui->btnNewHotkey, &QPushButton::clicked, this, &ServerConfigDialog::addHotkey);
   connect(ui->btnEditHotkey, &QPushButton::clicked, this, &ServerConfigDialog::editHotkey);
@@ -542,6 +533,29 @@ void ServerConfigDialog::updateControls() const
   setButtonBoxEnabledButtons();
 }
 
+void ServerConfigDialog::restoreFromDefaults()
+{
+  m_protocol = networkProtocolFromString(Settings::defaultValue(Settings::Server::Protocol).toString());
+  m_enableHeartbeat = Settings::defaultValue(Settings::Server::EnableHeatbeat).toBool();
+  m_heartbeatRate = Settings::defaultValue(Settings::Server::Heartbeat).toInt();
+  m_relativeMouseMoves = Settings::defaultValue(Settings::Server::RelativeMouseMoves).toBool();
+  m_win32keepForeground = Settings::defaultValue(Settings::Server::Win32KeepForeground).toBool();
+  m_enableSwitchDelay = Settings::defaultValue(Settings::Server::EnableSwitchDelay).toBool();
+  m_switchDelay = Settings::defaultValue(Settings::Server::SwitchDelay).toInt();
+  m_enableSwitchDoubleTap = Settings::defaultValue(Settings::Server::EnableSwitchDoubleTap).toBool();
+  m_switchDoubleTap = Settings::defaultValue(Settings::Server::SwitchDoubleTap).toInt();
+  m_defaultLockToComputerState = Settings::defaultValue(Settings::Server::DefaultLockToComputerState).toBool();
+  m_disableLockToComputer = Settings::defaultValue(Settings::Server::DisableLockToComputer).toBool();
+  m_enableClipboard = Settings::defaultValue(Settings::Server::EnableClipboard).toBool();
+  m_clipboardSize = Settings::defaultValue(Settings::Server::ClipboardSize).toUInt();
+
+  ui->groupExternalConfig->setChecked(Settings::defaultValue(Settings::Server::ExternalConfig).toBool());
+  ui->lineConfigFile->setText(Settings::defaultValue(Settings::Server::ExternalConfigFile).toString());
+
+  refreshControls();
+  updateControls();
+}
+
 void ServerConfigDialog::setServerConfig()
 {
   const auto configFile = ui->lineConfigFile->text();
@@ -586,9 +600,29 @@ bool ServerConfigDialog::isGeneralConfigModified() const
          m_defaultLockToComputerState != Settings::value(Settings::Server::DefaultLockToComputerState).toBool();
 }
 
+bool ServerConfigDialog::isGeneralConfigDefault() const
+{
+  return ui->groupExternalConfig->isChecked() == Settings::defaultValue(Settings::Server::ExternalConfig).toBool() &&
+         ui->lineConfigFile->text() == Settings::defaultValue(Settings::Server::ExternalConfigFile).toString() &&
+         m_protocol == networkProtocolFromString(Settings::defaultValue(Settings::Server::Protocol).toString()) &&
+         m_enableClipboard == Settings::defaultValue(Settings::Server::EnableClipboard).toBool() &&
+         m_clipboardSize == Settings::defaultValue(Settings::Server::ClipboardSize).toUInt() &&
+         m_enableHeartbeat == Settings::defaultValue(Settings::Server::EnableHeatbeat).toBool() &&
+         m_heartbeatRate == Settings::defaultValue(Settings::Server::Heartbeat).toInt() &&
+         m_enableSwitchDelay == Settings::defaultValue(Settings::Server::EnableSwitchDelay).toBool() &&
+         m_switchDelay == Settings::defaultValue(Settings::Server::SwitchDelay).toInt() &&
+         m_enableSwitchDoubleTap == Settings::defaultValue(Settings::Server::EnableSwitchDoubleTap).toBool() &&
+         m_switchDoubleTap == Settings::defaultValue(Settings::Server::SwitchDoubleTap).toInt() &&
+         m_relativeMouseMoves == Settings::defaultValue(Settings::Server::RelativeMouseMoves).toBool() &&
+         m_win32keepForeground == Settings::defaultValue(Settings::Server::Win32KeepForeground).toBool() &&
+         m_disableLockToComputer == Settings::defaultValue(Settings::Server::DisableLockToComputer).toBool() &&
+         m_defaultLockToComputerState == Settings::defaultValue(Settings::Server::DefaultLockToComputerState).toBool();
+}
+
 void ServerConfigDialog::setButtonBoxEnabledButtons() const
 {
   const bool writable = Settings::isWritable();
   m_buttonBox->enableSave(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));
   m_buttonBox->enableReset(writable && (isGeneralConfigModified() || !(m_originalServerConfig == m_serverConfig)));
+  m_buttonBox->enableRestoreDefaults(writable && !isGeneralConfigDefault() && ui->tabWidget->currentIndex() == 2);
 }

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -91,6 +91,7 @@ private:
   void resetFromSettings();
   void initConnections() const;
   void updateControls() const;
+  void setServerConfig();
   bool isGeneralConfigModified() const;
   void setButtonBoxEnabledButtons() const;
   std::unique_ptr<Ui::ServerConfigDialog> ui;

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -90,6 +90,7 @@ private:
   void loadFromConfig();
   void initConnections() const;
   void updateControls() const;
+  bool isGeneralConfigModified() const;
   void onChange();
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -89,10 +89,13 @@ private:
   void cancel();
   void loadFromConfig();
   void resetFromSettings();
+  void refreshControls();
   void initConnections() const;
   void updateControls() const;
+  void restoreFromDefaults();
   void setServerConfig();
   bool isGeneralConfigModified() const;
+  bool isGeneralConfigDefault() const;
   void setButtonBoxEnabledButtons() const;
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -88,6 +88,7 @@ private:
   void save();
   void cancel();
   void loadFromConfig();
+  void resetFromSettings();
   void initConnections() const;
   void updateControls() const;
   bool isGeneralConfigModified() const;

--- a/src/lib/gui/dialogs/ServerConfigDialog.h
+++ b/src/lib/gui/dialogs/ServerConfigDialog.h
@@ -91,7 +91,7 @@ private:
   void initConnections() const;
   void updateControls() const;
   bool isGeneralConfigModified() const;
-  void onChange();
+  void setButtonBoxEnabledButtons() const;
   std::unique_ptr<Ui::ServerConfigDialog> ui;
   QString m_message = "";
   int m_columns;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Server Config Dialog Changes
 - Fix Saving of external config file when editing the line and not browsing
 - onChange -> setButtonBoxEnabledButtons
 - Provide a reset feature to reload settings from their initial state
 - provide a restoredefaults methods to reset items in Deskflow.conf
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
N/A
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally 