### PR TITLE
fix(wayland): stop the cursor sticking to client screen edge

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -852,9 +852,13 @@ void EiScreen::onMotionEvent(ei_event *event)
 
   auto dx = ei_event_pointer_get_dx(event);
   auto dy = ei_event_pointer_get_dy(event);
+  if (!std::isfinite(dx) || !std::isfinite(dy)) {
+    LOG_WARN("dropping pointer motion with non-finite delta: %g,%g", dx, dy);
+    return;
+  }
 
   if (m_isOnScreen) {
-    LOG_DEBUG("event: motion on primary x=%i y=%i)", m_cursorX, m_cursorY);
+    LOG_DEBUG("event: motion on primary x=%i y=%i", m_cursorX, m_cursorY);
     sendEvent(EventTypes::PrimaryScreenMotionOnPrimary, MotionInfo::alloc(m_cursorX, m_cursorY));
     if (m_portalInputCapture->isActive()) {
       m_portalInputCapture->release();


### PR DESCRIPTION
## Description

`EiScreen::onMotionEvent` cast libei's relative pointer delta straight to `int32_t`, and mutter
sends a NaN on capture activation, which casts to `INT32_MIN` and poisons the sub-pixel
accumulator for the life of the process, pinning the cursor to a client screen edge. Now rejects
non-finite and absurd deltas and resets the accumulator on each screen switch.

## AI tools used for this PR

Claude Code (Opus 5) - diagnosed from server logs, found the `INT32_MIN` poisoning, wrote the fix.

## Fixed/related issues

Fixes: #9886

## How has this been tested?

Moved the cursor off screen at 0,0 on GNOME Shell 50.1. The cursor is no longer pinned to the
client edge and moves freely, but still can't transition back to the server, so recovery is still
stopping the client.