### PR TITLE
docs: point security reports at private disclosure

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -7,5 +7,16 @@ https://github.com/deskflow/deskflow/releases
 
 ## Reporting a Vulnerability
 
-Please report vulnerabilities on our issue tracker as bugs:
-https://github.com/deskflow/deskflow/issues
+Please report vulnerabilities privately, not on the public issue tracker.
+
+Use GitHub's private reporting form:
+https://github.com/deskflow/deskflow/security/advisories/new
+
+That opens a draft advisory only visible to maintainers. Include a proof of concept
+if you have one.
+
+## What happens next
+
+We land the fix on master, ship it in a continuous build, then publish the advisory
+and proof of concept together, so a fixed build is always available at the point the
+details go public. You will be credited in the advisory unless you ask otherwise.


### PR DESCRIPTION
## Description

The security policy told reporters to file vulnerabilities as public issues, which is how #10107 ended up public with a working PoC (effectively crating a 0day exploit). 

Now points at GitHub's private reporting form, which is already enabled on this repo and already in use.

## AI tools used for this PR

Claude Code (Opus 5) - spotted the policy problem while reviewing #10110

## Fixed/related issues

Related: #10107, #10110

## How has this been tested?

n/a