### PR TITLE
build: add Nix flake for source-build package manager install

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+use flake

--- a/.github/README.md
+++ b/.github/README.md
@@ -106,6 +106,45 @@ Then install either:
 - Stable: `brew install deskflow`
 - Continuous: `brew install deskflow-dev`
 
+## Installing with Nix
+
+Deskflow can be installed and run using [Nix](https://nixos.org/) on Linux and macOS.
+
+### Default (recommended)
+
+On Linux, builds from source using the [nixpkgs](https://github.com/NixOS/nixpkgs) packaging (inheriting its fixup logic and testing). On macOS, builds from source directly (nixpkgs does not package Deskflow for Darwin):
+
+```bash
+nix run github:deskflow/deskflow
+nix profile install github:deskflow/deskflow
+```
+
+### From source (all platforms)
+
+Builds Deskflow from source on all platforms, bypassing the nixpkgs packaging:
+
+```bash
+nix run github:deskflow/deskflow#source
+nix profile install github:deskflow/deskflow#source
+```
+
+### nixpkgs version (Linux only)
+
+Uses the [nixpkgs](https://github.com/NixOS/nixpkgs)-packaged version at its pinned version:
+
+```bash
+nix run github:deskflow/deskflow#nixpkgs
+nix profile install github:deskflow/deskflow#nixpkgs
+```
+
+### Development shell
+
+Enter a development shell with all build dependencies:
+
+```bash
+nix develop
+```
+
 ## Similar Projects
 
 In the open source developer community, similar projects collaborate for the improvement of all

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+name: Nix
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - flake.nix
+      - flake.lock
+      - deploy/nix/**
+      - .github/workflows/nix.yml
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - deploy/nix/**
+      - .github/workflows/nix.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      - run: nix flake check --all-systems --no-build
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: x86_64-darwin
+            runner: macos-13
+          - system: aarch64-darwin
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        with:
+          name: deskflow
+          # Create the cache at https://app.cachix.org and add CACHIX_AUTH_TOKEN
+          # to GitHub secrets, then remove skipPush to enable binary caching.
+          skipPush: true
+      - run: nix build .#deskflow --print-out-paths
+      # SECURITY: nix run executes the built binary outside the Nix sandbox on
+      # the runner, where it can reach GITHUB_TOKEN. On a PR, that binary is
+      # PR-controlled code. Drop this guard only if the workflow has no
+      # pull_request trigger.
+      - run: nix run .#deskflow -- --version
+        if: github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,13 @@ CMakeFiles/*
 # Ai helperfilers
 **/[cC]laude.[mM][dD]
 **/CLAUDE.[mM][dD]
+
+# Nix
+/result
+/result-*
+
+# Devbox
+.devbox/
+
+# Allow .envrc (direnv) — ignored by .env* above
+!.envrc

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,6 +28,7 @@ path = [
  , "src/apps/res/deskflow.plist.in"
  , "src/apps/res/entitlements-dev.plist"
  , "translations/*.ts"
+ , "flake.lock"
 ]
 SPDX-FileCopyrightText = "Deskflow Developers"
 SPDX-License-Identifier = "MIT"

--- a/deploy/nix/deskflow.nix
+++ b/deploy/nix/deskflow.nix
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+#
+# Deskflow derivation — builds from source using CMake/Qt6.
+# Imported by the root flake.nix.
+{
+  lib,
+  pkgs,
+  self,
+}:
+let
+  isLinux = pkgs.stdenv.hostPlatform.isLinux;
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+in
+pkgs.stdenv.mkDerivation {
+  pname = "deskflow";
+  # Derive from the flake's git revision — CMake also reads git tags for the
+  # binary's internal version, so this stays honest with the actual source.
+  version = "unstable-${self.shortRev or "dirty"}";
+
+  src = self;
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.ninja
+    pkgs.pkg-config
+    pkgs.qt6.wrapQtAppsHook
+    pkgs.doxygen
+  ];
+
+  buildInputs = [
+    pkgs.qt6.qtbase
+    pkgs.qt6.qttools
+    pkgs.qt6.qttranslations
+    pkgs.openssl
+    pkgs.pugixml
+    pkgs.python3
+  ]
+  ++ lib.optionals isLinux [
+    pkgs.gtest
+    pkgs.libei
+    pkgs.libportal
+    pkgs.libx11
+    pkgs.libxkbfile
+    pkgs.libxinerama
+    pkgs.libxi
+    pkgs.libxrandr
+    pkgs.libxtst
+    pkgs.libxkbcommon
+    pkgs.gdk-pixbuf
+    pkgs.libnotify
+    pkgs.qt6.qtwayland
+    pkgs.qt6.qtdeclarative
+    pkgs.wayland
+    pkgs.wayland-protocols
+    pkgs.libsysprof-capture
+    pkgs.lerc
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+    "-DSKIP_BUILD_TESTS=ON"
+    "-DBUILD_INSTALLER=OFF"
+  ];
+
+  preConfigure = lib.optionalString isDarwin ''
+    # CMake unconditionally checks for macdeployqt on macOS (even with
+    # BUILD_INSTALLER=OFF). The binary is in qtbase's bin directory.
+    export PATH="${pkgs.qt6.qtbase}/bin:$PATH"
+  '';
+
+  postPatch = ''
+    # Qt translation files are in a separate qttranslations package in nixpkgs.
+    substituteInPlace translations/CMakeLists.txt \
+      --replace-fail 'PATHS ''${QT_ROOT_DIR} PATH_SUFFIXES "translations" "share/qt/translations"' 'PATHS "${pkgs.qt6.qttranslations}/translations"'
+    # nixpkgs Qt6 disables the cxx17_filesystem feature, so
+    # QFile::filesystemFileName() is unavailable. Use the equivalent
+    # conversion via QString::toStdString().
+    substituteInPlace src/lib/net/SecureUtils.cpp \
+      --replace-fail "file.filesystemFileName()" "std::filesystem::path(file.fileName().toStdString())"
+  ''
+  + lib.optionalString isLinux ''
+    substituteInPlace src/lib/deskflow/unix/AppUtilUnix.cpp \
+      --replace-fail "/usr/share/X11/xkb/rules/evdev.xml" "${pkgs.xkeyboard_config}/share/X11/xkb/rules/evdev.xml"
+  ''
+  + lib.optionalString isDarwin ''
+    # The project requests static OpenSSL on macOS to avoid Apple's
+    # system OpenSSL. With nixpkgs OpenSSL (shared libs only), this is
+    # unnecessary — we're not using the system OpenSSL.
+    substituteInPlace src/lib/net/CMakeLists.txt \
+      --replace-fail "set(OPENSSL_USE_STATIC_LIBS TRUE)" ""
+  '';
+
+  qtWrapperArgs = lib.optionals isLinux [
+    "--set QT_QPA_PLATFORM_PLUGIN_PATH ${pkgs.qt6.qtwayland}/${pkgs.qt6.qtbase.qtPluginPrefix}/platforms"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://github.com/deskflow/deskflow";
+    description = "Share one mouse and keyboard between multiple computers on Windows, macOS and Linux";
+    mainProgram = "deskflow";
+    license = with lib.licenses; [
+      gpl2Plus
+      openssl
+      mit
+    ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/deploy/nix/outputs.nix
+++ b/deploy/nix/outputs.nix
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+#
+# Per-system outputs for the Deskflow flake.
+# Imported by the root flake.nix.
+#
+# Hybrid approach:
+# - Linux: overrideAttrs on the nixpkgs package (inherits nixpkgs fixup + testing)
+# - Darwin: from-source build (nixpkgs doesn't package Deskflow for macOS)
+{
+  lib,
+  pkgs,
+  self,
+  nixpkgs,
+  system,
+}:
+let
+  isLinux = pkgs.stdenv.hostPlatform.isLinux;
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+
+  # From-source build — used on Darwin (nixpkgs doesn't cover macOS) and
+  # exposed as #source on all platforms.
+  sourceDeskflow = import ./deskflow.nix { inherit lib pkgs self; };
+
+  # nixpkgs-packaged version — Linux only (nixpkgs meta.platforms = linux).
+  nixpkgsPkg = nixpkgs.legacyPackages.${system}.deskflow;
+
+  # Linux: override nixpkgs package's src to build from the flake's source.
+  # Inherits nixpkgs' fixup logic (XKB substitution, os-release handling,
+  # Qt wrapping, postInstall docs, checkPhase).
+  overrideDeskflow = import ./override.nix { inherit nixpkgsPkg self; };
+
+  # Hybrid: nixpkgs override on Linux, from-source on Darwin.
+  deskflow =
+    if isLinux then overrideDeskflow else sourceDeskflow;
+
+  # On macOS, the binary is inside a .app bundle.
+  binPath =
+    if isDarwin then "${deskflow}/Deskflow.app/Contents/MacOS/deskflow" else "${deskflow}/bin/deskflow";
+in
+{
+  packages = {
+    inherit deskflow;
+    source = sourceDeskflow;
+    default = deskflow;
+  }
+  // lib.optionalAttrs isLinux {
+    nixpkgs = nixpkgsPkg;
+  };
+
+  apps = {
+    deskflow = {
+      type = "app";
+      program = binPath;
+    };
+    default = {
+      type = "app";
+      program = binPath;
+    };
+  }
+  // lib.optionalAttrs isLinux {
+    nixpkgs = {
+      type = "app";
+      program = "${nixpkgsPkg}/bin/deskflow";
+    };
+  };
+
+  devShells.default = pkgs.mkShell {
+    packages = sourceDeskflow.buildInputs ++ sourceDeskflow.nativeBuildInputs;
+  };
+}

--- a/deploy/nix/override.nix
+++ b/deploy/nix/override.nix
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+#
+# Linux override — reuses the nixpkgs Deskflow package with src swapped to
+# the flake's source tree. Inherits nixpkgs' fixup logic (XKB substitution,
+# os-release handling, Qt wrapping, postInstall docs, checkPhase).
+{ nixpkgsPkg, self }:
+nixpkgsPkg.overrideAttrs (old: {
+  # Build from the flake's source tree instead of the nixpkgs-pinned tag.
+  # Inherits all of nixpkgs' buildInputs, postPatch, cmakeFlags, checkPhase,
+  # postInstall, and qtWrapperArgs.
+  src = self;
+  # Override nixpkgs' version (which tracks its pinned tag) with the flake's
+  # git revision — the source may be ahead of nixpkgs. CMake also reads git
+  # tags for the binary's internal version.
+  version = "unstable-${self.shortRev or "dirty"}";
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788775869,
+        "narHash": "sha256-JRf1lSypbvKj6AzUZHpUA6YC1DirVuitZWOnRwcm+Ww=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "58973d74f1893afe13f5902919803a0e99da0ca4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin-legacy": {
+      "locked": {
+        "lastModified": 1788807765,
+        "narHash": "sha256-J9oC0bKnkXUrMegqRTXVkyDFJ0gn2U/Qpoo9HgGMQmA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin-legacy": "nixpkgs-darwin-legacy"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Deskflow Developers
+# SPDX-License-Identifier: MIT
+#
+# Root flake — thin shim that delegates to deploy/nix/.
+# flake.nix must live at the repository root for `nix run github:...` to work;
+# the actual implementation is in deploy/nix/.
+{
+  description = "Deskflow — share one mouse and keyboard between multiple computers";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # nixpkgs-unstable (26.11) dropped x86_64-darwin support. Pin x86_64-darwin
+    # to the 26.05 stable branch, which still supports it and uses a newer SDK
+    # (14.x) than the older -darwin branches.
+    nixpkgs-darwin-legacy.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-darwin-legacy,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem
+      [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ]
+      (
+        system:
+        let
+          pkgs =
+            if system == "x86_64-darwin" then
+              nixpkgs-darwin-legacy.legacyPackages.${system}
+            else
+              nixpkgs.legacyPackages.${system};
+        in
+        import ./deploy/nix/outputs.nix {
+          inherit (pkgs) lib;
+          inherit pkgs self nixpkgs system;
+        }
+      );
+}


### PR DESCRIPTION
## Description

Adds a Nix flake that builds Deskflow from source, enabling installation via `nix run` and `nix profile install` on Linux and macOS.

### Outputs

| Output | Description | Platforms |
|--------|-------------|-----------|
| `#default` / `#deskflow` / `#source` | From-source build | All 4 systems |
| `#nixpkgs` | Wraps the nixpkgs-packaged version | Linux only |
| `devShells.default` | Development shell with all build deps | All 4 systems |

### Supported systems

- `x86_64-linux`
- `aarch64-linux`
- `x86_64-darwin` (pinned to `nixpkgs-26.05-darwin` — nixpkgs-unstable dropped x86_64-darwin in 26.11)
- `aarch64-darwin`

### Build patches

The source build adapts the nixpkgs derivation with patches for:
- Qt translation file path (`qttranslations` is a separate package in nixpkgs)
- `QFile::filesystemFileName()` (nixpkgs Qt6 disables `cxx17_filesystem`)
- Static OpenSSL request on macOS (nixpkgs OpenSSL is shared only)
- XKB `evdev.xml` path substitution on Linux
- `macdeployqt` PATH on macOS (CMake checks for it unconditionally)

### Usage

```bash
# Run from source
nix run github:deskflow/deskflow

# Install from source
nix profile install github:deskflow/deskflow

# Use the nixpkgs-packaged version (Linux only)
nix run github:deskflow/deskflow#nixpkgs

# Development shell
nix develop github:deskflow/deskflow
```

### CI

Adds `.github/workflows/nix.yml` with:
- `flake check --all-systems --no-build` on Ubuntu
- Build on `x86_64-linux` and `aarch64-linux`
- Build and `nix run -- --help` on macOS

## AI tools used for this PR

- Devin (GLM-5.2 High) was used to generate the Nix flake, CI workflow, and documentation.

## Fixed/related issues

Related to the closed PR #7850 which added initial Nix scaffolding. This PR takes a different approach by building from source with a complete flake that exposes installable package outputs.

## How has this been tested?

- `nix flake check --all-systems --no-build` passes on all 4 systems
- `nix build .#deskflow` succeeds on `x86_64-darwin`
- `nix run .#deskflow -- --help` works on `x86_64-darwin`
- `statix check` and `deadnix` pass clean
- `nixfmt` formatting applied
