### PR TITLE
feat(keymap): add per-screen key mappings

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2025 - 2026 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2016 - 2025 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -127,6 +128,7 @@ public:
   struct Screen
   {
     inline static const auto Aliases = QStringLiteral("screen_%1/aliases");
+    inline static const auto KeyMappings = QStringLiteral("screen_%1/keyMappings");
   };
 
   // Track Removed keys to make upgrading config easier

--- a/src/lib/gui/CMakeLists.txt
+++ b/src/lib/gui/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(${target} STATIC
 
 target_link_libraries(${target}
   PUBLIC
+    app
     common
     platform
     net

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -34,6 +35,7 @@ void Screen::loadSettings(QSettingsProxy &settings)
   readSettings(settings, fixes(), "fix", 0, static_cast<int>(NumFixes));
 
   m_Aliases = Settings::value(Settings::Screen::Aliases.arg(name)).toStringList();
+  m_KeyMappings = Settings::value(Settings::Screen::KeyMappings.arg(name)).toStringList();
 }
 
 void Screen::saveSettings(QSettingsProxy &settings) const
@@ -46,6 +48,7 @@ void Screen::saveSettings(QSettingsProxy &settings) const
     return;
 
   Settings::setValue(Settings::Screen::Aliases.arg(screenName), m_Aliases);
+  Settings::setValue(Settings::Screen::KeyMappings.arg(screenName), m_KeyMappings);
 
   settings.setValue("switchCornerSize", switchCornerSize());
 
@@ -76,6 +79,9 @@ QString Screen::screensSection() const
 
   out.append(lineTemplate.arg(QStringLiteral("switchCornerSize"), QString::number(switchCornerSize())));
 
+  for (const auto &mapping : keyMappings()) {
+    out.append(lineTemplate.arg(QStringLiteral("keymap"), mapping));
+  }
   return out;
 }
 
@@ -83,5 +89,6 @@ bool Screen::operator==(const Screen &screen) const
 {
   return m_Name == screen.m_Name && m_Aliases == screen.m_Aliases && m_Modifiers == screen.m_Modifiers &&
          m_SwitchCorners == screen.m_SwitchCorners && m_SwitchCornerSize == screen.m_SwitchCornerSize &&
-         m_Fixes == screen.m_Fixes && m_Swapped == screen.m_Swapped && m_isServer == screen.m_isServer;
+         m_KeyMappings == screen.m_KeyMappings && m_Fixes == screen.m_Fixes && m_Swapped == screen.m_Swapped &&
+         m_isServer == screen.m_isServer;
 }

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
@@ -31,13 +32,13 @@ class Screen : public ScreenConfig
   friend QDataStream &operator<<(QDataStream &outStream, const Screen &screen)
   {
     return outStream << screen.name() << screen.switchCornerSize() << screen.aliases() << screen.modifiers()
-                     << screen.switchCorners() << screen.fixes() << screen.isServer();
+                     << screen.switchCorners() << screen.fixes() << screen.isServer() << screen.keyMappings();
   }
 
   friend QDataStream &operator>>(QDataStream &inStream, Screen &screen)
   {
     return inStream >> screen.m_Name >> screen.m_SwitchCornerSize >> screen.m_Aliases >> screen.m_Modifiers >>
-           screen.m_SwitchCorners >> screen.m_Fixes >> screen.m_isServer;
+           screen.m_SwitchCorners >> screen.m_Fixes >> screen.m_isServer >> screen.m_KeyMappings;
   }
 
 public:
@@ -79,6 +80,10 @@ public:
   [[nodiscard]] int switchCornerSize() const
   {
     return m_SwitchCornerSize;
+  }
+  [[nodiscard]] const QStringList &keyMappings() const
+  {
+    return m_KeyMappings;
   }
   [[nodiscard]] bool fix(const Fix f) const
   {
@@ -143,6 +148,10 @@ protected:
   {
     m_SwitchCornerSize = val;
   }
+  QStringList &keyMappings()
+  {
+    return m_KeyMappings;
+  }
   void setFix(const Fix f, const bool on)
   {
     m_Fixes[static_cast<int8_t>(f)] = on;
@@ -163,6 +172,7 @@ private:
   QList<int> m_Modifiers = {0, 1, 2, 3, 4, 5, 6};
   QList<bool> m_SwitchCorners = {false, false, false, false};
   int m_SwitchCornerSize = 0;
+  QStringList m_KeyMappings;
   QList<bool> m_Fixes{false, false, false, false};
   bool m_Swapped = false;
   bool m_isServer = false;

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -8,6 +9,8 @@
 #include "ScreenSettingsDialog.h"
 #include "ui_ScreenSettingsDialog.h"
 
+#include "deskflow/KeyMap.h"
+#include "deskflow/KeyTypes.h"
 #include "gui/config/Screen.h"
 #include "validators/AliasValidator.h"
 #include "validators/ScreenNameValidator.h"
@@ -56,6 +59,11 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget *parent, Screen *screen, cons
   ui->chkDeadBottomRight->setChecked(m_screen->switchCorner(static_cast<int>(BottomRight)));
   ui->sbSwitchCornerSize->setValue(m_screen->switchCornerSize());
 
+  fillKeyNames();
+  for (const auto &mapping : m_screen->keyMappings()) {
+    new QListWidgetItem(mapping, ui->listKeyMappings);
+  }
+
   ui->chkFixCapsLock->setChecked(m_screen->fix(CapsLock));
   ui->chkFixNumLock->setChecked(m_screen->fix(NumLock));
   ui->chkFixScrollLock->setChecked(m_screen->fix(ScrollLock));
@@ -63,6 +71,9 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget *parent, Screen *screen, cons
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ScreenSettingsDialog::accept);
   connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ScreenSettingsDialog::reject);
+  connect(ui->btnAddMapping, &QPushButton::clicked, this, &ScreenSettingsDialog::addKeyMapping);
+  connect(ui->btnRemoveMapping, &QPushButton::clicked, this, &ScreenSettingsDialog::removeKeyMapping);
+  connect(ui->listKeyMappings, &QListWidget::itemSelectionChanged, this, &ScreenSettingsDialog::keyMappingSelected);
   connect(ui->btnAddAlias, &QPushButton::clicked, this, &ScreenSettingsDialog::addAlias);
   connect(ui->btnRemoveAlias, &QPushButton::clicked, this, &ScreenSettingsDialog::removeAlias);
   connect(ui->lineAddAlias, &QLineEdit::textChanged, this, &ScreenSettingsDialog::checkNewAliasName);
@@ -114,12 +125,68 @@ void ScreenSettingsDialog::accept()
   m_screen->setSwitchCorner(BottomRight, ui->chkDeadBottomRight->isChecked());
   m_screen->setSwitchCornerSize(ui->sbSwitchCornerSize->value());
 
+  m_screen->keyMappings().clear();
+  for (int i = 0; i < ui->listKeyMappings->count(); i++) {
+    m_screen->keyMappings().append(ui->listKeyMappings->item(i)->text());
+  }
+
   m_screen->setFix(CapsLock, ui->chkFixCapsLock->isChecked());
   m_screen->setFix(NumLock, ui->chkFixNumLock->isChecked());
   m_screen->setFix(ScrollLock, ui->chkFixScrollLock->isChecked());
   m_screen->setFix(XTest, ui->chkFixXTest->isChecked());
 
   QDialog::accept();
+}
+
+void ScreenSettingsDialog::fillKeyNames() const
+{
+  QStringList names;
+  for (const KeyNameMapEntry *entry = kKeyNameMap; entry->m_name != nullptr; ++entry) {
+    names.append(QString::fromUtf8(entry->m_name));
+  }
+  names.sort(Qt::CaseInsensitive);
+
+  ui->comboMapFrom->addItems(names);
+  ui->comboMapTo->addItems(names);
+  ui->comboMapFrom->setCurrentIndex(-1);
+  ui->comboMapTo->setCurrentIndex(-1);
+}
+
+void ScreenSettingsDialog::addKeyMapping()
+{
+  const auto from = ui->comboMapFrom->currentText().trimmed();
+  const auto to = ui->comboMapTo->currentText().trimmed();
+
+  KeyID parsed = kKeyNone;
+  if (!deskflow::KeyMap::parseKey(from.toStdString(), parsed) || parsed == kKeyNone) {
+    ui->lblMappingError->setText(tr("Unknown key: %1").arg(from));
+    return;
+  }
+  if (!deskflow::KeyMap::parseKey(to.toStdString(), parsed) || parsed == kKeyNone) {
+    ui->lblMappingError->setText(tr("Unknown key: %1").arg(to));
+    return;
+  }
+
+  const auto entry = QStringLiteral("%1,%2").arg(from, to);
+  if (!ui->listKeyMappings->findItems(from + QStringLiteral(","), Qt::MatchStartsWith).isEmpty()) {
+    ui->lblMappingError->setText(tr("%1 is already mapped").arg(from));
+    return;
+  }
+
+  ui->lblMappingError->clear();
+  new QListWidgetItem(entry, ui->listKeyMappings);
+  ui->comboMapFrom->setCurrentIndex(-1);
+  ui->comboMapTo->setCurrentIndex(-1);
+}
+
+void ScreenSettingsDialog::removeKeyMapping() const
+{
+  qDeleteAll(ui->listKeyMappings->selectedItems());
+}
+
+void ScreenSettingsDialog::keyMappingSelected() const
+{
+  ui->btnRemoveMapping->setEnabled(!ui->listKeyMappings->selectedItems().isEmpty());
 }
 
 void ScreenSettingsDialog::addAlias()

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.h
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -31,12 +32,17 @@ public Q_SLOTS:
   void accept() override;
 
 private Q_SLOTS:
+  void addKeyMapping();
+  void removeKeyMapping() const;
+  void keyMappingSelected() const;
   void addAlias();
   void removeAlias() const;
   void checkNewAliasName(const QString &text);
   void aliasSelected();
 
 private:
+  void fillKeyNames() const;
+
   std::unique_ptr<Ui::ScreenSettingsDialog> ui;
   Screen *m_screen;
 };

--- a/src/lib/gui/dialogs/ScreenSettingsDialog.ui
+++ b/src/lib/gui/dialogs/ScreenSettingsDialog.ui
@@ -607,6 +607,79 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupKeyMappings">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Key Mappings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayoutKeyMappings">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayoutAddMapping">
+            <item>
+             <widget class="QComboBox" name="comboMapFrom">
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+              <property name="toolTip">
+               <string>Key arriving from this computer.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblMapArrow">
+              <property name="text">
+               <string notr="true">→</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboMapTo">
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+              <property name="toolTip">
+               <string>Key sent to this screen instead.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnAddMapping">
+              <property name="text">
+               <string>A&amp;dd</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblMappingError">
+            <property name="text">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QListWidget" name="listKeyMappings"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="btnRemoveMapping">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>R&amp;emove</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupAliases">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -24,6 +24,32 @@
 using namespace deskflow::string;
 
 namespace deskflow::server {
+
+KeyModifierMask Config::modifierMaskForKey(KeyID id)
+{
+  switch (id) {
+  case kKeyShift_L:
+  case kKeyShift_R:
+    return KeyModifierShift;
+  case kKeyControl_L:
+  case kKeyControl_R:
+    return KeyModifierControl;
+  case kKeyAlt_L:
+  case kKeyAlt_R:
+    return KeyModifierAlt;
+  case kKeyMeta_L:
+  case kKeyMeta_R:
+    return KeyModifierMeta;
+  case kKeySuper_L:
+  case kKeySuper_R:
+    return KeyModifierSuper;
+  case kKeyAltGr:
+    return KeyModifierAltGr;
+  default:
+    return 0;
+  }
+}
+
 //
 // Config
 //
@@ -301,6 +327,50 @@ Config::link_const_iterator Config::endNeighbor(const std::string &srcName) cons
 const NetworkAddress &Config::getDeskflowAddress() const
 {
   return m_deskflowAddress;
+}
+
+const Config::ScreenKeyMap *Config::keyMap(const std::string &name) const
+{
+  const auto index = m_map.find(name);
+  if (index == m_map.end()) {
+    return nullptr;
+  }
+
+  return &index->second.m_keyMap;
+}
+
+KeyID Config::mapKey(const std::string &name, KeyID id) const
+{
+  const auto mappings = keyMap(name);
+  if (mappings == nullptr) {
+    return id;
+  }
+
+  const auto mapping = mappings->find(id);
+  return mapping == mappings->end() ? id : mapping->second;
+}
+
+Config::MappedKeyEvent Config::mapKeyEvent(const std::string &name, KeyID id, KeyModifierMask mask) const
+{
+  const auto mapped = mapKey(name, id);
+  if (mapped == id) {
+    return {id, mask, true};
+  }
+
+  const auto sourceModifier = modifierMaskForKey(id);
+  const auto targetModifier = modifierMaskForKey(mapped);
+  return {mapped, (mask & ~sourceModifier) | targetModifier, (sourceModifier == 0) == (targetModifier == 0)};
+}
+
+bool Config::addKeyMapping(const std::string &name, KeyID from, KeyID to)
+{
+  const auto index = m_map.find(name);
+  if (index == m_map.end()) {
+    return false;
+  }
+
+  index->second.m_keyMap[from] = to;
+  return true;
 }
 
 const Config::ScreenOptions *Config::getOptions(const std::string &name) const
@@ -616,6 +686,29 @@ void Config::readSectionScreens(ConfigReadContext &s)
         addOption(screen, kOptionScreenSwitchCornerSize, s.parseInt(value));
       } else if (name == "preserveFocus") {
         addOption(screen, kOptionScreenPreserveFocus, s.parseBoolean(value));
+      } else if (name == "keymap") {
+        const auto comma = value.find(',');
+        if (comma == std::string::npos) {
+          throw ServerConfigReadException(s, "syntax for keymap: keymap = fromKey,toKey");
+        }
+        const auto trim = [](std::string s) {
+          const auto first = s.find_first_not_of(" \t");
+          if (first == std::string::npos) {
+            return std::string();
+          }
+          return s.substr(first, s.find_last_not_of(" \t") - first + 1);
+        };
+        const auto fromName = trim(value.substr(0, comma));
+        const auto toName = trim(value.substr(comma + 1));
+        KeyID from = kKeyNone;
+        KeyID to = kKeyNone;
+        if (!deskflow::KeyMap::parseKey(fromName, from) || from == kKeyNone) {
+          throw ServerConfigReadException(s, "unknown key \"%{1}\"", fromName);
+        }
+        if (!deskflow::KeyMap::parseKey(toName, to) || to == kKeyNone) {
+          throw ServerConfigReadException(s, "unknown key \"%{1}\"", toName);
+        }
+        addKeyMapping(screen, from, to);
       } else {
         // unknown argument
         throw ServerConfigReadException(s, "unknown argument \"%{1}\"", name);
@@ -1383,6 +1476,13 @@ std::ostream &operator<<(std::ostream &s, const Config &config)
         if (name != nullptr && !value.empty()) {
           s << "\t\t" << name << " = " << value << std::endl;
         }
+      }
+    }
+
+    if (const auto mappings = config.keyMap(screen); mappings != nullptr) {
+      for (const auto &[from, to] : *mappings) {
+        s << "\t\t" << "keymap = " << deskflow::KeyMap::formatKey(from, 0) << "," << deskflow::KeyMap::formatKey(to, 0)
+          << std::endl;
       }
     }
   }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -11,6 +11,7 @@
 #include "base/BaseException.h"
 #include "base/String.h"
 #include "deskflow/IPlatformScreen.h"
+#include "deskflow/KeyTypes.h"
 #include "deskflow/OptionTypes.h"
 #include "net/NetworkAddress.h"
 #include "server/InputFilter.h"
@@ -53,7 +54,16 @@ class Config
 {
 public:
   using ScreenOptions = std::map<OptionID, OptionValue>;
+  //! Keys rewritten on their way to a screen, keyed by the incoming KeyID
+  using ScreenKeyMap = std::map<KeyID, KeyID>;
   using Interval = std::pair<float, float>;
+
+  struct MappedKeyEvent
+  {
+    KeyID m_id;
+    KeyModifierMask m_mask;
+    bool m_repeatable;
+  };
 
   class CellEdge
   {
@@ -133,6 +143,7 @@ private:
 
   public:
     ScreenOptions m_options;
+    ScreenKeyMap m_keyMap;
   };
   using CellMap = std::map<std::string, Cell, deskflow::string::CaselessCmp>;
   using NameMap = std::map<std::string, std::string, deskflow::string::CaselessCmp>;
@@ -351,6 +362,17 @@ public:
   */
   const ScreenOptions *getOptions(const std::string &name) const;
 
+  //! Get the key rewrites for a screen, nullptr when the screen is unknown
+  const ScreenKeyMap *keyMap(const std::string &name) const;
+
+  //! Rewrite \p id for \p name, returning it unchanged when no rewrite applies
+  KeyID mapKey(const std::string &name, KeyID id) const;
+
+  MappedKeyEvent mapKeyEvent(const std::string &name, KeyID id, KeyModifierMask mask) const;
+
+  //! Add a key rewrite to a screen, replacing any existing rewrite of \p from
+  bool addKeyMapping(const std::string &name, KeyID from, KeyID to);
+
   //! Check for lock to screen action
   /*!
   Returns \c true if this configuration has a lock to screen action.
@@ -394,6 +416,7 @@ public:
   //@}
 
 private:
+  static KeyModifierMask modifierMaskForKey(KeyID id);
   void readSection(ConfigReadContext &);
   void readSectionOptions(ConfigReadContext &);
   void readSectionScreens(ConfigReadContext &);

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers.
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -1518,6 +1518,17 @@ void Server::onScreensaver(bool activated)
   }
 }
 
+Server::ServerConfig::MappedKeyEvent
+Server::mapKeyForScreen(const std::string &screen, KeyID id, KeyModifierMask mask) const
+{
+  const auto mapped = m_config->mapKeyEvent(screen, id, mask);
+  if (mapped.m_id != id) {
+    LOG_DEBUG("remapped key %d to %d for %s", id, mapped.m_id, screen.c_str());
+  }
+
+  return mapped;
+}
+
 void Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const std::string &lang, const char *screens)
 {
   LOG_VERBOSE("onKeyDown id=%d mask=0x%04x button=0x%04x lang=%s", id, mask, button, lang.c_str());
@@ -1525,7 +1536,8 @@ void Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const s
 
   // relay
   if (!m_keyboardBroadcasting && IKeyState::KeyInfo::isDefault(screens)) {
-    m_active->keyDown(id, mask, button, lang);
+    const auto mapped = mapKeyForScreen(getName(m_active), id, mask);
+    m_active->keyDown(mapped.m_id, mapped.m_mask, button, lang);
   } else {
     if (!screens && m_keyboardBroadcasting) {
       screens = m_keyboardBroadcastingScreens.c_str();
@@ -1535,7 +1547,8 @@ void Server::onKeyDown(KeyID id, KeyModifierMask mask, KeyButton button, const s
     }
     for (ClientList::const_iterator index = m_clients.begin(); index != m_clients.end(); ++index) {
       if (IKeyState::KeyInfo::contains(screens, index->first)) {
-        index->second->keyDown(id, mask, button, lang);
+        const auto mapped = mapKeyForScreen(index->first, id, mask);
+        index->second->keyDown(mapped.m_id, mapped.m_mask, button, lang);
       }
     }
   }
@@ -1548,7 +1561,8 @@ void Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button, const cha
 
   // relay
   if (!m_keyboardBroadcasting && IKeyState::KeyInfo::isDefault(screens)) {
-    m_active->keyUp(id, mask, button);
+    const auto mapped = mapKeyForScreen(getName(m_active), id, mask);
+    m_active->keyUp(mapped.m_id, mapped.m_mask, button);
   } else {
     if (!screens && m_keyboardBroadcasting) {
       screens = m_keyboardBroadcastingScreens.c_str();
@@ -1558,7 +1572,8 @@ void Server::onKeyUp(KeyID id, KeyModifierMask mask, KeyButton button, const cha
     }
     for (ClientList::const_iterator index = m_clients.begin(); index != m_clients.end(); ++index) {
       if (IKeyState::KeyInfo::contains(screens, index->first)) {
-        index->second->keyUp(id, mask, button);
+        const auto mapped = mapKeyForScreen(index->first, id, mask);
+        index->second->keyUp(mapped.m_id, mapped.m_mask, button);
       }
     }
   }
@@ -1573,7 +1588,11 @@ void Server::onKeyRepeat(KeyID id, KeyModifierMask mask, int32_t count, KeyButto
   assert(m_active != nullptr);
 
   // relay
-  m_active->keyRepeat(id, mask, count, button, lang);
+  const auto mapped = mapKeyForScreen(getName(m_active), id, mask);
+  if (!mapped.m_repeatable) {
+    return;
+  }
+  m_active->keyRepeat(mapped.m_id, mapped.m_mask, count, button, lang);
 }
 
 void Server::onMouseDown(ButtonID id)

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -1,6 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
- * SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+ * SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2002 Chris Schoeneman
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -334,6 +334,7 @@ private:
   void onMouseUp(ButtonID);
   bool onMouseMovePrimary(int32_t x, int32_t y);
   void onMouseMoveSecondary(int32_t dx, int32_t dy);
+  ServerConfig::MappedKeyEvent mapKeyForScreen(const std::string &screen, KeyID id, KeyModifierMask mask) const;
   void onMouseWheel(int32_t xDelta, int32_t yDelta);
 
   // add client to list and attach event handlers for client

--- a/src/unittests/server/ServerConfigTests.cpp
+++ b/src/unittests/server/ServerConfigTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-FileCopyrightText: (C) 2014 - 2016 Synergy App Ltd
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -159,6 +160,57 @@ void ServerConfigTests::equalityCheck_diff_neighbours3()
   QVERIFY(b.addScreen("screenC"));
   QVERIFY(b.connect("screenA", Direction::Bottom, 0.0f, 0.5f, "screenC", 0.5f, 1.0f));
   QVERIFY(a != b);
+}
+
+void ServerConfigTests::mapKeyEvent_modifierToModifier_rewritesMask()
+{
+  Config config(nullptr);
+  QVERIFY(config.addScreen("macbook"));
+  QVERIFY(config.addKeyMapping("macbook", kKeyAlt_R, kKeyControl_R));
+
+  const auto keyDown = config.mapKeyEvent("macbook", kKeyAlt_R, KeyModifierShift);
+  QCOMPARE(keyDown.m_id, kKeyControl_R);
+  QCOMPARE(keyDown.m_mask, KeyModifierShift | KeyModifierControl);
+
+  const auto keyRepeat = config.mapKeyEvent("macbook", kKeyAlt_R, KeyModifierShift | KeyModifierAlt);
+  QCOMPARE(keyRepeat.m_id, kKeyControl_R);
+  QCOMPARE(keyRepeat.m_mask, KeyModifierShift | KeyModifierControl);
+  QVERIFY(keyRepeat.m_repeatable);
+}
+
+void ServerConfigTests::mapKeyEvent_modifierToFunction_suppressesRepeat()
+{
+  Config config(nullptr);
+  QVERIFY(config.addScreen("macbook"));
+  QVERIFY(config.addKeyMapping("macbook", kKeyAlt_R, kKeyF16));
+
+  const auto event = config.mapKeyEvent("macbook", kKeyAlt_R, KeyModifierAlt);
+  QCOMPARE(event.m_id, kKeyF16);
+  QCOMPARE(event.m_mask, 0u);
+  QVERIFY(!event.m_repeatable);
+}
+
+void ServerConfigTests::mapKeyEvent_functionToModifier_suppressesRepeat()
+{
+  Config config(nullptr);
+  QVERIFY(config.addScreen("macbook"));
+  QVERIFY(config.addKeyMapping("macbook", kKeyF16, kKeyAlt_R));
+
+  const auto event = config.mapKeyEvent("macbook", kKeyF16, 0);
+  QCOMPARE(event.m_id, kKeyAlt_R);
+  QCOMPARE(event.m_mask, KeyModifierAlt);
+  QVERIFY(!event.m_repeatable);
+}
+
+void ServerConfigTests::mapKeyEvent_unmappedKey_preservesEvent()
+{
+  Config config(nullptr);
+  QVERIFY(config.addScreen("macbook"));
+
+  const auto event = config.mapKeyEvent("macbook", kKeyAlt_R, KeyModifierShift | KeyModifierAlt);
+  QCOMPARE(event.m_id, kKeyAlt_R);
+  QCOMPARE(event.m_mask, KeyModifierShift | KeyModifierAlt);
+  QVERIFY(event.m_repeatable);
 }
 
 QTEST_MAIN(ServerConfigTests)

--- a/src/unittests/server/ServerConfigTests.h
+++ b/src/unittests/server/ServerConfigTests.h
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2025 Chris Rizzitello <sithlord48@gmail.com>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
  */
@@ -18,4 +19,8 @@ private Q_SLOTS:
   void equalityCheck_diff_neighbours1();
   void equalityCheck_diff_neighbours2();
   void equalityCheck_diff_neighbours3();
+  void mapKeyEvent_modifierToModifier_rewritesMask();
+  void mapKeyEvent_modifierToFunction_suppressesRepeat();
+  void mapKeyEvent_functionToModifier_suppressesRepeat();
+  void mapKeyEvent_unmappedKey_preservesEvent();
 };


### PR DESCRIPTION
## Description
Add per-screen key mappings to the screen settings dialog and server configuration. Modifier masks are rewritten with the mapped key, and repeats are suppressed when a mapping crosses modifier boundaries.

## AI tools used for this PR
OpenAI Codex (GPT-5) was used to port the tested fork changes onto current master, resolve conflicts, and add tests. The behavior was manually tested with a Linux server and macOS client.

## Fixed/related issues
Related: #6237
Related: #85

## How has this been tested?
- Fedora 44 build with warnings treated as errors
- GUI target compiled
- ServerConfigTests: 13 passed
- Linux server mapping right Alt to F16 on a macOS client
