### PR TITLE
fix(settings): keyword typo heatbeat -> heartbeat

### DIFF
--- a/src/lib/common/Settings.h
+++ b/src/lib/common/Settings.h
@@ -109,7 +109,7 @@ public:
     inline static const auto DefaultLockToComputerState = QStringLiteral("server/defaultLockToComputerState");
     inline static const auto DisableLockToComputer = QStringLiteral("server/disableLockToComputer");
     inline static const auto EnableClipboard = QStringLiteral("server/enableClipboard");
-    inline static const auto EnableHeatbeat = QStringLiteral("server/enableHeatbeat");
+    inline static const auto EnableHeartbeat = QStringLiteral("server/enableHeartbeat");
     inline static const auto EnableSwitchDelay = QStringLiteral("server/enableSwitchDelay");
     inline static const auto EnableSwitchDoubleTap = QStringLiteral("server/enableSwitchDoubleTap");
     inline static const auto ExternalConfig = QStringLiteral("server/externalConfig");
@@ -307,7 +307,7 @@ private:
     , Server::DefaultLockToComputerState
     , Server::DisableLockToComputer
     , Server::EnableClipboard
-    , Server::EnableHeatbeat
+    , Server::EnableHeartbeat
     , Server::EnableSwitchDelay
     , Server::EnableSwitchDoubleTap
     , Server::ExternalConfig
@@ -341,7 +341,7 @@ private:
     , Log::GuiDebug
     , Server::DefaultLockToComputerState
     , Server::DisableLockToComputer
-    , Server::EnableHeatbeat
+    , Server::EnableHeartbeat
     , Server::EnableSwitchDelay
     , Server::EnableSwitchDoubleTap
     , Server::ExternalConfig
@@ -380,7 +380,7 @@ private:
     , {InternalConfig::NumRows, Server::GridHeight}
     , {InternalConfig::Heatbeat, Server::Heartbeat}
     , {InternalConfig::SwitchDelay, Server::SwitchDelay}
-    , {InternalConfig::HasHeartbeat, Server::EnableHeatbeat}
+    , {InternalConfig::HasHeartbeat, Server::EnableHeartbeat}
     , {InternalConfig::HasSwitchDelay, Server::EnableSwitchDelay}
     , {InternalConfig::HasSwitchDoubleTap, Server::EnableSwitchDoubleTap}
     , {InternalConfig::ClipboardSharing, Server::EnableClipboard}

--- a/src/lib/gui/dialogs/ServerConfigDialog.cpp
+++ b/src/lib/gui/dialogs/ServerConfigDialog.cpp
@@ -80,7 +80,7 @@ void ServerConfigDialog::save()
   Settings::setValue(Settings::Server::Protocol, networkProtocolToOption(m_protocol));
   Settings::setValue(Settings::Server::EnableClipboard, m_enableClipboard);
   Settings::setValue(Settings::Server::ClipboardSize, m_clipboardSize);
-  Settings::setValue(Settings::Server::EnableHeatbeat, m_enableHeartbeat);
+  Settings::setValue(Settings::Server::EnableHeartbeat, m_enableHeartbeat);
   Settings::setValue(Settings::Server::Heartbeat, m_heartbeatRate);
   Settings::setValue(Settings::Server::EnableSwitchDelay, m_enableSwitchDelay);
   Settings::setValue(Settings::Server::SwitchDelay, m_switchDelay);
@@ -385,7 +385,7 @@ bool ServerConfigDialog::browseConfigFile()
 void ServerConfigDialog::loadFromConfig()
 {
   m_protocol = Settings::networkProtocol();
-  m_enableHeartbeat = Settings::value(Settings::Server::EnableHeatbeat).toBool();
+  m_enableHeartbeat = Settings::value(Settings::Server::EnableHeartbeat).toBool();
   m_heartbeatRate = Settings::value(Settings::Server::Heartbeat).toInt();
   m_relativeMouseMoves = Settings::value(Settings::Server::RelativeMouseMoves).toBool();
   m_win32keepForeground = Settings::value(Settings::Server::Win32KeepForeground).toBool();
@@ -540,7 +540,7 @@ void ServerConfigDialog::updateControls() const
 void ServerConfigDialog::restoreFromDefaults()
 {
   m_protocol = networkProtocolFromString(Settings::defaultValue(Settings::Server::Protocol).toString());
-  m_enableHeartbeat = Settings::defaultValue(Settings::Server::EnableHeatbeat).toBool();
+  m_enableHeartbeat = Settings::defaultValue(Settings::Server::EnableHeartbeat).toBool();
   m_heartbeatRate = Settings::defaultValue(Settings::Server::Heartbeat).toInt();
   m_relativeMouseMoves = Settings::defaultValue(Settings::Server::RelativeMouseMoves).toBool();
   m_win32keepForeground = Settings::defaultValue(Settings::Server::Win32KeepForeground).toBool();
@@ -592,7 +592,7 @@ bool ServerConfigDialog::isGeneralConfigModified() const
          m_protocol != Settings::networkProtocol() ||
          m_enableClipboard != Settings::value(Settings::Server::EnableClipboard).toBool() ||
          m_clipboardSize != Settings::value(Settings::Server::ClipboardSize).toUInt() ||
-         m_enableHeartbeat != Settings::value(Settings::Server::EnableHeatbeat).toBool() ||
+         m_enableHeartbeat != Settings::value(Settings::Server::EnableHeartbeat).toBool() ||
          m_heartbeatRate != Settings::value(Settings::Server::Heartbeat).toInt() ||
          m_enableSwitchDelay != Settings::value(Settings::Server::EnableSwitchDelay).toBool() ||
          m_switchDelay != Settings::value(Settings::Server::SwitchDelay).toInt() ||
@@ -611,7 +611,7 @@ bool ServerConfigDialog::isGeneralConfigDefault() const
          m_protocol == networkProtocolFromString(Settings::defaultValue(Settings::Server::Protocol).toString()) &&
          m_enableClipboard == Settings::defaultValue(Settings::Server::EnableClipboard).toBool() &&
          m_clipboardSize == Settings::defaultValue(Settings::Server::ClipboardSize).toUInt() &&
-         m_enableHeartbeat == Settings::defaultValue(Settings::Server::EnableHeatbeat).toBool() &&
+         m_enableHeartbeat == Settings::defaultValue(Settings::Server::EnableHeartbeat).toBool() &&
          m_heartbeatRate == Settings::defaultValue(Settings::Server::Heartbeat).toInt() &&
          m_enableSwitchDelay == Settings::defaultValue(Settings::Server::EnableSwitchDelay).toBool() &&
          m_switchDelay == Settings::defaultValue(Settings::Server::SwitchDelay).toInt() &&

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -452,7 +452,7 @@ void Config::readSection(ConfigReadContext &s)
 
 void Config::readSectionOptions(ConfigReadContext &s)
 {
-  if (Settings::value(Settings::Server::EnableHeatbeat).toBool()) {
+  if (Settings::value(Settings::Server::EnableHeartbeat).toBool()) {
     addOption("", kOptionHeartbeat, Settings::value(Settings::Server::Heartbeat).toInt());
   }
 


### PR DESCRIPTION
## Description
<!--- Describe what your changes do -->

Fix spelling of key from `heatbeat` -> `heartbeat`

Since this was added between 1.26 and now the upgrade path for the old key (in the server config)  now uses the updated key. The Incorrect key (enableHeatbeat) will be removed and users may need to re add it if they are using continuous

## AI tools used for this PR
<!--- If any AI tools were used to create this PR you must tell us  -->
<!--- Include the model version as well as what it was used for  -->
None
## Fixed/related issues
<!--- If fixing an issue you must add a `fixes` line for each issues fixed-->
<!--- Example, if fixing Issues #1234 you would add -->
<!--- fixes: #1234 -->
fixes: #10141 

## How has this been tested?
<!--- Please describe how you tested your changes -->
<!--- Include details of your testing environment -->
Local run