### PR TITLE
Default action for help dialog

### DIFF
--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -107,6 +107,7 @@ MainWindow::MainWindow()
 
   m_actionSettings->setIcon(QIcon::fromTheme(QStringLiteral("configure")));
   m_actionSettings->setMenuRole(QAction::PreferencesRole);
+  m_actionSettings->setShortcut(QKeySequence::Preferences);
 
   m_actionStartCore->setIcon(QIcon::fromTheme(QStringLiteral("system-run")));
   m_actionStartCore->setMenuRole(QAction::NoRole);

--- a/src/lib/gui/MainWindow.cpp
+++ b/src/lib/gui/MainWindow.cpp
@@ -120,6 +120,7 @@ MainWindow::MainWindow()
 
   m_actionShowHelp->setIcon(QIcon::fromTheme(QStringLiteral("question")));
   m_actionShowHelp->setMenuRole(QAction::NoRole);
+  m_actionShowHelp->setShortcut(QKeySequence::HelpContents);
 
   // Setup the Instance Checking
   // In case of a previous crash remove first

--- a/src/lib/gui/dialogs/HelpDialog.cpp
+++ b/src/lib/gui/dialogs/HelpDialog.cpp
@@ -32,6 +32,8 @@ HelpDialog::HelpDialog(QWidget *parent, const QUrl &source)
   m_btnHome->setMaximumWidth(m_btnHome->height());
   m_btnHome->setEnabled(false);
   m_btnClose->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::WindowClose));
+  m_btnClose->setDefault(true);
+  m_btnClose->setFocus();
 
   updateText();
 


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 1. Focus the Close button when the Help Dialog is opened
 2. Set the shortcut for the showHelp action to the standard HelpContents sequence
 3. Set the shortcut for the preferences dialog to the standard Preferences sequence
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
 N/A
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally