### PR TITLE
fix(mac): prevent Option characters from becoming dead keys

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -352,9 +352,9 @@ KeyButton OSXKeyState::mapKeyFromEvent(KeyIDs &ids, KeyModifierMask *maskOut, CG
 
   // if we've used a command key then we want the glyph produced without
   // the option key (i.e. the base glyph).
-  // if (isCommand) {
-  modifiers &= ~optionKey;
-  //}
+  if (isCommand) {
+    modifiers &= ~optionKey;
+  }
 
   // choose action
   uint16_t action;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1159,12 +1159,14 @@ bool OSXScreen::onKey(CGEventRef event)
     return false;
   }
 
-  // check for AltGr in mask.  if set we send neither the AltGr nor
-  // the super modifiers to clients then remove AltGr before passing
-  // the modifiers to onKey.
+  // AltGr marks a printable character that was translated using the
+  // macOS Option layer.  The KeyID already contains Option's effect, so
+  // don't also send Option (represented by KeyModifierAlt) to clients.
+  // Keep Option in the local state so its separate key-up event remains
+  // balanced.
   KeyModifierMask sendMask = (mask & ~KeyModifierAltGr);
   if ((mask & KeyModifierAltGr) != 0) {
-    sendMask &= ~KeyModifierSuper;
+    sendMask &= ~KeyModifierAlt;
   }
   mask &= ~KeyModifierAltGr;
 


### PR DESCRIPTION
## Description

UCKeyTranslate needs the Option modifier to resolve characters from the Option layer of the active layout. Clearing it unconditionally makes those keys translate as their base or dead-key variants, leaving composition state
pending and sending the wrong character.

For example, with the Spanish-ISO layout, Option plus the ` key produces `[`. Without Option, UCKeyTranslate sees the grave-accent dead key, returns no character, and waits for another key to complete the composition. Deskflow
therefore sends a backtick first instead of `[`. Other Option-layer punctuation, including `{`, is affected in the same way.

Restore a commented out if statement to only remove Option when Command or Control is also held, where Deskflow intentionally uses the base glyph to identify the shortcut key. Special keys are handled before layout translation and are unaffected.

**I don't know the motivations of the original commented out code**, so unclear to me if this could introduce regressions. Still it fixes the Spanish keyboard issue for me and is a tiny change, so it might be worth considering.

This changes Option-modified printable keys to follow the active layout, including its dead-key behavior. An application binding bare Option plus a printable key may therefore receive the layout-produced character instead of
the base glyph it received from the previous, incorrect translation.

## AI tools used for this PR
Codex with sol medium. I am new to the deskflow codebase so this might very well not be the sound fix, it just empirically works for my two-mac setup without triggering other issues so far.

## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
related: #10095 but this patch is just re-enabling a commented out if, so it's tiny in comparison. Not sure if it fixes the same issue with Brazilian keyboards though.


## How has this been tested?
I have a mac mini with an external Apple spanish keyboard connected as the deskflow server. The client is a macbook pro with a spanish layout as well, used as the client here.