### PR TITLE
fix(wayland): use a larger release margin for InputCapture barriers

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -475,7 +475,15 @@ std::pair<double, double> PortalInputCapture::mapPortalReleasePosition(double x,
   const auto screenTop = screenY;
   const auto screenRight = screenX + screenW - 1;
   const auto screenBottom = screenY + screenH - 1;
-  const auto jumpZoneSize = m_screen->getJumpZoneSize();
+  // IPrimaryScreen::getJumpZoneSize() returns 1px on every backend (X11, Win32,
+  // macOS, EI) - fine for those barrier implementations, but too tight here:
+  // releasing the pointer only 1px inside a libportal InputCapture barrier
+  // re-triggers that same barrier almost immediately (observed as a rapid
+  // activate/release feedback loop, several times per second, on Hyprland's
+  // InputCapture backend), so the pointer never actually settles back onto
+  // the local screen. Use a larger portal-specific minimum instead.
+  constexpr std::int32_t kPortalReleaseMargin = 15;
+  const auto jumpZoneSize = std::max<std::int32_t>(m_screen->getJumpZoneSize(), kPortalReleaseMargin);
   Bounds portalBounds;
   if (!getPortalBounds(portalBounds)) {
     return {x, y};


### PR DESCRIPTION
## Problem

On a portal-based InputCapture server (tested on Hyprland 0.56 /
xdg-desktop-portal-hyprland 1.4.1), the pointer never actually settles
back onto the local screen after control returns from a client. Server
and client logs both show a rapid `leaving screen`/`entering screen`
oscillation, several times per second, with no user input involved.

## Root cause

`EiScreen::getJumpZoneSize()` (and the equivalent on every other
platform - X11, Win32, macOS) returns a hardcoded `1`. That's fine for
their native barrier implementations, but `PortalInputCapture::mapPortalReleasePosition()`
uses this same 1px margin when placing the pointer back inside the
local screen on release. Landing only 1px inside a libportal
InputCapture barrier re-triggers that same barrier almost immediately,
producing the observed feedback loop.

Confirmed via `journalctl -t xdg-desktop-portal-hyprland`: the portal
correctly reports `activate`/accepts the `Release` request each time,
with the release `cursorPosition` sitting 1-2px from the barrier
coordinate on every cycle.

## Fix

Use a larger, portal-specific minimum margin (15px) in
`mapPortalReleasePosition()` instead of the generic per-platform jump
zone size, while still respecting a larger platform-configured value if
one is ever set.

## Testing

Verified on Hyprland 0.56.2 / xdg-desktop-portal-hyprland 1.4.1
(InputCapture support merged upstream 2026-07-14, hyprwm/xdg-desktop-portal-hyprland#268)
built from current `continuous` (commit a930c87e). Before the fix: the
oscillation is 100% reproducible on every screen return. After the fix:
verified over multiple real back-and-forth switches with no
oscillation.