### PR TITLE
Update aqtinstall to allow Qt > 6.10 on windows, use Qt 6.11.2 

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -71,6 +71,7 @@ runs:
         version: ${{inputs.qt-version}}
         cache: true
         cache-key-prefix: ${{matrix.target.os}}-${{inputs.qt-version}}
+        aqtsource: git+https://github.com/miurahr/aqtinstall.git@16db45a70b5905ad596941b223469bc86a56901e
 
     - name: Build and cache vcpkg
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,7 +101,7 @@ jobs:
             config-args: "-G Ninja"
             vcpkg-triplet: x64-windows-release
             arch: "amd64"
-            qt-version: 6.10.3
+            qt-version: 6.11.2
 
           - name: "windows-2022-arm64"
             runs-on: "windows-11-arm"
@@ -109,12 +109,12 @@ jobs:
             config-args: "-G Ninja"
             vcpkg-triplet: arm64-windows
             arch: "arm64"
-            qt-version: 6.11.1
+            qt-version: 6.11.2
 
           - name: "macos-arm64"
             runs-on: macos-15
             timeout: 10
-            qt-version: 6.11.1
+            qt-version: 6.11.2
             config-args: '-DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=14'
 
           - name: "macos-x64"

--- a/src/apps/deskflow-gui/deskflow-gui.cpp
+++ b/src/apps/deskflow-gui/deskflow-gui.cpp
@@ -32,7 +32,7 @@
 #include <QLoggingCategory>
 #endif
 
-#if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN)
 #include "platform/XDGPortalRegistry.h"
 #endif
 
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true\nqt.*=false"));
 #endif
 
-#if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN)
   if (QT_VERSION < QT_VERSION_CHECK(6, 10, 0))
     deskflow::platform::setAppId();
 #endif

--- a/src/lib/deskflow/App.cpp
+++ b/src/lib/deskflow/App.cpp
@@ -22,7 +22,7 @@
 
 #include <stdexcept>
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 #include <ApplicationServices/ApplicationServices.h>
 #endif
 

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -37,7 +37,7 @@
 #include "platform/EiScreen.h"
 #endif
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 #include "platform/OSXScreen.h"
 #endif
 
@@ -108,7 +108,7 @@ deskflow::Screen *ClientApp::createScreen()
       ),
       getEvents()
   );
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
   return new deskflow::Screen(
       new OSXScreen(getEvents(), false, Settings::value(Settings::Client::LanguageSync).toBool()), getEvents()
   );

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -43,7 +43,7 @@
 #include "platform/EiScreen.h"
 #endif
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 #include "platform/OSXScreen.h"
 #endif
 
@@ -393,7 +393,7 @@ deskflow::Screen *ServerApp::createScreen()
   return new deskflow::Screen(
       new MSWindowsScreen(true, Settings::value(Settings::Core::UseHooks).toBool(), getEvents()), getEvents()
   );
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
   return new deskflow::Screen(new OSXScreen(getEvents(), true), getEvents());
 #else
   if (deskflow::platform::isWayland()) {

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -14,7 +14,7 @@
 #if WINAPI_XWINDOWS
 #include <X11/XKBlib.h>
 #include <deskflow/unix/XkbLayoutsParser.h>
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
 #include <Carbon/Carbon.h>
 #include <platform/OSXAutoTypes.h>
 #endif
@@ -46,7 +46,7 @@ std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
 #if WINAPI_XWINDOWS
   layoutLangCodes = XkbLayoutsParser::getXkbLanguageList();
 
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
   CFStringRef keys[] = {kTISPropertyInputSourceCategory};
   CFStringRef values[] = {kTISCategoryKeyboardInputSource};
   AutoCFDictionary dict(
@@ -142,7 +142,7 @@ std::string AppUtilUnix::getCurrentLanguageCode()
 
   result = XkbLayoutsParser::convertLayoutToISO(result);
 
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
   AutoTISInputSourceRef source(nullptr, CFRelease);
   CFArrayRef layoutLanguages = nullptr;
   {

--- a/src/lib/gui/StyleUtils.h
+++ b/src/lib/gui/StyleUtils.h
@@ -60,7 +60,7 @@ inline QFont fixedFont()
   QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 #endif
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
   f.setPointSize(12);
 #endif
   return f;


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Use `master` version of aqtinstall to fix issue installing > Qt6.10 on windows 
 - Replace deprecated `Q_OS_MAC` with `Q_OS_MACOS`
 - Use Qt 6.11.2 for Windows / and Mac (arm) builds.
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Windows builds can now use the same Qt as others
Ready to use Qt 6.12 on mac os fixing the build issue w/ the os define 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
CI / Locally (using qt 6.11 on my local mac / windows vm)
