### PR TITLE
fix(mac): run event queue events in autoreleasepool

### DIFF
--- a/src/lib/base/CMakeLists.txt
+++ b/src/lib/base/CMakeLists.txt
@@ -1,9 +1,17 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
 # SPDX-FileCopyrightText: (C) 2024 Chris Rizzitello <sithlord48@gmail.com>
 # SPDX-FileCopyrightText: (C) 2012 - 2024 Symless Ltd
 # SPDX-FileCopyrightText: (C) 2009 - 2012 Nick Bolton
 # SPDX-License-Identifier: MIT
 
-add_library(base STATIC
+if(APPLE)
+  set(PLATFORM_CODE
+    OSXAutoReleasePool.h
+    OSXAutoReleasePool.mm
+  )
+endif()
+
+add_library(base STATIC ${PLATFORM_CODE}
   BaseException.cpp
   BaseException.h
   DirectionTypes.h

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -18,6 +18,10 @@
 
 #include <stdexcept>
 
+#if defined(__APPLE__)
+#include "base/OSXAutoReleasePool.h"
+#endif
+
 // interrupt handler.  this just adds a quit event to the queue.
 static void interrupt(Arch::ThreadSignal, void *data)
 {
@@ -166,16 +170,23 @@ bool EventQueue::getEvent(Event &event, double timeout)
 
 bool EventQueue::dispatchEvent(const Event &event)
 {
-  void *target = event.getTarget();
-  if (auto typeHandler = getHandler(event.getType(), target); typeHandler.has_value()) {
-    (*typeHandler)(event);
-    return true;
-  }
-  if (auto anyHandler = getHandler(EventTypes::Unknown, target); anyHandler.has_value()) {
-    (*anyHandler)(event);
-    return true;
-  }
-  return false;
+#if defined(__APPLE__)
+  auto dispatch = [&] {
+#endif
+    void *target = event.getTarget();
+    if (auto typeHandler = getHandler(event.getType(), target); typeHandler.has_value()) {
+      (*typeHandler)(event);
+      return true;
+    }
+    if (auto anyHandler = getHandler(EventTypes::Unknown, target); anyHandler.has_value()) {
+      (*anyHandler)(event);
+      return true;
+    }
+    return false;
+#if defined(__APPLE__)
+  };
+  return deskflow::runInAutoReleasePool(dispatch);
+#endif
 }
 
 void EventQueue::addEvent(Event &&event)

--- a/src/lib/base/OSXAutoReleasePool.h
+++ b/src/lib/base/OSXAutoReleasePool.h
@@ -1,0 +1,16 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace deskflow {
+
+//! Run \p fn inside an Objective-C \c \@autoreleasepool block.
+bool runInAutoReleasePool(const std::function<bool()> &fn);
+
+} // namespace deskflow

--- a/src/lib/base/OSXAutoReleasePool.mm
+++ b/src/lib/base/OSXAutoReleasePool.mm
@@ -1,0 +1,20 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+ * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
+ */
+
+#import "base/OSXAutoReleasePool.h"
+
+#import <Foundation/Foundation.h>
+
+namespace deskflow {
+
+bool runInAutoReleasePool(const std::function<bool()> &fn)
+{
+  @autoreleasepool {
+    return fn();
+  }
+}
+
+} // namespace deskflow


### PR DESCRIPTION
## Description
The event loop thread was not properly being drained leaving a huge memory footprint if deskflow was used for a very long period unnatended.

It enforces events dispatched to run throughout an autoreleasepool.

Thanks to @pedrorambo help on doing diagnosing this issue.  

## AI tools used for this PR
No AI tool used for the implementation.

Anyway, this was done based on the changes suggested in #10132 by @pedrorambo which used Claude Code Opus 5 to diagnose the issue and implement the initial fix.

## Fixed/related issues
fixes: #8653
replaces: #10132 

## How has this been tested?

Verified that it caused no issue on my local mac.
Ran CI in my repo to verify builds passes on all other OS targets.

Pending validation by @pedrorambo (will move from draft after the fix is confirmed to be working)