### PR TITLE
fix(mac): reveal cursor on local client input

### DIFF
--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1660,17 +1660,13 @@ bool OSXScreen::HotKeyItem::operator<(const HotKeyItem &x) const
 CGEventRef
 OSXScreen::handleCGInputEventSecondary(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
 {
-  // this fix is really screwing with the correct show/hide behavior. it
-  // should be tested better before reintroducing.
-  return event;
-
   OSXScreen *screen = (OSXScreen *)refcon;
   if (screen->m_cursorHidden && type == kCGEventMouseMoved) {
 
     CGPoint pos = CGEventGetLocation(event);
     if (pos.x != screen->m_xCenter || pos.y != screen->m_yCenter) {
 
-      LOG_DEBUG("show cursor on secondary, type=%d pos=%d,%d", type, pos.x, pos.y);
+      LOG_DEBUG("show cursor on secondary, type=%d pos=%.0f,%.0f", static_cast<int>(type), pos.x, pos.y);
       screen->showCursor();
     }
   }


### PR DESCRIPTION
## Description

Remove the early return from the existing macOS secondary input handler so local mouse or trackpad movement reveals the hidden cursor while the shared cursor is on another screen.

The only other change corrects the format specifiers in the debug log that becomes reachable.

## AI tools used for this PR

OpenAI Codex (GPT-5 and GPT-5.6) was used for code analysis and review.

## Fixed/related issues

fixes: #8709

## How has this been tested?

- Compared clean upstream `c20870cc7` and patched builds with an Ubuntu 24.04 server and macOS 27.0 client
- Verified that the cursor stays hidden without local input and appears on the first small local trackpad movement
- Repeated Linux → Mac → Linux cursor transitions five times
- Built Release with warnings as errors
- Passed all 26 macOS tests, clang-format 20.1.0, REUSE lint, and `git diff --check`
