### PR TITLE
ci(mac): fix cmake retry on package

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -281,16 +281,21 @@ jobs:
               cmake --build build --config Release -j8 --target package
             else
               cmake --build build --config Release -j8
+              packaged=false
               for i in $(seq 1 5); do
-                cmake --build build --config Release -j8 --target package 2>&1
-                if [ $? -eq 0 ]; then
+                if cmake --build build --config Release -j8 --target package; then
                   echo "Package successful"
+                  packaged=true
                   break
                 else
                   echo "Package attempt $i failed"
                   sleep 1
                 fi
               done
+              if [ "$packaged" != true ]; then
+                echo "Packaging failed after $i attempts" >&2
+                exit 1
+              fi
             fi
           else
             cmake --build build --config Release -j8


### PR DESCRIPTION
## Description
Attempts to fix DMG creation issues based on retry.

Github actions bash scripting always fail on the first failed command. The retry logic was basically dead code. This changes the way the cmake packages step runs for mac os runners and really attempts to run it 5 times.

## AI tools used for this PR
N/A

## Fixed/related issues
N/A

## How has this been tested?
Tested on my local fork
