### PR TITLE
ci: disable fedora h264 repo we do not need this

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -40,6 +40,7 @@ runs:
                 qt6-base-dev qt6-tools-dev libxkbregistry-dev libxkbcommon-dev \
                 libei-dev libportal-dev help2man -y >/dev/null
             elif [ ${{inputs.like}} == "fedora" ]; then
+              dnf config-manager setopt fedora-cisco-openh264.enabled=0
               dnf install -y cmake make ninja-build gcc-c++ rpm-build openssl-devel \
                 libXtst-devel libxkbfile-devel qt6-qtbase-devel qt6-qttools-devel libxkbcommon-x11-devel \
                 libei-devel libxkbcommon-devel libportal-devel help2man libXinerama-devel libXrandr-devel


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->
 - Fedora has its fedora-cisco-openh264 repo enabled so we are downloading and installing unneeded things in the build 
 this disables that repo
## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
Random CI failures due to that repo not having updated keys on rawhide.
## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
CI RUN