### PR TITLE
hack(wayland): avoid sharing a pointer barrier endpoint at screen corners

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -524,6 +524,9 @@ void PortalInputCapture::addBarrier(
   gint y1 = 0;
   gint y2 = 0;
 
+  // a horizontal barrier must not share an end point with a vertical one: mutter's release only
+  // clears the held barrier and re-runs the warp from the trapped point, so a pointer sitting on
+  // both lines is caught again by the other before it moves and never leaves the corner
   using enum BarrierSide;
   switch (side) {
   case Left:
@@ -539,15 +542,15 @@ void PortalInputCapture::addBarrier(
     y2 = zoneY + static_cast<gint>(zoneHeight) - 1;
     break;
   case Top:
-    x1 = zoneX;
+    x1 = zoneX + 1;
     y1 = zoneY;
-    x2 = zoneX + static_cast<gint>(zoneWidth) - 1;
+    x2 = zoneX + static_cast<gint>(zoneWidth) - 2;
     y2 = zoneY;
     break;
   case Bottom:
-    x1 = zoneX;
+    x1 = zoneX + 1;
     y1 = zoneY + static_cast<gint>(zoneHeight);
-    x2 = zoneX + static_cast<gint>(zoneWidth) - 1;
+    x2 = zoneX + static_cast<gint>(zoneWidth) - 2;
     y2 = y1;
     break;
   }


### PR DESCRIPTION
## Description

This is a hack, real fix is upstream.

This prevents the cursor from crossing at 0,0 but should not be landed because it will also impact non-GNOME users.

## AI tools used for this PR

Claude Code (Sonnet 5) 

## Fixed/related issues

Requires PR #10122
Related: #9886

## How has this been tested?

Moving mouse from 0,0 on Wayland server