### PR TITLE
fix: clear settings should wipe the state file too

### DIFF
--- a/src/lib/common/Settings.cpp
+++ b/src/lib/common/Settings.cpp
@@ -60,6 +60,12 @@ void Settings::setStateFile(const QString &stateFile)
   qInfo().noquote() << "state file changed:" << instance()->m_stateSettings->fileName();
 }
 
+void Settings::clearState()
+{
+  instance()->m_stateSettings->clear();
+  instance()->m_stateSettings->sync();
+}
+
 Settings::Settings(QObject *parent) : QObject(parent), m_settingsWatcher{new QFileSystemWatcher(this)}
 {
   QString fileToLoad;

--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -175,6 +175,7 @@ public:
   static Settings *instance();
   static void setSettingsFile(const QString &settingsFile = QString());
   static void setStateFile(const QString &stateFile = QString());
+  static void clearState();
   static void setValue(const QString &key = QString(), const QVariant &value = QVariant());
   static QVariant value(const QString &key = QString());
   static void restoreDefaultSettings();

--- a/src/lib/gui/Diagnostic.cpp
+++ b/src/lib/gui/Diagnostic.cpp
@@ -34,9 +34,7 @@ void clearSettings(bool enableRestart)
 {
   qDebug("clearing settings");
   Settings::proxy().clear();
-
-  // Reset the windowGeometry
-  Settings::setValue(Settings::Gui::WindowGeometry);
+  Settings::clearState();
 
   // save but do not emit saving signal which will prevent the current state of
   // the app config and server configs from being applied.

--- a/src/unittests/common/SettingsTests.cpp
+++ b/src/unittests/common/SettingsTests.cpp
@@ -101,4 +101,14 @@ void SettingsTests::checkCleanScreenName_LongName()
   QCOMPARE(Settings::value(Settings::Core::ComputerName).toString(), expected);
 }
 
+void SettingsTests::checkClearState()
+{
+  Settings::setValue(Settings::Gui::WindowGeometry, QRect(1, 2, 3, 4));
+  QVERIFY(Settings::value(Settings::Gui::WindowGeometry).toRect().isValid());
+
+  Settings::clearState();
+
+  QVERIFY(!Settings::value(Settings::Gui::WindowGeometry).toRect().isValid());
+}
+
 QTEST_MAIN(SettingsTests)

--- a/src/unittests/common/SettingsTests.h
+++ b/src/unittests/common/SettingsTests.h
@@ -24,6 +24,7 @@ private Q_SLOTS:
   void checkValidSettings();
   void checkCleanScreenName();
   void checkCleanScreenName_LongName();
+  void checkClearState();
 
 private:
   inline static const QString m_settingsPathTemp = QStringLiteral("tmp/test");


### PR DESCRIPTION
## Description

`Diagnostic::clearSettings()` only cleared the main config file and reset `WindowGeometry` as a one-off. Added `Settings::clearState()` to wipe the whole state file, so anything in `m_stateKeys` gets cleared on a full
reset instead of needing a manual reset added per key. Came out of the settings-reset discussion on #10124.

## AI tools used for this PR

I had Claude Sonnet 5 write the quick unit test. That was all.

## Fixed/related issues

Related to the discussion on #10124, not tied to a specific issue number.

## How has this been tested?

Added unit test.