### PR TITLE
fix(wayland): Prevent clipboard causing portal reprompts if the backend is incorrectly reporting clipboard state of the previous token

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -43,6 +43,7 @@ public:
     inline static const auto XScrollScale = QStringLiteral("client/xScrollScale");
     inline static const auto LanguageSync = QStringLiteral("client/languageSync");
     inline static const auto RemoteHost = QStringLiteral("client/remoteHost");
+    inline static const auto XdpClipboardRetried = QStringLiteral("client/xdpClipboardRetried");
     inline static const auto XdpRestoreToken = QStringLiteral("client/xdpRestoreToken");
   };
   struct Core
@@ -121,6 +122,7 @@ public:
     inline static const auto SwitchDelay = QStringLiteral("server/switchDelay");
     inline static const auto SwitchDoubleTap = QStringLiteral("server/switchDoubleTap");
     inline static const auto Win32KeepForeground = QStringLiteral("server/win32KeepForeground");
+    inline static const auto XdpClipboardRetried = QStringLiteral("server/xdpClipboardRetried");
     inline static const auto XdpRestoreToken = QStringLiteral("server/xdpRestoreToken");
   };
 
@@ -334,6 +336,7 @@ private:
     , Client::DynamicConnectionRetry
     , Client::InvertYScroll
     , Client::InvertXScroll
+    , Client::XdpClipboardRetried
     , Log::ToFile
     , Log::GuiDebug
     , Server::DefaultLockToComputerState
@@ -343,6 +346,7 @@ private:
     , Server::EnableSwitchDoubleTap
     , Server::ExternalConfig
     , Server::RelativeMouseMoves
+    , Server::XdpClipboardRetried
   };
 
   // When checking the default values this list contains the ones that default to true.
@@ -362,7 +366,9 @@ private:
   // Settings saved in our State file
   inline static const QStringList m_stateKeys = {
       Gui::WindowGeometry
+    , Client::XdpClipboardRetried
     , Client::XdpRestoreToken
+    , Server::XdpClipboardRetried
     , Server::XdpRestoreToken
    };
 

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -73,6 +73,10 @@ void ServerConfigDialog::save()
   // now that the dialog has been accepted, copy the new server config to the
   // original one, which is a reference to the one in MainWindow.
   setOriginalServerConfig(serverConfig());
+  if (Settings::value(Settings::Server::EnableClipboard).toBool() != m_enableClipboard) {
+    Settings::setValue(Settings::Server::XdpRestoreToken, QString());
+    Settings::setValue(Settings::Server::XdpClipboardRetried, false);
+  }
   Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(m_protocol));
   Settings::setValue(Settings::Server::EnableClipboard, m_enableClipboard);
   Settings::setValue(Settings::Server::ClipboardSize, m_clipboardSize);

--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -11,15 +11,12 @@
 #include "base/Event.h"
 #include "base/Log.h"
 #include "base/TMethodJob.h"
+#include "common/Settings.h"
 #include "deskflow/ClipboardTypes.h"
 #include "platform/EiClipboard.h"
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
 #include "platform/PortalClipboard.h"
-#endif
-
-#ifdef HAVE_LIBPORTAL_INPUTCAPTURE_RESTORE
-#include "common/Settings.h"
 #endif
 
 #include <algorithm>
@@ -298,17 +295,20 @@ void PortalInputCapture::setupSession(XdpInputCaptureSession *session)
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
   if (!xdp_session_is_clipboard_enabled(parentSession) && m_portalVersion > 1) {
-    // Restored sessions can pre-date clipboard support, leaving the channel
-    // disabled even though we requested it. Drop the saved token and recreate
-    // the session from scratch so the user gets a fresh permission dialog.
-    LOG_WARN("clipboard not enabled on session, discarding restore token to force a fresh session");
+    if (Settings::value(Settings::Server::XdpClipboardRetried).toBool()) {
+      // some backends never report clipboard enabled even when granted; don't loop forever
+      LOG_DEBUG("clipboard still not enabled on session after one retry, continuing without it");
+    } else {
+      LOG_WARN("clipboard not enabled on session, discarding restore token to force a fresh session");
 #ifdef HAVE_LIBPORTAL_INPUTCAPTURE_RESTORE
-    Settings::setValue(Settings::Server::XdpRestoreToken, QString());
+      Settings::setValue(Settings::Server::XdpRestoreToken, QString());
 #endif
-    g_object_unref(m_session);
-    m_session = nullptr;
-    g_idle_add([](gpointer data) { return static_cast<PortalInputCapture *>(data)->initSession(); }, this);
-    return;
+      Settings::setValue(Settings::Server::XdpClipboardRetried, true);
+      g_object_unref(m_session);
+      m_session = nullptr;
+      g_idle_add([](gpointer data) { return static_cast<PortalInputCapture *>(data)->initSession(); }, this);
+      return;
+    }
   }
 #endif
 

--- a/src/lib/platform/PortalRemoteDesktop.cpp
+++ b/src/lib/platform/PortalRemoteDesktop.cpp
@@ -100,28 +100,35 @@ void PortalRemoteDesktop::handleSessionStarted(GObject *object, GAsyncResult *re
 
 #ifdef HAVE_LIBPORTAL_CLIPBOARD
   if (!xdp_session_is_clipboard_enabled(session)) {
-    LOG_WARN("clipboard not enabled on remote desktop session, discarding restore token to force a fresh session");
-    Settings::setValue(Settings::Client::XdpRestoreToken, QString());
-    free(m_sessionRestoreToken);
-    m_sessionRestoreToken = nullptr;
-    if (m_selectionTransferSignalId) {
-      g_signal_handler_disconnect(session, m_selectionTransferSignalId);
-      m_selectionTransferSignalId = 0;
+    if (Settings::value(Settings::Client::XdpClipboardRetried).toBool()) {
+      // some backends never report clipboard enabled even when granted; don't loop forever
+      LOG_DEBUG("clipboard still not enabled on remote desktop session after one retry, continuing without it");
+    } else {
+      LOG_WARN("clipboard not enabled on remote desktop session, discarding restore token to force a fresh session");
+      Settings::setValue(Settings::Client::XdpRestoreToken, QString());
+      Settings::setValue(Settings::Client::XdpClipboardRetried, true);
+      free(m_sessionRestoreToken);
+      m_sessionRestoreToken = nullptr;
+      if (m_selectionTransferSignalId) {
+        g_signal_handler_disconnect(session, m_selectionTransferSignalId);
+        m_selectionTransferSignalId = 0;
+      }
+      if (m_selectionOwnerChangedSignalId) {
+        g_signal_handler_disconnect(session, m_selectionOwnerChangedSignalId);
+        m_selectionOwnerChangedSignalId = 0;
+      }
+      if (m_sessionSignalId) {
+        g_signal_handler_disconnect(session, m_sessionSignalId);
+        m_sessionSignalId = 0;
+      }
+      g_clear_object(&m_session);
+      reconnect(0);
+      return;
     }
-    if (m_selectionOwnerChangedSignalId) {
-      g_signal_handler_disconnect(session, m_selectionOwnerChangedSignalId);
-      m_selectionOwnerChangedSignalId = 0;
-    }
-    if (m_sessionSignalId) {
-      g_signal_handler_disconnect(session, m_sessionSignalId);
-      m_sessionSignalId = 0;
-    }
-    g_clear_object(&m_session);
-    reconnect(0);
-    return;
   }
 #endif
 
+  free(m_sessionRestoreToken);
   m_sessionRestoreToken = xdp_session_get_restore_token(session);
   if (m_sessionRestoreToken) {
     Settings::setValue(Settings::Client::XdpRestoreToken, QString(m_sessionRestoreToken));
@@ -227,7 +234,7 @@ void PortalRemoteDesktop::claimClipboard() const
     return;
   }
   if (!xdp_session_is_clipboard_enabled(m_session)) {
-    LOG_WARN("portal remote desktop clipboard not enabled on session, cannot claim");
+    LOG_DEBUG("portal remote desktop clipboard not enabled on session, cannot claim");
     return;
   }
   PortalClipboard::claimOwnership(m_screen->getClipboardCache(), m_session);


### PR DESCRIPTION
## Description

`PortalInputCapture` (server) and `PortalRemoteDesktop` (client) discard their saved xdg-desktop-portal restore token and force a fresh permission dialog whenever a restored session doesn't report clipboard as enabled, on the assumption the token predates clipboard support. If clipboard is never reported enabled (reported in #9845) the token gets discarded and reprompted on every single restore, forever.

Basically a one-shot "already retried" flag. It discards and retries once, then keeps the session instead of reprompting again if clipboard is still disabled.

## AI tools used for this PR

I wrote the fix. Claude (Sonnet 5) via Claude Code did code review, caught the ifdef mismatch and a memory leak in the client-path fallthrough.

## Fixed/related issues

related: #9845

## How has this been tested?

Running as my live deskflow client on my daily-driver machine: openSUSE Tumbleweed (20260830), KWin/Plasma 6.7.4, Wayland session, libportal 0.10.0, xdg-desktop-portal-kde6 6.7.4. Built from this branch and running continuously since, across normal sleep/wake and lock/unlock cycles, with no clipboard-portal reprompt recurring.