### PR TITLE
fix(server): read boolean server options with toBool()

### DIFF
--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -464,10 +464,12 @@ void Config::readSectionOptions(ConfigReadContext &s)
     addOption("", kOptionScreenSwitchTwoTap, Settings::value(Settings::Server::SwitchDoubleTap).toInt());
   }
 
-  addOption("", kOptionDefaultLockToScreenState, Settings::value(Settings::Server::DefaultLockToComputerState).toInt());
-  addOption("", kOptionDisableLockToScreen, Settings::value(Settings::Server::DisableLockToComputer).toInt());
-  addOption("", kOptionRelativeMouseMoves, Settings::value(Settings::Server::RelativeMouseMoves).toInt());
-  addOption("", kOptionWin32KeepForeground, Settings::value(Settings::Server::Win32KeepForeground).toInt());
+  addOption(
+      "", kOptionDefaultLockToScreenState, Settings::value(Settings::Server::DefaultLockToComputerState).toBool()
+  );
+  addOption("", kOptionDisableLockToScreen, Settings::value(Settings::Server::DisableLockToComputer).toBool());
+  addOption("", kOptionRelativeMouseMoves, Settings::value(Settings::Server::RelativeMouseMoves).toBool());
+  addOption("", kOptionWin32KeepForeground, Settings::value(Settings::Server::Win32KeepForeground).toBool());
   addOption("", kOptionClipboardSharing, Settings::value(Settings::Server::EnableClipboard).toBool());
   addOption("", kOptionClipboardSharingSize, Settings::value(Settings::Server::ClipboardSize).toUInt() * 1024);
 


### PR DESCRIPTION
## Description

`Config::readSectionOptions()` reads four boolean server options with `QVariant::toInt()`. QSettings stores a bool in the ini file as the string `true`/`false`, which `toInt()` cannot convert back, so it silently returns 0.

The gui does not notice because its own QSettings still holds the cached bool. The core parses the settings file in a separate process and only ever sees the string, so these options are disabled as soon as the value has been written to the file:

- `defaultLockToComputerState`
- `disableLockToScreen`
- `relativeMouseMoves`
- `win32KeepForeground`

`win32KeepForeground` defaults to true, so saving the server settings once inverts its behaviour. The others are silently ignored whenever the user enables them.

This is a regression from 95ffe1ba0 ("fix: set new options before reading old ones"), which introduced these four lines. Reading them with `toBool()` handles both the cached bool and the string form.

## AI tools used for this PR

Claude Opus 5 (`claude-opus-5`) via Claude Code, for locating the bug, writing the fix, and building the standalone QSettings probe used to verify it.

## Fixed/related issues

None that I could find; the symptom is quiet enough that it does not seem to have been reported.

## How has this been tested?

Windows 11, MSVC 2022, Qt 6.10.3, Ninja, Release.

- Standalone QSettings probe. A bool written by one process reads back in a second process as `type=QString`, `toInt()=0`, `toBool()=true`. An int setting round-trips correctly.

```
[write] same process (via the QSettings cache)
  win32KeepForeground          type=bool       toInt()=1  toBool()=1
[write] resulting ini
  win32KeepForeground=true
[read] second process, re-read from the file
  win32KeepForeground          type=QString    toInt()=0  toBool()=1
```

- Two-machine setup. Reproduced the dead scroll lock options before the change, and confirmed they take effect after it.
- Unit tests 25/25 pass. Clean build with `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON`.
