### PR TITLE
fix(windows): send space for ctrl+space and shift+space with korean IME

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1278,6 +1278,11 @@ KeyID MSWindowsKeyState::getKeyID(UINT virtualKey, KeyButton button) const
   // But they have different X11 keysym. So we should distinguish them.
   if ((LOWORD(m_keyLayout) & 0xffffu) == 0x0412u) { // 0x0412 : Korean Locale ID
     if (virtualKey == VK_HANGUL || virtualKey == VK_HANJA) {
+      const auto hangulSpace = 0x0039u;
+      if (button == hangulSpace) {
+        return VK_SPACE;
+      }
+
       // If shift-space is used to change the input mode,
       // the extented bit is not set. So add it to get right key id.
       button |= 0x100u;


### PR DESCRIPTION
## Description

With the Korean IME active on a Windows server, `ctrl+space` and `shift+space` never reach the client.

The Korean IME rewrites the virtual key before the low-level hook sees it: `shift+space` arrives as `VK_HANGUL` and `ctrl+space` as `VK_HANJA`, while the scan code stays that of the space bar. `getKeyID()` treats those as the real IME keys and sends `kKeyHangul`/`kKeyHanja` to the client. Clients whose key map has no entry for those key ids — macOS in particular — drop the key press silently, so the combination is simply lost.

Captured on a Windows 11 server (log level `Verbose`), before the change:

```
hook: vk=0x19 up=0 scan=0x039 ext=0        <- physically the space bar
mapKeyFromEvent: wc=0x0000 vk=0x19 button=0x039 -> id=0xef34
send key down to "<mac client>" id=61236   <- 0xEF34 = kKeyHanja
```

The physical scan code tells the two cases apart:

| input | vk | scan | ext |
|---|---|---|---|
| real hangul key | `0x15` | `0x1f2` | 1 |
| real hanja key | `0x19` | `0x1f2` | 1 |
| shift+space | `0x15` | `0x039` | 0 |
| ctrl+space | `0x19` | `0x039` | 0 |

The real hangul and hanja keys always arrive with the extended bit set, so a plain `0x39` scan code means the space bar was pressed. This patch maps that case back to a space key id and lets the client synthesize it with whatever modifier is currently active. The extended-bit path for the genuine IME keys is untouched.

Trade-off worth a reviewer's attention: on this server, `shift+space` / `ctrl+space` now travel to the client as space plus the modifier instead of as `kKeyHangul` / `kKeyHanja`. That is the correct behaviour for a macOS client, which has no key map entry for those ids and discards them today. For Windows and Linux clients the change means the client's own IME sees `shift+space` rather than a synthesized hangul key — I have not been able to test those client platforms, so I am happy to gate the behaviour differently if maintainers prefer.

## AI tools used for this PR

Claude Opus 5, used through Claude Code (the CLI), for:

- analysing the Verbose server logs and narrowing the cause down to the IME virtual-key rewrite
- reviewing and discarding several earlier attempts at a fix that turned out to be dead code or to cause regressions (for example, unconditionally converting `kKeyHangul` to space, which broke the real hangul key)
- drafting the patch and this description

All findings were verified against real capture logs on real hardware, and the final behaviour was confirmed by hand (see below). The commit carries a `Co-Authored-By: Claude Code` trailer.

## Fixed/related issues

No open issue tracks this exact case, so there is no `fixes:` line.

Related, previously reported and closed without a fix:

- #7253 — "Want to send Shift-Space to client." (closed as *not planned* by the stale bot; same Windows 11 server → macOS client symptom)
- #5712 — "macOS client cannot receive some key combination from Windows server."
- #3764 — "Support Shift-Space for Korean"

Those reports proposed patching `KeyMap.cpp` to translate `kKeyHangul`/`kKeyHanja` into space. That approach also rewrites the genuine hangul and hanja keys; keying off the scan code in `MSWindowsKeyState::getKeyID()` fixes the combinations without touching the real IME keys.

## How has this been tested?

Manually, on real hardware.

**Environment**

- Server: Windows 11 Pro (26200), Korean keyboard layout (`0x0412`), Microsoft Korean IME, built from this branch
- Client: macOS Tahoe 26.5.2, MacBook Air 15"

**Procedure**

Stopped the GUI, daemon and core, set `[log] level=Verbose` in `Deskflow.conf`, and ran the core directly from a console so the log could be captured:

```powershell
build\bin\Release\deskflow-core.exe server --new-instance `
  --settings "$env:APPDATA\Deskflow\Deskflow.conf" > core.log 2>&1
```

**Results after the change**

```
send key down to "<mac client>" id=32, mask=0x2002, button=0x0039   <- ctrl+space
send key down to "<mac client>" id=32, mask=0x2001, button=0x0039   <- shift+space
```

- `ctrl+space` reaches the macOS client and works as expected
- `shift+space` inserts a space on the client
- the real hangul key (scan `0x1f2`) still yields `kKeyHangul` — it is not converted to space

One note for anyone reproducing this: do not verify with the macOS Keyboard Viewer. Synthesized modifiers show up there, but ordinary keys do not, because `OSXKeyState::postHIDVirtualKey()` sends modifiers as `NX_FLAGSCHANGED` and ordinary keys as `NX_KEYDOWN`, which the viewer does not observe. Check the actual target application or the client log instead.

**Not tested:** Windows and Linux clients — I do not have a setup for either. See the trade-off note above.