### PR TITLE
fix(win32): keep parked cursor hidden over window borders

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -367,8 +367,11 @@ void MSWindowsDesks::destroyClass(ATOM windowClass) const
 
 HWND MSWindowsDesks::createWindow(ATOM windowClass, const wchar_t *name) const
 {
+  // The primary hider must participate in hit testing so its blank class cursor wins over
+  // resize cursors from windows underneath the center parking position.
+  const DWORD extendedStyle = m_isPrimary ? WS_EX_TOOLWINDOW : WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW;
   HWND window = CreateWindowEx(
-      WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW, MAKEINTATOM(windowClass), name, WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
+      extendedStyle, MAKEINTATOM(windowClass), name, WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
       MSWindowsScreen::getWindowInstance(), nullptr
   );
   if (window == nullptr) {


### PR DESCRIPTION
## Summary
- keep the primary cursor-hider window in hit testing
- preserve transparency for secondary hider windows
- prevent an underlying window border at the cursor parking point from replacing the blank cursor with a resize cursor

## Validation
- built successfully with MSVC on Windows
- reproduced with a resizable window border positioned exactly at the screen center