### PR TITLE
Deletion of dead code, refactor and correcting logging messages

### DIFF
--- a/src/apps/deskflow-core/deskflow-core.cpp
+++ b/src/apps/deskflow-core/deskflow-core.cpp
@@ -137,6 +137,7 @@ int main(int argc, char **argv)
   if (exitCode == s_exitSuccess) {
     exitCode = coreApp->getExitCode();
   }
+  delete coreApp;
 
   LOG_DEBUG("core exited, code: %d", exitCode);
   return exitCode;

--- a/src/lib/deskflow/AppUtil.h
+++ b/src/lib/deskflow/AppUtil.h
@@ -35,7 +35,6 @@ public:
 
   // Virtual Methods subclasses can impliment
   virtual int run() = 0;
-  virtual void startNode() = 0;
   virtual std::vector<std::string> getKeyboardLayoutList() = 0;
   virtual std::string getCurrentLanguageCode() = 0;
 

--- a/src/lib/deskflow/ClientApp.cpp
+++ b/src/lib/deskflow/ClientApp.cpp
@@ -323,7 +323,7 @@ int ClientApp::mainLoop()
   setSocketMultiplexer(std::make_unique<SocketMultiplexer>());
 
   // start client, etc
-  appUtil().startNode();
+  startNode();
 
   // run event loop.  if startClient() failed we're supposed to retry
   // later.  the timer installed by startClient() will take care of

--- a/src/lib/deskflow/Screen.cpp
+++ b/src/lib/deskflow/Screen.cpp
@@ -78,7 +78,7 @@ Screen::~Screen()
   // Perhaps it indicates that the cursor is still being controlled on the
   // client while it's shutting down? i.e. the screen is entered and is not the
   // server, or the screen is not entered and is the server.
-  if (m_entered == m_isPrimary) {
+  if (m_entered != m_isPrimary) {
     LOG(
         (CLOG_DEBUG "current screen: entered=%s, primary=%s", //
          m_entered ? "yes" : "no", m_isPrimary ? "yes" : "no")

--- a/src/lib/deskflow/ServerApp.cpp
+++ b/src/lib/deskflow/ServerApp.cpp
@@ -517,7 +517,7 @@ int ServerApp::mainLoop()
 
   // start server, etc
   try {
-    appUtil().startNode();
+    startNode();
   } catch (...) {
     // a fatal startup failure exits by throwing, skipping the cleanup below;
     // tear down here so the screen's worker threads don't outlive the app.

--- a/src/lib/deskflow/ipc/IpcServer.cpp
+++ b/src/lib/deskflow/ipc/IpcServer.cpp
@@ -96,7 +96,12 @@ void IpcServer::handleDisconnected()
 void IpcServer::handleErrorOccurred()
 {
   const auto clientSocket = qobject_cast<QLocalSocket *>(sender());
-  LOG_ERR("%s ipc server client error: %s", m_typeName.constData(), clientSocket->errorString().toUtf8().constData());
+  if (clientSocket->error() == QLocalSocket::PeerClosedError) {
+    LOG_DEBUG("%s ipc server client closed connection", m_typeName.constData());
+  } else {
+    LOG_ERR("%s ipc server client error: %s", m_typeName.constData(), clientSocket->errorString().toUtf8().constData());
+  }
+
   m_clients.remove(clientSocket);
   clientSocket->deleteLater();
 }

--- a/src/lib/deskflow/unix/AppUtilUnix.cpp
+++ b/src/lib/deskflow/unix/AppUtilUnix.cpp
@@ -34,11 +34,6 @@ int AppUtilUnix::run()
   return app().runInner(&startStatic);
 }
 
-void AppUtilUnix::startNode()
-{
-  app().startNode();
-}
-
 std::vector<std::string> AppUtilUnix::getKeyboardLayoutList()
 {
   std::vector<std::string> layoutLangCodes;

--- a/src/lib/deskflow/unix/AppUtilUnix.h
+++ b/src/lib/deskflow/unix/AppUtilUnix.h
@@ -20,7 +20,6 @@ public:
   ~AppUtilUnix() override = default;
 
   int run() override;
-  void startNode() override;
   std::vector<std::string> getKeyboardLayoutList() override;
   std::string getCurrentLanguageCode() override;
 };

--- a/src/lib/deskflow/win32/AppUtilWindows.cpp
+++ b/src/lib/deskflow/win32/AppUtilWindows.cpp
@@ -126,11 +126,6 @@ AppUtilWindows &AppUtilWindows::instance()
   return (AppUtilWindows &)AppUtil::instance();
 }
 
-void AppUtilWindows::startNode()
-{
-  app().startNode();
-}
-
 std::vector<std::string> AppUtilWindows::getKeyboardLayoutList()
 {
   std::vector<std::string> layoutLangCodes;

--- a/src/lib/deskflow/win32/AppUtilWindows.h
+++ b/src/lib/deskflow/win32/AppUtilWindows.h
@@ -38,7 +38,6 @@ public:
   int daemonNTMainLoop();
   int run() override;
   void exitApp(int code) override;
-  void startNode() override;
   std::vector<std::string> getKeyboardLayoutList() override;
   std::string getCurrentLanguageCode() override;
   HKL getCurrentKeyboardLayout() const;

--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -141,26 +141,23 @@ void EiScreen::initEi()
 
 void EiScreen::cleanupEi()
 {
+  for (auto device : m_eiDevices) {
+    delete static_cast<ScrollRemainder *>(ei_device_get_user_data(device));
+    ei_device_set_user_data(device, nullptr);
+  }
+
   if (m_eiPointer) {
-    free(ei_device_get_user_data(m_eiPointer));
-    ei_device_set_user_data(m_eiPointer, nullptr);
     m_eiPointer = ei_device_unref(m_eiPointer);
   }
   if (m_eiKeyboard) {
-    free(ei_device_get_user_data(m_eiKeyboard));
-    ei_device_set_user_data(m_eiKeyboard, nullptr);
     m_eiKeyboard = ei_device_unref(m_eiKeyboard);
   }
   if (m_eiAbs) {
-    free(ei_device_get_user_data(m_eiAbs));
-    ei_device_set_user_data(m_eiAbs, nullptr);
     m_eiAbs = ei_device_unref(m_eiAbs);
   }
   m_eiSeat = ei_seat_unref(m_eiSeat);
-  for (auto it = m_eiDevices.begin(); it != m_eiDevices.end(); it++) {
-    free(ei_device_get_user_data(*it));
-    ei_device_set_user_data(*it, nullptr);
-    ei_device_unref(*it);
+  for (auto device : m_eiDevices) {
+    ei_device_unref(device);
   }
   m_eiDevices.clear();
   m_ei = ei_unref(m_ei);
@@ -636,11 +633,15 @@ void EiScreen::removeDevice(struct ei_device *device)
     cancelIdleEmulationTimer();
   }
 
-  for (auto it = m_eiDevices.begin(); it != m_eiDevices.end(); it++) {
+  delete static_cast<ScrollRemainder *>(ei_device_get_user_data(device));
+  ei_device_set_user_data(device, nullptr);
+
+  for (auto it = m_eiDevices.begin(); it != m_eiDevices.end();) {
     if (*it == device) {
-      m_eiDevices.erase(it);
+      it = m_eiDevices.erase(it);
       ei_device_unref(device);
-      break;
+    } else {
+      ++it;
     }
   }
 

--- a/src/lib/platform/XDGPowerManager.cpp
+++ b/src/lib/platform/XDGPowerManager.cpp
@@ -84,8 +84,8 @@ bool XDGPowerManager::inhibitScreenCall(InhibitScreenServices serviceID, bool st
       cookies[serviceNum] = reply.value();
   } else {
     if (!cookies[serviceNum]) {
-      error = "cookies are empty";
-      return false;
+      // Nothing was ever inhibited for this service
+      return true;
     }
     reply = screenSaverInterface.call("UnInhibit", cookies[serviceNum]);
     cookies[serviceNum] = 0;

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -791,14 +791,6 @@ void InputFilter::addFilterRule(const Rule &rule)
   }
 }
 
-void InputFilter::removeFilterRule(uint32_t index)
-{
-  if (m_primaryClient != nullptr) {
-    m_ruleList[index].disable(m_primaryClient);
-  }
-  m_ruleList.erase(m_ruleList.begin() + index);
-}
-
 InputFilter::Rule &InputFilter::getRule(uint32_t index)
 {
   return m_ruleList[index];

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -378,9 +378,6 @@ public:
   // add rule, adopting the condition and the actions
   void addFilterRule(const Rule &rule);
 
-  // remove a rule
-  void removeFilterRule(uint32_t index);
-
   // get rule by index
   Rule &getRule(uint32_t index);
 

--- a/src/unittests/client/ServerProxyTests.cpp
+++ b/src/unittests/client/ServerProxyTests.cpp
@@ -35,10 +35,6 @@ public:
     return 0;
   }
 
-  void startNode() override
-  {
-  }
-
   std::vector<std::string> getKeyboardLayoutList() override
   {
     return {"en"};

--- a/src/unittests/platform/EiKeyStateTests.cpp
+++ b/src/unittests/platform/EiKeyStateTests.cpp
@@ -25,10 +25,6 @@ public:
     return 0;
   }
 
-  void startNode() override
-  {
-  }
-
   std::vector<std::string> getKeyboardLayoutList() override
   {
     return {"en"};


### PR DESCRIPTION
## Description
The commits all work by themselves
- refactor: don't route startNode through AppUtil
Currently we route our startNode calls through AppUtil. This is not needed.
- refactor: delete dead InputFilter::removeFilterRule
InputFilter::removeFilterRule is called nowhere. I removed it
- fix: correct wrong screen entered warning
See commit description ("In #7437, we replaced an assert with an if for logging, but forgot to negate the if clause")
- fix: don't show an error when ipc server is closed
When we stop the server, we close the ipc server. This is not an error, so don't show it as one in the logs
- fix: let inhibitScreenCall succeed when nothing was inhibited
When we close the server, inhibitScreenCall fails if nothing was inhibited. Correct this to not show an error
- fix(wayland): delete ScrollRemainder in EiScreen
ScrollRemainder is not necessarily deleted in EiScreen. Change this
- fix: delete coreApp
coreApp is created with new, but nowhere deleted.

## AI tools used for this PR
I  asked claude it for feedback.

## Fixed/related issues
-
## How has this been tested?
Tested on a wayland server