### PR TITLE
fix(win32): destroy server socket multiplexer before exit

### DIFF
--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -522,6 +522,9 @@ int ServerApp::mainLoop()
     // a fatal startup failure exits by throwing, skipping the cleanup below;
     // tear down here so the screen's worker threads don't outlive the app.
     cleanupServer();
+    // The multiplexer owns a worker thread and must be destroyed on this core thread before unwinding.
+    // Keep the normal shutdown path below in sync; validate both startup failure and service stop/restart.
+    setSocketMultiplexer({});
     throw;
   }
 
@@ -553,6 +556,7 @@ int ServerApp::mainLoop()
   getEvents()->removeHandler(EventTypes::ServerAppForceReconnect, getEvents()->getSystemTarget());
   getEvents()->removeHandler(EventTypes::ServerAppReloadConfig, getEvents()->getSystemTarget());
   cleanupServer();
+  setSocketMultiplexer({});
   LOG_INFO("stopped server");
 
   return exitCode;


### PR DESCRIPTION
## Summary
- destroy the server socket multiplexer on the core thread after normal server cleanup
- do the same when startup throws, before unwinding
- prevent the socket multiplexer thread from surviving into later app teardown and triggering the self-join failure reported in #8941

## Testing
- not run locally (Windows service lifecycle change)