### PR TITLE
fix(clipboard): check oob for clipboard before reading number of formats

### DIFF
--- a/src/lib/deskflow/IClipboard.cpp
+++ b/src/lib/deskflow/IClipboard.cpp
@@ -27,13 +27,13 @@ void IClipboard::unmarshall(IClipboard *clipboard, const std::string_view &data,
     // clear existing data
     clipboard->empty();
 
-    // read the number of formats
-    const uint32_t numFormats = readUInt32(index);
     if (end - index < 4) {
       LOG_ERR("clipboard unmarshall: truncated header");
       clipboard->close();
       return;
     }
+    // read the number of formats
+    const uint32_t numFormats = readUInt32(index);
     index += 4;
 
     // read each format


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 Check the number of formats after oob check on clipboard header 
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
https://github.com/deskflow/deskflow/security/advisories/GHSA-xpjj-c4qw-mv8q
CVE-2026-41476
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Locally built copied a few things to / from the clipboard on my server / client