### PR TITLE
fix(gui): allow keyboard activation of key sequence input

### DIFF
--- a/src/lib/gui/widgets/KeySequenceWidget.cpp
+++ b/src/lib/gui/widgets/KeySequenceWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
  * SPDX-FileCopyrightText: (C) 2012 - 2016 Synergy App Ltd
  * SPDX-FileCopyrightText: (C) 2008 Volker Lanz <vl@fidra.de>
  * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
@@ -14,7 +15,7 @@ KeySequenceWidget::KeySequenceWidget(QWidget *parent, const KeySequence &seq)
       m_KeySequence(seq),
       m_BackupSequence(seq)
 {
-  setFocusPolicy(Qt::NoFocus);
+  setFocusPolicy(Qt::StrongFocus);
   updateOutput();
 }
 
@@ -99,7 +100,7 @@ void KeySequenceWidget::keyPressEvent(QKeyEvent *event)
   event->accept();
 
   if (status() == Stopped)
-    return;
+    startRecording();
 
   if (m_KeySequence.appendKey(event->key(), event->modifiers()))
     stopRecording();

--- a/src/unittests/gui/CMakeLists.txt
+++ b/src/unittests/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) 2025 Deskflow Developers
+# SPDX-FileCopyrightText: (C) 2025 - 2026 Deskflow Developers
 # SPDX-License-Identifier: MIT
 
 add_subdirectory(config)
@@ -8,5 +8,12 @@ create_test(
   NAME LoggerTests
   DEPENDS gui
   SOURCE LoggerTests.cpp
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
+)
+
+create_test(
+  NAME KeySequenceWidgetTests
+  DEPENDS gui
+  SOURCE KeySequenceWidgetTests.cpp
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib/gui"
 )

--- a/src/unittests/gui/KeySequenceWidgetTests.cpp
+++ b/src/unittests/gui/KeySequenceWidgetTests.cpp
@@ -1,0 +1,27 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#include "KeySequenceWidgetTests.h"
+
+#include "gui/widgets/KeySequenceWidget.h"
+
+void KeySequenceWidgetTests::focusPolicy_default_strongFocus()
+{
+  KeySequenceWidget widget(nullptr);
+
+  QCOMPARE(widget.focusPolicy(), Qt::StrongFocus);
+}
+
+void KeySequenceWidgetTests::keyClick_stoppedWidget_recordsKey()
+{
+  KeySequenceWidget widget(nullptr);
+
+  QTest::keyClick(&widget, Qt::Key_A);
+
+  QCOMPARE(widget.keySequence().toString(), QStringLiteral("a"));
+}
+
+QTEST_MAIN(KeySequenceWidgetTests)

--- a/src/unittests/gui/KeySequenceWidgetTests.h
+++ b/src/unittests/gui/KeySequenceWidgetTests.h
@@ -1,0 +1,18 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <QTest>
+
+class KeySequenceWidgetTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void focusPolicy_default_strongFocus();
+  void keyClick_stoppedWidget_recordsKey();
+};


### PR DESCRIPTION
## Description

Make `KeySequenceWidget` keyboard-focusable and record the first key pressed after it receives keyboard focus.

## AI tools used for this PR

Codex GPT-5.6: code navigation, implementation, tests, and local validation.

## Fixed/related issues

fixes: #8472

## How has this been tested?

- Manual GUI check on macOS 26.6.2 arm64, Qt 6.11.1, Debug: Tab focus and first ordinary key recording
- `KeySequenceWidgetTests`
- Full local unit suite: 27/27
- GitHub Actions CI, clang-format 20.1.0, and REUSE lint
