### PR TITLE
ci: macOS artifacts are now signed and notarized

### DIFF
--- a/.github/actions/codesign-keychain/action.yml
+++ b/.github/actions/codesign-keychain/action.yml
@@ -1,0 +1,47 @@
+name: "Apple code-signing keychain"
+description: "Imports or cleans up the temporary keychain used to hold the Apple Developer ID certificate"
+
+inputs:
+  action:
+    description: "Which lifecycle step to run: 'import' or 'cleanup'"
+    required: true
+
+  apple-codesign-p12:
+    description: "Base64-encoded Apple codesign certificate (.p12), required for 'import'"
+    required: false
+
+  apple-codesign-p12-pwd:
+    description: "Password for the Apple codesign certificate (.p12), required for 'import'"
+    required: false
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Import certificate
+      if: inputs.action == 'import'
+      shell: bash
+      env:
+        APPLE_CODESIGN_P12: ${{ inputs.apple-codesign-p12 }}
+        APPLE_CODESIGN_P12_PWD: ${{ inputs.apple-codesign-p12-pwd }}
+      run: |
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+        APPLE_CODESIGN_BUILD_PWD=$(openssl rand -hex 32)
+        echo "::add-mask::$APPLE_CODESIGN_BUILD_PWD"
+        echo -n "$APPLE_CODESIGN_P12" | base64 --decode > $CERTIFICATE_PATH
+        security create-keychain -p "$APPLE_CODESIGN_BUILD_PWD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$APPLE_CODESIGN_BUILD_PWD" $KEYCHAIN_PATH
+        security import $CERTIFICATE_PATH -k $KEYCHAIN_PATH -P "$APPLE_CODESIGN_P12_PWD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_CODESIGN_BUILD_PWD" $KEYCHAIN_PATH
+        security list-keychains -d user -s $KEYCHAIN_PATH
+
+    - name: Clean up keychain
+      if: inputs.action == 'cleanup'
+      shell: bash
+      run: |
+        if [ -f $RUNNER_TEMP/build.keychain ]; then
+          security delete-keychain $RUNNER_TEMP/build.keychain
+        fi
+        rm -f $RUNNER_TEMP/build_certificate.p12

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,15 +113,15 @@ jobs:
 
           - name: "macos-arm64"
             runs-on: macos-15
-            timeout: 10
+            timeout: 20
             qt-version: 6.11.2
             config-args: '-DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=14'
 
           - name: "macos-x64"
             runs-on: macos-15-intel
-            timeout: 20
+            timeout: 30
             qt-version: 6.9.3
-            config-args: '-DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DCMAKE_OSX_SYSROOT=/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
+            config-args: '-DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DCMAKE_OSX_SYSROOT=/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk ${APPLE_CODESIGN_DEV:+-DAPPLE_CODESIGN_DEV="$APPLE_CODESIGN_DEV"}'
 
           - name: "debian-x86_64"
             runs-on: ubuntu-latest
@@ -271,7 +271,17 @@ jobs:
         uses: ./.github/actions/get-version
 
       - name: Configure
+        env:
+          APPLE_CODESIGN_DEV: ${{ secrets.APPLE_CODESIGN_DEV }}
         run: ${{env.CMAKE_CONFIGURE}} ${{ matrix.target.config-args }} ${{ steps.get-deps.outputs.vcpkg-cmake-config }} -DPACKAGE_VERSION_LABEL="${{env.DESKFLOW_PACKAGE_VERSION}}"
+
+      - name: Import code-signing certificate
+        if: runner.os == 'macOS' && ((github.ref == 'refs/heads/master') || (contains(github.ref, '/tags/v')))
+        uses: ./.github/actions/codesign-keychain
+        with:
+          action: import
+          apple-codesign-p12: ${{ secrets.APPLE_CODESIGN_P12 }}
+          apple-codesign-p12-pwd: ${{ secrets.APPLE_CODESIGN_P12_PWD }}
 
       - name: Build
         shell: bash
@@ -308,6 +318,26 @@ jobs:
             mv *.pkg.tar.zst deskflow-${{env.DESKFLOW_PACKAGE_VERSION}}-${OSNAME}-${ARCH}.pkg.tar.zst
             cd ..
           fi
+
+      - name: Notarize (macOS)
+        if: runner.os == 'macOS' && ((github.ref == 'refs/heads/master') || (contains(github.ref, '/tags/v')))
+        shell: bash
+        env:
+          APPLE_NOTARIZE_ID: ${{ secrets.APPLE_NOTARIZE_ID }}
+          APPLE_NOTARIZE_PWD: ${{ secrets.APPLE_NOTARIZE_PWD }}
+          APPLE_CODESIGN_DEV: ${{ secrets.APPLE_CODESIGN_DEV }}
+        run: |
+          [[ "$APPLE_CODESIGN_DEV" =~ ^Developer\ ID\ Application:\ .+\ \(([A-Z0-9]+)\)$ ]]
+          APPLE_NOTARIZE_TEAM="${BASH_REMATCH[1]}"
+          xcrun codesign -s "${APPLE_CODESIGN_DEV}" build/deskflow[-_]*.dmg
+          xcrun notarytool submit --apple-id "${APPLE_NOTARIZE_ID}" --password "${APPLE_NOTARIZE_PWD}" --team-id "${APPLE_NOTARIZE_TEAM}" --wait build/deskflow[-_]*.dmg
+          xcrun stapler staple build/deskflow[-_]*.dmg
+
+      - name: Clean up keychain
+        if: always() && runner.os == 'macOS' && ((github.ref == 'refs/heads/master') || (contains(github.ref, '/tags/v')))
+        uses: ./.github/actions/codesign-keychain
+        with:
+          action: cleanup
 
       - name: Check for unexpected repo changes
         shell: bash


### PR DESCRIPTION
## Description
This allows CI to deliver a signed and notarized Deskflow.app for macOS

**Depends on #10087 landing first.**

Before continuing, a codesigning identity is needed.

A paid Apple Developer is required for signing and notarizing.

Follow the following instructions to generate a developer id certificate: https://developer.apple.com/help/account/certificates/create-developer-id-certificates/

Then, to use it, there's the need to define the following secrets in the repository:

**APPLE_CODESIGN_DEV**

Should contain the full name of the signing identity to be used to sign the application.

After installing your identity locally you can run `security find-identity -v` to find the full name of your identity.
It should look something like:
`Developer ID Application: <dev name> (<team id>)`

**APPLE_CODESIGN_P12**

Should contain the P12 container file in base64. 

Please ensure both the certificate and private key are exported.

In order to generate this, in your local machine where you have the identity installed, head to "Keychain Access", select your identity, right click on it and chose export. Please ensure to use a strong password to export it. Save the p12 file somewhere. Then run `base64 <p12file>` on a terminal to get its content in base64. You can run `base64 <p12file> | pbcopy` to directly copy its content to the clipboard.

**APPLE_CODESIGN_P12_PWD**

Should contain the P12 password in plain text. 

This is what was used in "Keychain Access" in order to generate APPLE_CODESIGN_P12.

**APPLE_NOTARIZE_ID**

Should contain the Apple ID of an user from the team of the Developer ID certificate.

We recommend not to use the main Apple ID of the developer account, instead create a dedicated user account on the App Store connect with the "App manager" role. Even individual developers may create those secondary accounts and they will have notarization permissions.

**APPLE_NOTARIZE_PWD**

Should contain a application specific password for that given Apple ID
It won't work with the real account password.
Head to https://account.apple.com to generate one for that account.

## Fixed/related issues
N/A

## How has this been tested?
Tested in my local fork ([amagus/deskflow](https://www.github.com/amagus/deskflow))
