### PR TITLE
fix(wayland): track held mouse buttons in EiScreen

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -22,6 +22,7 @@
 #include "platform/PortalRemoteDesktop.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -261,9 +262,13 @@ std::int32_t EiScreen::getJumpZoneSize() const
   return 1;
 }
 
-bool EiScreen::isAnyMouseButtonDown(uint32_t &) const
+bool EiScreen::isAnyMouseButtonDown(uint32_t &buttonID) const
 {
-  return false;
+  if (m_buttons.none())
+    return false;
+
+  buttonID = std::countr_zero(m_buttons.to_ulong());
+  return true;
 }
 
 void EiScreen::getCursorCenter(int32_t &x, int32_t &y) const
@@ -424,6 +429,8 @@ void EiScreen::enter()
   } else if (m_isPrimary) {
     LOG_DEBUG("releasing input capture at x=%i y=%i", m_cursorX, m_cursorY);
     m_portalInputCapture->release(m_cursorX, m_cursorY);
+    // no more button events once capture is released, so drop any held state
+    updateButtons();
   }
 }
 
@@ -631,6 +638,8 @@ void EiScreen::removeDevice(struct ei_device *device)
   if (wasTracked) {
     m_isEmulating = false;
     cancelIdleEmulationTimer();
+    // same as for a paused device: no release events follow a removal
+    updateButtons();
   }
 
   delete static_cast<ScrollRemainder *>(ei_device_get_user_data(device));
@@ -756,6 +765,8 @@ void EiScreen::onButtonEvent(ei_event *event)
     LOG_DEBUG("event: button not recognized");
     return;
   }
+
+  m_buttons.set(buttonID, pressed);
 
   auto eventType = pressed ? EventTypes::PrimaryScreenButtonDown : EventTypes::PrimaryScreenButtonUp;
 
@@ -968,6 +979,9 @@ void EiScreen::handleSystemEvent(const Event &)
     case EI_EVENT_DEVICE_PAUSED:
       LOG_DEBUG("device %s is paused", ei_device_get_name(device));
       m_isEmulating = false;
+      // a paused device is reset to neutral by the EIS side and sends no
+      // further events, so the releases for held buttons never arrive
+      updateButtons();
       cancelIdleEmulationTimer();
       break;
     case EI_EVENT_DEVICE_RESUMED:
@@ -1026,7 +1040,9 @@ void EiScreen::handleSystemEvent(const Event &)
 void EiScreen::updateButtons()
 {
   // libei relies on the EIS implementation to keep our button count correct,
-  // so there's not much we need to/can do here.
+  // and the held buttons cannot be polled, so resyncing means assuming that
+  // everything is released.
+  m_buttons.reset();
 }
 
 IKeyState *EiScreen::getKeyState() const

--- a/src/lib/platform/EiScreen.h
+++ b/src/lib/platform/EiScreen.h
@@ -11,6 +11,7 @@
 #include "deskflow/PlatformScreen.h"
 #include "platform/XDGPowerManager.h"
 
+#include <bitset>
 #include <climits>
 #include <libei.h>
 #include <map>
@@ -143,6 +144,9 @@ private:
   EiKeyState *m_keyState = nullptr;
 
   KeyID m_lastPressed = kKeyNone;
+
+  // mouse buttons currently held, indexed by ButtonID
+  std::bitset<NumButtonIDs> m_buttons;
 
   // clipboard stuff
   EiClipboard *m_clipboard = nullptr;


### PR DESCRIPTION
## Description
`EiScreen::isAnyMouseButtonDown()` always returned false, so the server never saw the screen as locked and could switch away in the middle of a drag.

A drag started on the server screen still cannot cross the barrier under KWin (I didn't tested GNOME), which ignores pointer barriers while a button is held. That side is being fixed in KWin itself: https://invent.kde.org/plasma/kwin/-/merge_requests/9891 ("plugins/eis: Fix input capture barrier activation"). This PR only fixes the other direction: the server no longer switches away while a button is down.

## AI tools used for this PR
No AI tool used for the code implementation. It was just used for commit message.

## Fixed/related issues

## How has this been tested?
Builds on Linux (Wayland, GCC, C++20). Full test suite passes, 27/27.
Tested the build by keeping the left/right button (I did 2 tests) pressed while in another screen and the cursor correctly doesn't exit the screen.
