### PR TITLE
feat(wayland): add Hyprland virtual input backend

### DIFF
--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 if(UNIX AND NOT APPLE)
+  pkg_check_modules(WAYLAND_CLIENT REQUIRED QUIET wayland-client)
   pkg_check_modules(LIBEI REQUIRED QUIET "libei-1.0 >= ${REQUIRED_LIBEI_VERSION}")
   message(STATUS "libei version: ${LIBEI_VERSION}")
 
@@ -103,12 +104,51 @@ elseif(APPLE)
     OSXScreenSaverUtil.m
   )
 elseif(UNIX)
+  find_program(WAYLAND_SCANNER wayland-scanner REQUIRED)
+  set(PROTOCOLS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/protocols")
+  set(WLR_VIRTUAL_POINTER_XML "${PROTOCOLS_DIR}/wlr-virtual-pointer-unstable-v1.xml")
+  set(XDG_OUTPUT_XML "${PROTOCOLS_DIR}/xdg-output-unstable-v1.xml")
+  set(VIRTUAL_KEYBOARD_XML "${PROTOCOLS_DIR}/virtual-keyboard-unstable-v1.xml")
+  set(WLR_VIRTUAL_POINTER_HEADER "${CMAKE_CURRENT_BINARY_DIR}/wlr-virtual-pointer-unstable-v1-client-protocol.h")
+  set(WLR_VIRTUAL_POINTER_CODE "${CMAKE_CURRENT_BINARY_DIR}/wlr-virtual-pointer-unstable-v1-protocol.c")
+  set(XDG_OUTPUT_HEADER "${CMAKE_CURRENT_BINARY_DIR}/xdg-output-unstable-v1-client-protocol.h")
+  set(XDG_OUTPUT_CODE "${CMAKE_CURRENT_BINARY_DIR}/xdg-output-unstable-v1-protocol.c")
+  set(VIRTUAL_KEYBOARD_HEADER "${CMAKE_CURRENT_BINARY_DIR}/virtual-keyboard-unstable-v1-client-protocol.h")
+  set(VIRTUAL_KEYBOARD_CODE "${CMAKE_CURRENT_BINARY_DIR}/virtual-keyboard-unstable-v1-protocol.c")
+  add_custom_command(
+    OUTPUT "${WLR_VIRTUAL_POINTER_HEADER}" "${WLR_VIRTUAL_POINTER_CODE}"
+    COMMAND "${WAYLAND_SCANNER}" client-header "${WLR_VIRTUAL_POINTER_XML}" "${WLR_VIRTUAL_POINTER_HEADER}"
+    COMMAND "${WAYLAND_SCANNER}" private-code "${WLR_VIRTUAL_POINTER_XML}" "${WLR_VIRTUAL_POINTER_CODE}"
+    DEPENDS "${WLR_VIRTUAL_POINTER_XML}"
+  )
+  add_custom_command(
+    OUTPUT "${XDG_OUTPUT_HEADER}" "${XDG_OUTPUT_CODE}"
+    COMMAND "${WAYLAND_SCANNER}" client-header "${XDG_OUTPUT_XML}" "${XDG_OUTPUT_HEADER}"
+    COMMAND "${WAYLAND_SCANNER}" private-code "${XDG_OUTPUT_XML}" "${XDG_OUTPUT_CODE}"
+    DEPENDS "${XDG_OUTPUT_XML}"
+  )
+  add_custom_command(
+    OUTPUT "${VIRTUAL_KEYBOARD_HEADER}" "${VIRTUAL_KEYBOARD_CODE}"
+    COMMAND "${WAYLAND_SCANNER}" client-header "${VIRTUAL_KEYBOARD_XML}" "${VIRTUAL_KEYBOARD_HEADER}"
+    COMMAND "${WAYLAND_SCANNER}" private-code "${VIRTUAL_KEYBOARD_XML}" "${VIRTUAL_KEYBOARD_CODE}"
+    DEPENDS "${VIRTUAL_KEYBOARD_XML}"
+  )
   set(PLATFORM_SOURCES
     XDGPortalRegistry.h
     XDGPowerManager.cpp
     XDGPowerManager.h
     XDGKeyUtil.h
     XDGKeyUtil.cpp
+    WlrVirtualPointer.cpp
+    WlrVirtualPointer.h
+    WlrVirtualKeyboard.cpp
+    WlrVirtualKeyboard.h
+    protocols/wlr-virtual-pointer-unstable-v1.xml
+    protocols/xdg-output-unstable-v1.xml
+    protocols/virtual-keyboard-unstable-v1.xml
+    "${WLR_VIRTUAL_POINTER_CODE}"
+    "${XDG_OUTPUT_CODE}"
+    "${VIRTUAL_KEYBOARD_CODE}"
   )
   if (BUILD_X11_SUPPORT)
     configure_file(XWindowsConfig.h.in XWindowsConfig.h @ONLY)
@@ -192,13 +232,16 @@ if(UNIX)
     if (HAVE_LP_CLIPBOARD)
       target_compile_definitions(platform PUBLIC HAVE_LIBPORTAL_CLIPBOARD)
     endif()
-    target_include_directories(platform PUBLIC ${LIBEI_INCLUDE_DIRS} ${LIBPORTAL_INCLUDE_DIRS})
+    target_include_directories(platform
+      PUBLIC ${LIBEI_INCLUDE_DIRS} ${LIBPORTAL_INCLUDE_DIRS}
+      PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
     target_link_libraries(platform
       PUBLIC
         Qt6::DBus
       PRIVATE
         Qt6::Gui
         ${LIBXKBCOMMON_LINK_LIBRARIES}
+        ${WAYLAND_CLIENT_LINK_LIBRARIES}
         ${LIBEI_LINK_LIBRARIES} ${LIBPORTAL_LINK_LIBRARIES})
   endif()
 endif()

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -20,11 +20,14 @@
 #include "platform/EiKeyState.h"
 #include "platform/PortalInputCapture.h"
 #include "platform/PortalRemoteDesktop.h"
+#include "platform/WlrVirtualKeyboard.h"
+#include "platform/WlrVirtualPointer.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
 
@@ -46,7 +49,10 @@ EiScreen::EiScreen(bool isPrimary, IEventQueue *events, bool usePortal)
       m_h{1},
       m_isOnScreen{isPrimary}
 {
-  initEi();
+  const auto useWlrVirtualInput = usePortal && !isPrimary &&
+                                  qEnvironmentVariable("XDG_CURRENT_DESKTOP").contains("Hyprland", Qt::CaseInsensitive);
+  if (!useWlrVirtualInput)
+    initEi();
   m_keyState = new EiKeyState(this, events);
   // install event handlers
   m_events->addHandler(EventTypes::System, m_events->getSystemTarget(), [this](const auto &e) {
@@ -60,6 +66,28 @@ EiScreen::EiScreen(bool isPrimary, IEventQueue *events, bool usePortal)
     if (isPrimary) {
       m_portalInputCapture = new PortalInputCapture(this, m_events);
       // Portal input capture manages its own clipboard
+    } else if (useWlrVirtualInput) {
+      m_wlrPointer = new WlrVirtualPointer();
+      if (!m_wlrPointer->ready()) {
+        delete m_wlrPointer;
+        m_wlrPointer = nullptr;
+        initEi();
+        m_events->addHandler(EventTypes::EISessionClosed, getEventTarget(), [this](const auto &) {
+          handlePortalSessionClosed();
+        });
+        m_portalRemoteDesktop = new PortalRemoteDesktop(this, m_events);
+      } else {
+        m_w = m_wlrPointer->width();
+        m_h = m_wlrPointer->height();
+        LOG_INFO("wlroots virtual pointer screen size: %ux%u", m_w, m_h);
+        m_wlrKeyboard = new WlrVirtualKeyboard();
+        if (!m_wlrKeyboard->ready()) {
+          delete m_wlrKeyboard;
+          m_wlrKeyboard = nullptr;
+          LOG_WARN("wlroots virtual keyboard is unavailable; keyboard sharing remains disabled");
+        }
+      }
+      m_clipboard = new EiClipboard(kClipboardClipboard);
     } else {
       m_events->addHandler(EventTypes::EISessionClosed, getEventTarget(), [this](const auto &) {
         handlePortalSessionClosed();
@@ -90,14 +118,18 @@ EiScreen::~EiScreen()
   m_events->removeHandler(EventTypes::System, m_events->getSystemTarget());
 
   cancelIdleEmulationTimer();
+  cancelClipboardTimer();
 
-  cleanupEi();
+  if (m_ei)
+    cleanupEi();
 
   delete m_keyState;
   delete m_clipboard;
 
   delete m_portalRemoteDesktop;
   delete m_portalInputCapture;
+  delete m_wlrKeyboard;
+  delete m_wlrPointer;
 }
 
 void EiScreen::eiLogEvent(ei_log_priority priority, const char *message) const
@@ -279,9 +311,6 @@ void EiScreen::fakeMouseButton(ButtonID button, bool press)
 {
   uint32_t code;
 
-  if (!m_eiPointer)
-    return;
-
   switch (button) {
   case kButtonLeft:
     code = 0x110; // BTN_LEFT
@@ -297,6 +326,13 @@ void EiScreen::fakeMouseButton(ButtonID button, bool press)
     break;
   }
 
+  if (m_wlrPointer) {
+    m_wlrPointer->button(code, press);
+    return;
+  }
+  if (!m_eiPointer)
+    return;
+
   ensureEmulating();
   ei_device_button_button(m_eiPointer, code, press);
   ei_device_frame(m_eiPointer, ei_now(m_ei));
@@ -311,6 +347,16 @@ void EiScreen::fakeMouseMove(int32_t x, int32_t y)
     return;
   }
 
+  if (m_wlrPointer) {
+    m_cursorX = x;
+    m_cursorY = y;
+    // The XDG-output protocol gave us Hyprland's real logical desktop extent.
+    // Re-anchor every Deskflow coordinate in that frame. Relative deltas lose
+    // sync whenever a cursor crosses an L-shaped monitor-layout gap, and also
+    // discard the initial coordinate sent before enter().
+    m_wlrPointer->motionAbsolute(x, y, m_w, m_h);
+    return;
+  }
   if (!m_eiAbs)
     return;
 
@@ -321,6 +367,10 @@ void EiScreen::fakeMouseMove(int32_t x, int32_t y)
 
 void EiScreen::fakeMouseRelativeMove(int32_t dx, int32_t dy) const
 {
+  if (m_wlrPointer) {
+    m_wlrPointer->motion(dx, dy);
+    return;
+  }
   if (!m_eiPointer)
     return;
 
@@ -331,6 +381,12 @@ void EiScreen::fakeMouseRelativeMove(int32_t dx, int32_t dy) const
 
 void EiScreen::fakeMouseWheel(ScrollDelta delta) const
 {
+  if (m_wlrPointer) {
+    // Deskflow's wheel convention is the inverse of the wlroots virtual
+    // pointer protocol, matching the conversion used by the libei backend.
+    m_wlrPointer->scroll(-delta.x, -delta.y);
+    return;
+  }
   if (!m_eiPointer)
     return;
 
@@ -345,6 +401,12 @@ void EiScreen::fakeMouseWheel(ScrollDelta delta) const
 
 void EiScreen::fakeKey(uint32_t keycode, bool isDown) const
 {
+  if (m_wlrKeyboard) {
+    const auto xkbKeycode = keycode + 8;
+    m_keyState->updateXkbState(xkbKeycode, isDown);
+    m_wlrKeyboard->key(keycode, isDown);
+    return;
+  }
   if (!m_eiKeyboard)
     return;
 
@@ -357,16 +419,83 @@ void EiScreen::fakeKey(uint32_t keycode, bool isDown) const
 
 void EiScreen::enable()
 {
-  // Nothing really to be done here
-  // Portal-based clipboard gets notifications via events
-  // Socket-based clipboard is passive (no monitoring needed)
+  if (m_wlrPointer && !m_clipboardTimer) {
+    m_clipboardTimer = m_events->newTimer(1.0, nullptr);
+    m_events->addHandler(EventTypes::Timer, m_clipboardTimer, [this](const auto &) { syncWlrClipboard(); });
+    syncWlrClipboard();
+  }
 }
 
 void EiScreen::disable()
 {
-  // Nothing to do here
-  // Portal-based clipboard gets notifications via events
-  // Socket-based clipboard is passive (no monitoring needed)
+  cancelClipboardTimer();
+}
+
+void EiScreen::cancelClipboardTimer()
+{
+  if (m_clipboardTimer) {
+    m_events->removeHandler(EventTypes::Timer, m_clipboardTimer);
+    m_events->deleteTimer(m_clipboardTimer);
+    m_clipboardTimer = nullptr;
+  }
+}
+
+bool EiScreen::readWlrClipboardText(std::string &text) const
+{
+  constexpr auto command = "wl-paste --no-newline 2>/dev/null";
+  auto *pipe = popen(command, "r");
+  if (!pipe)
+    return false;
+
+  text.clear();
+  char buffer[4096];
+  const auto maximumBytes = m_maximumClipboardSize * 1024;
+  while (const auto count = fread(buffer, 1, sizeof(buffer), pipe)) {
+    if (text.size() + count > maximumBytes) {
+      pclose(pipe);
+      LOG_WARN("Wayland clipboard exceeds Deskflow limit of %zu KB", m_maximumClipboardSize);
+      return false;
+    }
+    text.append(buffer, count);
+  }
+
+  const auto status = pclose(pipe);
+  return status != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+bool EiScreen::writeWlrClipboardText(const std::string &text) const
+{
+  constexpr auto command = "wl-copy --type 'text/plain;charset=utf-8' 2>/dev/null";
+  auto *pipe = popen(command, "w");
+  if (!pipe)
+    return false;
+
+  const auto written = fwrite(text.data(), 1, text.size(), pipe);
+  const auto status = pclose(pipe);
+  return written == text.size() && status != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+void EiScreen::syncWlrClipboard()
+{
+  if (!m_wlrPointer || !m_clipboard)
+    return;
+
+  std::string text;
+  if (!readWlrClipboardText(text))
+    return;
+  if (m_lastWlrClipboardTextValid && text == m_lastWlrClipboardText)
+    return;
+
+  if (!m_clipboard->open(0))
+    return;
+  if (m_clipboard->empty())
+    m_clipboard->add(IClipboard::Format::Text, text);
+  m_clipboard->close();
+
+  m_lastWlrClipboardText = std::move(text);
+  m_lastWlrClipboardTextValid = true;
+  LOG_DEBUG("Wayland clipboard changed; synchronizing with Deskflow");
+  sendClipboardEvent(EventTypes::ClipboardGrabbed, kClipboardClipboard);
 }
 
 void EiScreen::cancelIdleEmulationTimer() const
@@ -419,7 +548,7 @@ void EiScreen::stopEmulating() const
 void EiScreen::enter()
 {
   m_isOnScreen = true;
-  if (!m_isPrimary && m_eiAbs) {
+  if (!m_isPrimary && (m_eiAbs || m_wlrPointer)) {
     // Emulation is started lazily by ensureEmulating() on the first injected
     // input and released again after a short idle, so this screen can DPMS-sleep
     // while the cursor sits here with no relayed activity.
@@ -466,6 +595,21 @@ bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 
   bool ok = IClipboard::copy(m_clipboard, clipboard);
 
+  if (ok && m_wlrPointer && id == kClipboardClipboard) {
+    std::string text;
+    if (clipboard->open(clipboard->getTime())) {
+      if (clipboard->has(IClipboard::Format::Text))
+        text = clipboard->get(IClipboard::Format::Text);
+      clipboard->close();
+    }
+    if (writeWlrClipboardText(text)) {
+      m_lastWlrClipboardText = std::move(text);
+      m_lastWlrClipboardTextValid = true;
+    } else {
+      LOG_WARN("failed to write Deskflow clipboard to the Wayland clipboard");
+    }
+  }
+
   if (ok && m_portalRemoteDesktop && id == kClipboardClipboard) {
     m_portalRemoteDesktop->claimClipboard();
   }
@@ -475,9 +619,7 @@ bool EiScreen::setClipboard(ClipboardID id, const IClipboard *clipboard)
 
 void EiScreen::checkClipboards()
 {
-  // For portal-based input capture, clipboard changes come via portal events
-  // For socket-based, clipboard is passive and changes are sent explicitly
-  // Nothing to do here
+  syncWlrClipboard();
 }
 
 void EiScreen::openScreensaver(bool notify)
@@ -899,6 +1041,8 @@ void EiScreen::handlePortalSessionClosed()
 
 void EiScreen::handleSystemEvent(const Event &)
 {
+  if (!m_ei)
+    return;
   std::scoped_lock lock{m_mutex};
 
   // Only one ei_dispatch per system event, see the comment in

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -29,6 +29,8 @@ namespace deskflow {
 class EiKeyState;
 class PortalRemoteDesktop;
 class PortalInputCapture;
+class WlrVirtualPointer;
+class WlrVirtualKeyboard;
 class EiClipboard;
 
 using ClipboardInfo = IScreen::ClipboardInfo;
@@ -127,6 +129,10 @@ private:
   void ensureEmulating() const;
   void stopEmulating() const;
   void cancelIdleEmulationTimer() const;
+  void cancelClipboardTimer();
+  bool readWlrClipboardText(std::string &text) const;
+  bool writeWlrClipboardText(const std::string &text) const;
+  void syncWlrClipboard();
 
   static void handleEiLogEvent(ei *ei, const ei_log_priority priority, const char *message, ei_log_context *)
   {
@@ -163,6 +169,9 @@ private:
   // this screen even while the deskflow cursor logically sits on it.
   mutable bool m_isEmulating = false;
   mutable EventQueueTimer *m_idleEmulationTimer = nullptr;
+  EventQueueTimer *m_clipboardTimer = nullptr;
+  std::string m_lastWlrClipboardText;
+  bool m_lastWlrClipboardTextValid = false;
   // Chosen empirically on one machine in 2026-06; not derived from any protocol constant.
   static constexpr double s_idleEmulationTimeout = 4.0;
 
@@ -188,6 +197,8 @@ private:
 
   PortalRemoteDesktop *m_portalRemoteDesktop = nullptr;
   PortalInputCapture *m_portalInputCapture = nullptr;
+  WlrVirtualPointer *m_wlrPointer = nullptr;
+  WlrVirtualKeyboard *m_wlrKeyboard = nullptr;
 
   struct HotKeyItem
   {

--- a/src/lib/platform/WlrVirtualKeyboard.cpp
+++ b/src/lib/platform/WlrVirtualKeyboard.cpp
@@ -1,0 +1,177 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "platform/WlrVirtualKeyboard.h"
+
+#include "base/Log.h"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <xkbcommon/xkbcommon.h>
+
+namespace deskflow {
+
+namespace {
+constexpr std::uint32_t kKeyPressed = 1;
+constexpr std::uint32_t kKeyReleased = 0;
+
+const wl_registry_listener s_registryListener = {
+    .global = WlrVirtualKeyboard::global,
+    .global_remove = WlrVirtualKeyboard::globalRemove,
+};
+} // namespace
+
+WlrVirtualKeyboard::WlrVirtualKeyboard()
+{
+  m_display = wl_display_connect(nullptr);
+  if (!m_display) {
+    LOG_WARN("wlroots virtual keyboard: failed to connect to Wayland display");
+    return;
+  }
+
+  m_registry = wl_display_get_registry(m_display);
+  wl_registry_add_listener(m_registry, &s_registryListener, this);
+  wl_display_roundtrip(m_display);
+
+  if (!m_manager || !m_seat) {
+    LOG_WARN("wlroots virtual keyboard: compositor does not expose required globals");
+    return;
+  }
+
+  m_keyboard = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(m_manager, m_seat);
+  if (!m_keyboard || !setDefaultKeymap()) {
+    if (m_keyboard) {
+      zwp_virtual_keyboard_v1_destroy(m_keyboard);
+      m_keyboard = nullptr;
+    }
+    LOG_WARN("wlroots virtual keyboard: failed to create keyboard or set keymap");
+    return;
+  }
+
+  wl_display_roundtrip(m_display);
+  LOG_INFO("using wlroots virtual keyboard for Hyprland input emulation");
+}
+
+WlrVirtualKeyboard::~WlrVirtualKeyboard()
+{
+  if (m_keyboard)
+    zwp_virtual_keyboard_v1_destroy(m_keyboard);
+  if (m_manager)
+    zwp_virtual_keyboard_manager_v1_destroy(m_manager);
+  if (m_seat)
+    wl_seat_destroy(m_seat);
+  if (m_registry)
+    wl_registry_destroy(m_registry);
+  if (m_display)
+    wl_display_disconnect(m_display);
+  if (m_xkbState)
+    xkb_state_unref(m_xkbState);
+  if (m_xkbKeymap)
+    xkb_keymap_unref(m_xkbKeymap);
+  if (m_xkbContext)
+    xkb_context_unref(m_xkbContext);
+}
+
+bool WlrVirtualKeyboard::ready() const
+{
+  return m_keyboard != nullptr;
+}
+
+void WlrVirtualKeyboard::global(
+    void *data, wl_registry *registry, std::uint32_t name, const char *interface, std::uint32_t version
+)
+{
+  auto *self = static_cast<WlrVirtualKeyboard *>(data);
+  if (std::strcmp(interface, wl_seat_interface.name) == 0 && !self->m_seat) {
+    self->m_seat = static_cast<wl_seat *>(wl_registry_bind(registry, name, &wl_seat_interface, std::min(version, 7u)));
+  } else if (std::strcmp(interface, zwp_virtual_keyboard_manager_v1_interface.name) == 0 && !self->m_manager) {
+    self->m_manager = static_cast<zwp_virtual_keyboard_manager_v1 *>(
+        wl_registry_bind(registry, name, &zwp_virtual_keyboard_manager_v1_interface, 1)
+    );
+  }
+}
+
+bool WlrVirtualKeyboard::setDefaultKeymap()
+{
+  m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!m_xkbContext)
+    return false;
+  m_xkbKeymap = xkb_keymap_new_from_names(m_xkbContext, nullptr, XKB_KEYMAP_COMPILE_NO_FLAGS);
+  if (!m_xkbKeymap) {
+    xkb_context_unref(m_xkbContext);
+    m_xkbContext = nullptr;
+    return false;
+  }
+
+  auto *text = xkb_keymap_get_as_string(m_xkbKeymap, XKB_KEYMAP_FORMAT_TEXT_V1);
+  if (!text) {
+    xkb_keymap_unref(m_xkbKeymap);
+    m_xkbKeymap = nullptr;
+    xkb_context_unref(m_xkbContext);
+    m_xkbContext = nullptr;
+    return false;
+  }
+  const auto size = std::strlen(text) + 1;
+  char filename[] = "/tmp/deskflow-keymap-XXXXXX";
+  const auto fd = mkstemp(filename);
+  bool success = fd >= 0;
+  if (success) {
+    unlink(filename);
+    size_t offset = 0;
+    while (offset < size) {
+      const auto written = write(fd, text + offset, size - offset);
+      if (written <= 0) {
+        success = false;
+        break;
+      }
+      offset += static_cast<size_t>(written);
+    }
+    success = success && lseek(fd, 0, SEEK_SET) >= 0;
+  }
+  if (success) {
+    zwp_virtual_keyboard_v1_keymap(
+        m_keyboard, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, fd, static_cast<std::uint32_t>(size)
+    );
+    wl_display_flush(m_display);
+  }
+  if (fd >= 0)
+    close(fd);
+  free(text);
+  if (!success)
+    return false;
+
+  m_xkbState = xkb_state_new(m_xkbKeymap);
+  return m_xkbState != nullptr;
+}
+
+std::uint32_t WlrVirtualKeyboard::time() const
+{
+  using namespace std::chrono;
+  return static_cast<std::uint32_t>(duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+void WlrVirtualKeyboard::key(std::uint32_t keycode, bool pressed)
+{
+  if (!m_keyboard || !m_xkbState)
+    return;
+  zwp_virtual_keyboard_v1_key(m_keyboard, time(), keycode, pressed ? kKeyPressed : kKeyReleased);
+  xkb_state_update_key(m_xkbState, keycode + 8, pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
+  zwp_virtual_keyboard_v1_modifiers(
+      m_keyboard,
+      xkb_state_serialize_mods(m_xkbState, XKB_STATE_MODS_DEPRESSED),
+      xkb_state_serialize_mods(m_xkbState, XKB_STATE_MODS_LATCHED),
+      xkb_state_serialize_mods(m_xkbState, XKB_STATE_MODS_LOCKED),
+      xkb_state_serialize_layout(m_xkbState, XKB_STATE_LAYOUT_EFFECTIVE)
+  );
+  wl_display_flush(m_display);
+}
+
+} // namespace deskflow

--- a/src/lib/platform/WlrVirtualKeyboard.h
+++ b/src/lib/platform/WlrVirtualKeyboard.h
@@ -1,0 +1,49 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct wl_display;
+struct wl_registry;
+struct wl_seat;
+struct zwp_virtual_keyboard_manager_v1;
+struct zwp_virtual_keyboard_v1;
+struct xkb_context;
+struct xkb_keymap;
+struct xkb_state;
+
+namespace deskflow {
+
+// Direct wlroots virtual-keyboard client used with WlrVirtualPointer when a
+// compositor does not provide the RemoteDesktop portal.
+class WlrVirtualKeyboard
+{
+public:
+  WlrVirtualKeyboard();
+  ~WlrVirtualKeyboard();
+
+  bool ready() const;
+  void key(std::uint32_t keycode, bool pressed);
+
+  static void global(void *data, wl_registry *registry, std::uint32_t name, const char *interface, std::uint32_t version);
+  static void globalRemove(void *, wl_registry *, std::uint32_t) {}
+
+private:
+  bool setDefaultKeymap();
+  std::uint32_t time() const;
+
+  wl_display *m_display = nullptr;
+  wl_registry *m_registry = nullptr;
+  wl_seat *m_seat = nullptr;
+  zwp_virtual_keyboard_manager_v1 *m_manager = nullptr;
+  zwp_virtual_keyboard_v1 *m_keyboard = nullptr;
+  xkb_context *m_xkbContext = nullptr;
+  xkb_keymap *m_xkbKeymap = nullptr;
+  xkb_state *m_xkbState = nullptr;
+};
+
+} // namespace deskflow

--- a/src/lib/platform/WlrVirtualPointer.cpp
+++ b/src/lib/platform/WlrVirtualPointer.cpp
@@ -1,0 +1,280 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "platform/WlrVirtualPointer.h"
+
+#include "base/Log.h"
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <limits>
+#include <wayland-client.h>
+
+namespace deskflow {
+
+namespace {
+constexpr std::uint32_t kPointerButtonPressed = 1;
+constexpr std::uint32_t kPointerButtonReleased = 0;
+constexpr std::uint32_t kAxisVertical = 0;
+constexpr std::uint32_t kAxisHorizontal = 1;
+constexpr std::uint32_t kAxisSourceWheel = 0;
+constexpr std::int32_t kDeskflowWheelDelta = 120;
+constexpr std::int32_t kWaylandWheelDelta = 15;
+
+const wl_registry_listener s_registryListener = {
+    .global = WlrVirtualPointer::global,
+    .global_remove = WlrVirtualPointer::globalRemove,
+};
+
+const wl_output_listener s_outputListener = {
+    WlrVirtualPointer::outputGeometry,
+    WlrVirtualPointer::outputMode,
+    WlrVirtualPointer::outputDone,
+    WlrVirtualPointer::outputScale,
+    WlrVirtualPointer::outputName,
+    WlrVirtualPointer::outputDescription,
+};
+
+const zxdg_output_v1_listener s_xdgOutputListener = {
+    WlrVirtualPointer::xdgOutputLogicalPosition,
+    WlrVirtualPointer::xdgOutputLogicalSize,
+    WlrVirtualPointer::xdgOutputDone,
+    WlrVirtualPointer::xdgOutputName,
+    WlrVirtualPointer::xdgOutputDescription,
+};
+} // namespace
+
+WlrVirtualPointer::WlrVirtualPointer()
+{
+  m_display = wl_display_connect(nullptr);
+  if (!m_display) {
+    LOG_WARN("wlroots virtual pointer: failed to connect to Wayland display");
+    return;
+  }
+
+  m_registry = wl_display_get_registry(m_display);
+  wl_registry_add_listener(m_registry, &s_registryListener, this);
+  wl_display_roundtrip(m_display);
+
+  if (!m_manager || !m_seat) {
+    LOG_WARN("wlroots virtual pointer: compositor does not expose required globals");
+    return;
+  }
+
+  if (m_xdgOutputManager) {
+    for (const auto &output : m_outputs) {
+      output->xdgOutput = zxdg_output_manager_v1_get_xdg_output(m_xdgOutputManager, output->output);
+      zxdg_output_v1_add_listener(output->xdgOutput, &s_xdgOutputListener, output.get());
+    }
+    wl_display_roundtrip(m_display);
+  }
+
+  m_pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(m_manager, m_seat);
+  wl_display_roundtrip(m_display);
+  if (!m_pointer)
+    LOG_WARN("wlroots virtual pointer: failed to create virtual pointer");
+  else
+    LOG_INFO("using wlroots virtual pointer for Hyprland input emulation");
+}
+
+WlrVirtualPointer::~WlrVirtualPointer()
+{
+  if (m_pointer)
+    zwlr_virtual_pointer_v1_destroy(m_pointer);
+  if (m_manager)
+    zwlr_virtual_pointer_manager_v1_destroy(m_manager);
+  for (const auto &output : m_outputs) {
+    if (output->xdgOutput)
+      zxdg_output_v1_destroy(output->xdgOutput);
+    wl_output_destroy(output->output);
+  }
+  if (m_xdgOutputManager)
+    zxdg_output_manager_v1_destroy(m_xdgOutputManager);
+  if (m_seat)
+    wl_seat_destroy(m_seat);
+  if (m_registry)
+    wl_registry_destroy(m_registry);
+  if (m_display)
+    wl_display_disconnect(m_display);
+}
+
+bool WlrVirtualPointer::ready() const
+{
+  return m_pointer != nullptr;
+}
+
+std::uint32_t WlrVirtualPointer::width() const
+{
+  bool haveLogicalGeometry = !m_outputs.empty();
+  std::int32_t left = std::numeric_limits<std::int32_t>::max();
+  std::int32_t right = std::numeric_limits<std::int32_t>::min();
+  for (const auto &output : m_outputs) {
+    if (output->logicalWidth <= 0) {
+      haveLogicalGeometry = false;
+      break;
+    }
+    left = std::min(left, output->logicalX);
+    right = std::max(right, output->logicalX + output->logicalWidth);
+  }
+  if (haveLogicalGeometry)
+    return std::max(right - left, 1);
+
+  std::uint32_t width = 0;
+  for (const auto &output : m_outputs) {
+    const auto scale = std::max(output->scale, 1);
+    width += std::max(output->width / scale, 1);
+  }
+  return std::max(width, 1u);
+}
+
+std::uint32_t WlrVirtualPointer::height() const
+{
+  bool haveLogicalGeometry = !m_outputs.empty();
+  std::int32_t top = std::numeric_limits<std::int32_t>::max();
+  std::int32_t bottom = std::numeric_limits<std::int32_t>::min();
+  for (const auto &output : m_outputs) {
+    if (output->logicalHeight <= 0) {
+      haveLogicalGeometry = false;
+      break;
+    }
+    top = std::min(top, output->logicalY);
+    bottom = std::max(bottom, output->logicalY + output->logicalHeight);
+  }
+  if (haveLogicalGeometry)
+    return std::max(bottom - top, 1);
+
+  std::uint32_t height = 0;
+  for (const auto &output : m_outputs) {
+    const auto scale = std::max(output->scale, 1);
+    height = std::max(height, static_cast<std::uint32_t>(std::max(output->height / scale, 1)));
+  }
+  return std::max(height, 1u);
+}
+
+void WlrVirtualPointer::global(
+    void *data, wl_registry *registry, std::uint32_t name, const char *interface, std::uint32_t version
+)
+{
+  auto *self = static_cast<WlrVirtualPointer *>(data);
+  if (std::strcmp(interface, wl_seat_interface.name) == 0 && !self->m_seat) {
+    self->m_seat = static_cast<wl_seat *>(wl_registry_bind(registry, name, &wl_seat_interface, std::min(version, 7u)));
+  } else if (std::strcmp(interface, wl_output_interface.name) == 0) {
+    auto output = std::make_unique<OutputInfo>();
+    output->output = static_cast<wl_output *>(wl_registry_bind(registry, name, &wl_output_interface, std::min(version, 4u)));
+    wl_output_add_listener(output->output, &s_outputListener, output.get());
+    self->m_outputs.push_back(std::move(output));
+  } else if (std::strcmp(interface, zwlr_virtual_pointer_manager_v1_interface.name) == 0 && !self->m_manager) {
+    self->m_manager = static_cast<zwlr_virtual_pointer_manager_v1 *>(
+        wl_registry_bind(registry, name, &zwlr_virtual_pointer_manager_v1_interface, std::min(version, 2u))
+    );
+  } else if (std::strcmp(interface, zxdg_output_manager_v1_interface.name) == 0 && !self->m_xdgOutputManager) {
+    self->m_xdgOutputManager = static_cast<zxdg_output_manager_v1 *>(
+        wl_registry_bind(registry, name, &zxdg_output_manager_v1_interface, std::min(version, 3u))
+    );
+  }
+}
+
+void WlrVirtualPointer::outputMode(
+    void *data, wl_output *, std::uint32_t flags, std::int32_t width, std::int32_t height, std::int32_t
+) noexcept
+{
+  auto *output = static_cast<OutputInfo *>(data);
+  if ((flags & WL_OUTPUT_MODE_CURRENT) != 0) {
+    output->width = std::max(width, 1);
+    output->height = std::max(height, 1);
+  }
+}
+
+void WlrVirtualPointer::outputScale(void *data, wl_output *, std::int32_t scale) noexcept
+{
+  static_cast<OutputInfo *>(data)->scale = std::max(scale, 1);
+}
+
+void WlrVirtualPointer::xdgOutputLogicalPosition(void *data, zxdg_output_v1 *, std::int32_t x, std::int32_t y) noexcept
+{
+  auto *output = static_cast<OutputInfo *>(data);
+  output->logicalX = x;
+  output->logicalY = y;
+}
+
+void WlrVirtualPointer::xdgOutputLogicalSize(
+    void *data, zxdg_output_v1 *, std::int32_t width, std::int32_t height
+) noexcept
+{
+  auto *output = static_cast<OutputInfo *>(data);
+  output->logicalWidth = width;
+  output->logicalHeight = height;
+}
+
+std::uint32_t WlrVirtualPointer::time() const
+{
+  using namespace std::chrono;
+  return static_cast<std::uint32_t>(duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+void WlrVirtualPointer::motion(std::int32_t dx, std::int32_t dy) const
+{
+  if (!m_pointer)
+    return;
+  LOG_DEBUG("wlroots virtual pointer relative motion dx=%d dy=%d", dx, dy);
+  zwlr_virtual_pointer_v1_motion(m_pointer, time(), wl_fixed_from_int(dx), wl_fixed_from_int(dy));
+  zwlr_virtual_pointer_v1_frame(m_pointer);
+  wl_display_flush(m_display);
+}
+
+void WlrVirtualPointer::motionAbsolute(std::int32_t x, std::int32_t y, std::uint32_t width, std::uint32_t height) const
+{
+  if (!m_pointer)
+    return;
+  const auto extentX = std::max(width, 1u);
+  const auto extentY = std::max(height, 1u);
+  zwlr_virtual_pointer_v1_motion_absolute(
+      m_pointer, time(), std::clamp(x, 0, static_cast<int>(extentX - 1)), std::clamp(y, 0, static_cast<int>(extentY - 1)),
+      extentX, extentY
+  );
+  zwlr_virtual_pointer_v1_frame(m_pointer);
+  wl_display_flush(m_display);
+}
+
+void WlrVirtualPointer::button(std::uint32_t code, bool pressed) const
+{
+  if (!m_pointer)
+    return;
+  zwlr_virtual_pointer_v1_button(m_pointer, time(), code, pressed ? kPointerButtonPressed : kPointerButtonReleased);
+  zwlr_virtual_pointer_v1_frame(m_pointer);
+  wl_display_flush(m_display);
+}
+
+void WlrVirtualPointer::scroll(std::int32_t dx, std::int32_t dy) const
+{
+  if (!m_pointer)
+    return;
+
+  const auto toDiscreteSteps = [](std::int32_t delta) {
+    if (delta == 0)
+      return 0;
+    const auto steps = delta / kDeskflowWheelDelta;
+    return steps == 0 ? (delta < 0 ? -1 : 1) : steps;
+  };
+
+  const auto xSteps = toDiscreteSteps(dx);
+  const auto ySteps = toDiscreteSteps(dy);
+  zwlr_virtual_pointer_v1_axis_source(m_pointer, kAxisSourceWheel);
+  if (ySteps)
+    zwlr_virtual_pointer_v1_axis_discrete(
+        m_pointer, time(), kAxisVertical, wl_fixed_from_int(ySteps * kWaylandWheelDelta), ySteps
+    );
+  if (xSteps)
+    zwlr_virtual_pointer_v1_axis_discrete(
+        m_pointer, time(), kAxisHorizontal, wl_fixed_from_int(xSteps * kWaylandWheelDelta), xSteps
+    );
+  zwlr_virtual_pointer_v1_frame(m_pointer);
+  wl_display_flush(m_display);
+}
+
+} // namespace deskflow

--- a/src/lib/platform/WlrVirtualPointer.h
+++ b/src/lib/platform/WlrVirtualPointer.h
@@ -1,0 +1,80 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+struct wl_display;
+struct wl_output;
+struct wl_registry;
+struct wl_seat;
+struct zxdg_output_manager_v1;
+struct zxdg_output_v1;
+struct zwlr_virtual_pointer_manager_v1;
+struct zwlr_virtual_pointer_v1;
+
+namespace deskflow {
+
+// Direct wlroots virtual-pointer client used when a compositor does not offer
+// the RemoteDesktop portal. Hyprland exposes this protocol natively.
+class WlrVirtualPointer
+{
+public:
+  WlrVirtualPointer();
+  ~WlrVirtualPointer();
+
+  bool ready() const;
+  std::uint32_t width() const;
+  std::uint32_t height() const;
+  void motion(std::int32_t dx, std::int32_t dy) const;
+  void motionAbsolute(std::int32_t x, std::int32_t y, std::uint32_t width, std::uint32_t height) const;
+  void button(std::uint32_t code, bool pressed) const;
+  void scroll(std::int32_t dx, std::int32_t dy) const;
+
+  static void global(void *data, wl_registry *registry, std::uint32_t name, const char *interface, std::uint32_t version);
+  static void globalRemove(void *, wl_registry *, std::uint32_t) {}
+  static void outputGeometry(void *, wl_output *, std::int32_t, std::int32_t, std::int32_t, std::int32_t, std::int32_t,
+                             const char *, const char *, std::int32_t) {}
+  static void outputMode(void *data, wl_output *, std::uint32_t flags, std::int32_t width, std::int32_t height,
+                         std::int32_t) noexcept;
+  static void outputDone(void *, wl_output *) {}
+  static void outputScale(void *data, wl_output *, std::int32_t scale) noexcept;
+  static void outputName(void *, wl_output *, const char *) {}
+  static void outputDescription(void *, wl_output *, const char *) {}
+  static void xdgOutputLogicalPosition(void *data, zxdg_output_v1 *, std::int32_t x, std::int32_t y) noexcept;
+  static void xdgOutputLogicalSize(void *data, zxdg_output_v1 *, std::int32_t width, std::int32_t height) noexcept;
+  static void xdgOutputDone(void *, zxdg_output_v1 *) {}
+  static void xdgOutputName(void *, zxdg_output_v1 *, const char *) {}
+  static void xdgOutputDescription(void *, zxdg_output_v1 *, const char *) {}
+
+private:
+  struct OutputInfo
+  {
+    wl_output *output = nullptr;
+    zxdg_output_v1 *xdgOutput = nullptr;
+    std::int32_t width = 1;
+    std::int32_t height = 1;
+    std::int32_t scale = 1;
+    std::int32_t logicalX = 0;
+    std::int32_t logicalY = 0;
+    std::int32_t logicalWidth = 0;
+    std::int32_t logicalHeight = 0;
+  };
+
+  std::uint32_t time() const;
+
+  wl_display *m_display = nullptr;
+  wl_registry *m_registry = nullptr;
+  std::vector<std::unique_ptr<OutputInfo>> m_outputs;
+  wl_seat *m_seat = nullptr;
+  zxdg_output_manager_v1 *m_xdgOutputManager = nullptr;
+  zwlr_virtual_pointer_manager_v1 *m_manager = nullptr;
+  zwlr_virtual_pointer_v1 *m_pointer = nullptr;
+};
+
+} // namespace deskflow

--- a/src/lib/platform/protocols/virtual-keyboard-unstable-v1.xml
+++ b/src/lib/platform/protocols/virtual-keyboard-unstable-v1.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: MIT -->
+<protocol name="virtual_keyboard_unstable_v1">
+  <copyright>
+    Copyright © 2008-2011  Kristian Høgsberg
+    Copyright © 2010-2013  Intel Corporation
+    Copyright © 2012-2013  Collabora, Ltd.
+    Copyright © 2018       Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_virtual_keyboard_v1" version="1">
+    <description summary="virtual keyboard">
+      The virtual keyboard provides an application with requests which emulate
+      the behaviour of a physical keyboard.
+
+      This interface can be used by clients on its own to provide raw input
+      events, or it can accompany the input method protocol.
+    </description>
+
+    <request name="keymap">
+      <description summary="keyboard mapping">
+        Provide a file descriptor to the compositor which can be
+        memory-mapped to provide a keyboard mapping description.
+
+        Format carries a value from the keymap_format enumeration.
+      </description>
+      <arg name="format" type="uint" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </request>
+
+    <enum name="error">
+      <entry name="no_keymap" value="0" summary="No keymap was set"/>
+    </enum>
+
+    <request name="key">
+      <description summary="key event">
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond granularity, with an
+        undefined base. All requests regarding a single object must share the
+        same clock.
+
+        Keymap must be set before issuing this request.
+
+        State carries a value from the key_state enumeration.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" summary="physical state of the key"/>
+    </request>
+
+    <request name="modifiers">
+      <description summary="modifier and group state">
+        Notifies the compositor that the modifier and/or group state has
+        changed, and it should update state.
+
+        The client should use wl_keyboard.modifiers event to synchronize its
+        internal state with seat state.
+
+        Keymap must be set before issuing this request.
+      </description>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual keyboard keyboard object"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_virtual_keyboard_manager_v1" version="1">
+    <description summary="virtual keyboard manager">
+      A virtual keyboard manager allows an application to provide keyboard
+      input events as if they came from a physical keyboard.
+    </description>
+
+    <enum name="error">
+      <entry name="unauthorized" value="0" summary="client not authorized to use the interface"/>
+    </enum>
+
+    <request name="create_virtual_keyboard">
+      <description summary="Create a new virtual keyboard">
+        Creates a new virtual keyboard associated to a seat.
+
+        If the compositor enables a keyboard to perform arbitrary actions, it
+        should present an error when an untrusted client requests a new
+        keyboard.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="zwp_virtual_keyboard_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/lib/platform/protocols/wlr-virtual-pointer-unstable-v1.xml
+++ b/src/lib/platform/protocols/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: MIT -->
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/lib/platform/protocols/xdg-output-unstable-v1.xml
+++ b/src/lib/platform/protocols/xdg-output-unstable-v1.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: MIT -->
+<protocol name="xdg_output_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol to describe output regions">
+    This protocol aims at describing outputs in a way which is more in line
+    with the concept of an output on desktop oriented systems.
+
+    Some information are more specific to the concept of an output for
+    a desktop oriented system and may not make sense in other applications,
+    such as IVI systems for example.
+
+    Typically, the global compositor space on a desktop system is made of
+    a contiguous or overlapping set of rectangular regions.
+
+    The logical_position and logical_size events defined in this protocol
+    might provide information identical to their counterparts already
+    available from wl_output, in which case the information provided by this
+    protocol should be preferred to their equivalent in wl_output. The goal is
+    to move the desktop specific concepts (such as output location within the
+    global compositor space, etc.) out of the core wl_output protocol.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zxdg_output_manager_v1" version="3">
+    <description summary="manage xdg_output objects">
+      A global factory interface for xdg_output objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output_manager object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output_manager object anymore.
+
+	Any objects already created through this instance are not affected.
+      </description>
+    </request>
+
+    <request name="get_xdg_output">
+      <description summary="create an xdg output from a wl_output">
+	This creates a new xdg_output object for the given wl_output.
+      </description>
+      <arg name="id" type="new_id" interface="zxdg_output_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+  </interface>
+
+  <interface name="zxdg_output_v1" version="3">
+    <description summary="compositor logical output region">
+      An xdg_output describes part of the compositor geometry.
+
+      This typically corresponds to a monitor that displays part of the
+      compositor space.
+
+      For objects version 3 onwards, after all xdg_output properties have been
+      sent (when the object is created and when properties are updated), a
+      wl_output.done event is sent. This allows changes to the output
+      properties to be seen as atomic, even if they happen via multiple events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output object anymore.
+      </description>
+    </request>
+
+    <event name="logical_position">
+      <description summary="position of the output within the global compositor space">
+	The position event describes the location of the wl_output within
+	the global compositor space.
+
+	The logical_position event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the location
+	of the output changes within the global compositor space.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+	   summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="logical_size">
+      <description summary="size of the output in the global compositor space">
+	The logical_size event describes the size of the output in the
+	global compositor space.
+
+	Most regular Wayland clients should not pay attention to the
+	logical size and would rather rely on xdg_shell interfaces.
+
+	Some clients such as Xwayland, however, need this to configure
+	their surfaces in the global compositor space as the compositor
+	may apply a different scale from what is advertised by the output
+	scaling property (to achieve fractional scaling, for example).
+
+	For example, for a wl_output mode 3840×2160 and a scale factor 2:
+
+	- A compositor not scaling the monitor viewport in its compositing space
+	  will advertise a logical size of 3840×2160,
+
+	- A compositor scaling the monitor viewport with scale factor 2 will
+	  advertise a logical size of 1920×1080,
+
+	- A compositor scaling the monitor viewport using a fractional scale of
+	  1.5 will advertise a logical size of 2560×1440.
+
+	For example, for a wl_output mode 1920×1080 and a 90 degree rotation,
+	the compositor will advertise a logical size of 1080x1920.
+
+	The logical_size event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the logical
+	size of the output changes, either as a result of a change in the
+	applied scale or because of a change in the corresponding output
+	mode(see wl_output.mode) or transform (see wl_output.transform).
+      </description>
+      <arg name="width" type="int"
+	   summary="width in global compositor space"/>
+      <arg name="height" type="int"
+	   summary="height in global compositor space"/>
+    </event>
+
+    <event name="done" deprecated-since="3">
+      <description summary="all information about the output have been sent">
+	This event is sent after all other properties of an xdg_output
+	have been sent.
+
+	This allows changes to the xdg_output properties to be seen as
+	atomic, even if they happen via multiple events.
+
+	For objects version 3 onwards, this event is deprecated. Compositors
+	are not required to send it anymore and must send wl_output.done
+	instead.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="name" since="2">
+      <description summary="name of this output">
+	Many compositors will assign names to their outputs, show them to the
+	user, allow them to be configured by name, etc. The client may wish to
+	know this name as well to offer the user similar behaviors.
+
+	The naming convention is compositor defined, but limited to
+	alphanumeric characters and dashes (-). Each name is unique among all
+	wl_output globals, but if a wl_output global is destroyed the same name
+	may be reused later. The names will also remain consistent across
+	sessions with the same hardware and software configuration.
+
+	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+	not assume that the name is a reflection of an underlying DRM
+	connector, X11 connection, etc.
+
+	The name event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output). This event is only sent once per
+	xdg_output, and the name does not change over the lifetime of the
+	wl_output global.
+
+        This event is deprecated, instead clients should use wl_output.name.
+        Compositors must still support this event.
+      </description>
+      <arg name="name" type="string" summary="output name"/>
+    </event>
+
+    <event name="description" since="2">
+      <description summary="human-readable description of this output">
+	Many compositors can produce human-readable descriptions of their
+	outputs.  The client may wish to know this description as well, to
+	communicate the user for various purposes.
+
+	The description is a UTF-8 string with no convention defined for its
+	contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+	output via :1'.
+
+	The description event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output) and whenever the description
+	changes. The description is optional, and may not be sent at all.
+
+	For objects of version 2 and lower, this event is only sent once per
+	xdg_output, and the description does not change over the lifetime of
+	the wl_output global.
+
+	This event is deprecated, instead clients should use
+	wl_output.description. Compositors must still support this event.
+      </description>
+      <arg name="description" type="string" summary="output description"/>
+    </event>
+
+  </interface>
+</protocol>


### PR DESCRIPTION
## Description

Adds a Hyprland-specific Wayland fallback for Deskflow clients when the RemoteDesktop portal is unavailable.

- Creates wlroots virtual pointer and virtual keyboard devices.
- Uses XDG output logical geometry for absolute pointer placement across mixed-scale displays.
- Relays buttons, modifier-aware keyboard shortcuts, and normalized discrete wheel events.
- Bridges standard text clipboard changes through the Wayland clipboard helper.
- Vendors the required MIT-licensed protocol definitions and generates client bindings during the CMake build.

## AI tools used for this PR

GPT-5 Codex was used for implementation assistance, iterative debugging, and build verification.

## Fixed/related issues

None.

## How has this been tested?

Built from a fresh CMake configuration on CachyOS/Arch Linux with Hyprland, Qt 6.11.2, libei 1.6.0, libportal 0.10.0, and wayland-client. Verified successful generation of all protocol bindings and successful `deskflow-core` build.

Manual runtime testing used a Deskflow client connected to a Windows host on the local network. Verified pointer entry and absolute motion over mixed-scale internal/external displays, buttons, keyboard text and Super/Ctrl modifiers, and text clipboard transfer in both directions. Wheel packets are mapped from Deskflow's 120-unit ticks to Wayland discrete wheel events.